### PR TITLE
Fix server crash by non-English page names.

### DIFF
--- a/zim/notebook/index/pages.py
+++ b/zim/notebook/index/pages.py
@@ -424,6 +424,9 @@ class PagesViewInternal(object):
 		pagename = parent
 		page_id = self.get_page_id(parent)
 		for i, basename in enumerate(names):
+			if isinstance(basename, str):
+				logger.debug('basename "%s" was not Unicode in _resolve_pagename' % basename)
+				basename = basename.decode('utf-8')
 			if page_id == ROOT_ID:
 				row = self.db.execute(
 					'SELECT id, name FROM pages WHERE name=?',

--- a/zim/notebook/page.py
+++ b/zim/notebook/page.py
@@ -150,6 +150,9 @@ class Path(object):
 		@returns: a string
 		@raises ValueError: when the result would be an empty string
 		'''
+		if isinstance(name, str):
+			logger.debug('name "%s" was not Unicode in makeValidPageName' % name)
+			name = name.decode('utf-8')
 		newname = _pagename_reduce_colon_re.sub(':', name.strip(':'))
 		newname = _pagename_invalid_char_re.sub('', newname)
 		newname = newname.replace('_', ' ')


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/zim/+bug/1698784

(I tested with pages named "English", "French", "Hebrew", "Russian" and "Japanese"  (in the corresponding languages), and found that each one except "English" crashed the server in _resolve_pagename().
After I found that some names are not unicode and fixed it there, only the "Hebrew" page crashed the server — now in makeValidPageName(), because the non-unicode  string was damaged by _pagename_invalid_char_re.sub().
)
![zim_server_index](https://user-images.githubusercontent.com/28747300/37588366-9692105e-2b94-11e8-895e-97d0161e03ee.png)
