### PR TITLE
Do not suggest or create floating links for the user.

### DIFF
--- a/zim/notebook/index/pages.py
+++ b/zim/notebook/index/pages.py
@@ -683,43 +683,7 @@ class PagesView(IndexView):
 		elif target.ischild(source):
 			return HRef(HREF_REL_RELATIVE, target.relname(source))
 		else:
-			href = self._find_floating_link(source, target)
-			return href or HRef(HREF_REL_ABSOLUTE, target.name)
-
-	def _find_floating_link(self, source, target):
-		# Relative links only resolve for pages that have a common parent
-		# with the source page. So we start finding the common parents and
-		# if that does not resolve (e.g. because same name also occurs on a
-		# lower level) try one level up to "anchor" the link.
-		# It is absolute must to use resolve_link() here - this ensures the
-		# outcome is always consistent between these functions.
-		parentnames = []
-		for n1, n2 in zip(source.parts, target.parts):
-			if n1 == n2:
-				parentnames.append(n1)
-			else:
-				break
-
-		def try_link(names):
-			assert names
-			href = HRef(HREF_REL_FLOATING, ':'.join(names))
-			pid, pagename = self._pages.resolve_link(source, href)
-			return href if pagename == target else None
-
-		relnames = target.parts[len(parentnames):]
-		if not relnames: # Target is direct parent
-			relnames.insert(0, parentnames.pop())
-		href = try_link(relnames)
-		if href is not None:
-			return href
-		else:
-			while parentnames:
-				relnames.insert(0, parentnames.pop())
-				href = try_link(relnames)
-				if href:
-					return href
-			else:
-				return None # no floating link possible
+			return HRef(HREF_REL_ABSOLUTE, target.name)
 
 	def list_recent_changes(self, limit=None, offset=None):
 		assert not (offset and not limit), "Can't use offset without limit"


### PR DESCRIPTION
Floating links routinely become broken and misdirected during page renames.

Futhermore, the algorithim used to compute a floating link between two
pages has a high runtime cost, and does not scale well with a large
number of pages, particularly repos with many 'deep' pages.

This commit removes Zim's ability to generate floating links, while not
removing general support (both for data-in-place and as the user might
manually enter). Without any particular user interaction, links that
were originally created to be floating will gradually be replaced by
absolute links as their target pages are moved and renamed.

As a result of this commit, users might be happy to find considerably
faster "insert link" and "edit link" dialog box operations (specifically
with the building of the autocompletion suggestions), faster page move
and rename operations, and (in the long term) far fewer broken links.

A downside, to many users, might be a considerable increase in the
number of longer/absolute links. This might be ameliorated by using
the page title or 'n' of the last path segments as the visible link
text.

The generation of links between pages that do no share a parent are
practically not effected (differing only with a preceding colon ':'),
except for the fact that they are no longer vulnerable to the page
movement bug.

This may be related to the following existing tickets:
* https://bugs.launchpad.net/zim/+bug/501496
* https://bugs.launchpad.net/zim/+bug/1086343
* https://bugs.launchpad.net/zim/+bug/1133365
* https://bugs.launchpad.net/zim/+bug/1419531
* #477
* #487
