### PR TITLE
Fixed the title in rst default template

### DIFF
--- a/data/templates/rst/Default.rst
+++ b/data/templates/rst/Default.rst
@@ -1,6 +1,8 @@
 [% FOR page IN pages %]
-================
+[% FOR i IN range(len(page.title)) %]
+=[% END %]
 [% page.title %]
-================
+[% FOR i IN range(len(page.title)) %]
+=[% END %]
 [% page.body %]
 [% END %]


### PR DESCRIPTION
The overlines and underlines for page titles were not long enough sometimes when exporting in reStructuredText format. I made the overline and underline lengths depend on the title length by updating the Default.rst template.