### PR TITLE
Always sort notebooks in Open dialog

### DIFF
--- a/zim/notebook/info.py
+++ b/zim/notebook/info.py
@@ -344,6 +344,8 @@ class NotebookInfoList(list):
 				info = NotebookInfo(uri)
 			self.append(info)
 
+		self.sort(key=lambda notebook: notebook.name)
+
 		if 'Default' in config['NotebookList'] \
 		and config['NotebookList']['Default']:
 			self.set_default(config['NotebookList']['Default'])


### PR DESCRIPTION
I use couple of notebooks (> 10) in zim and they are always in random order in the Open dialog, which is confusing and bothersome. This patch makes sure the list there is always sorted.