### PR TITLE
a fix in documentation that helps others when using equation plugin

### DIFF
--- a/data/manual/Plugins/Equation_Editor.txt
+++ b/data/manual/Plugins/Equation_Editor.txt
@@ -7,7 +7,7 @@ The equation editor is a simple dialog that allows you to insert equations into 
 
 In order to be able to use this plugin you must have latex installed and the following two commands must be available on your system: "''latex"'' and "''dvipng"''. You can control the look of the equations using the special template "''_Equation.tex"''. The only variable that can be used in this template is "''equation''", which will be replaced with the content from the dialog.
 
-**Dependencies:** This plugin requires a Latex suite to be installed as well as the "dvipng" application. In specific the "latex" and "dvipng" commands should be available in the system path.
+**Dependencies:** This plugin requires a Latex suite to be installed as well as the "dvipng" application. In specific the "latex" and "dvipng" commands should be available in the system path. you will also need the zhmetrics latex package which doesnt come default with miktex or other latex proccessors
 
 ===== Syntax =====
 


### PR DESCRIPTION
by including this in the documentation, it makes it easier for users to debug with why inserting an equation wont work.  this is at least partly discussed in this [bazaar bug](https://bugs.launchpad.net/zim/+bug/1237909)