### PR TITLE
accelmap migration info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Jaap Karssenberg <jaap.karssenberg@gmail.com>
 This branch is the Python rewrite and starts with version 0.42.
 Earlier version numbers for zim correspond to the Perl branch.
 
+## next 
+* Info about migrating from Zim 0.69 to 0.70 – accelmap stops working.
+
 ##  0.70-rc3 - Mon 18 Feb 2019
 * Ported zim to use Python3 & Gtk3
 * Refactored application framework, all windows run single process now with

--- a/data/manual/FAQ.txt
+++ b/data/manual/FAQ.txt
@@ -66,3 +66,6 @@ Zim is written as a "single user" program, so it is not intended for multiple pe
 ===== I have a useful trick or tip. How can I share it with other users? =====
 You can have a look at the [[http://www.zim-wiki.org/wiki/|zim documentation wiki]]. It has a section dedicated to tricks and tips. Or write a mail to the mailing list, see the [[https://launchpad.net/~zim-wiki|team page]] on launchpad
 
+===== Migrating from 0.69 to 0.70 ====
+
+You can define your own shortcuts at ''~/.config/zim/accelmap'' . Since Zim moved to Gtk3, you have to update your keybindigs accordingly (ex: ''<Actions>/MainWindowExtension'' to either ''<Actions>/BookmarksBarMainWindowExtension'' or ''<Actions>/VersionControlMainWindowExtension'' etc. or <Actions>/GtkInterface to either ''<Actions>/UIActions'' or ''<Actions>/GtkInterface/'' etc.). You may just delete the old ''accelmap'' file and let it regenerate.


### PR DESCRIPTION
I've been quite surprised that I have to renew the file `accelmap` since old accelerators stop working as of Zim 0.70. It may be a good idea to inform users they have to re-do they accelerator. I don't know where to put the information so I created a migrating section in the FAQ.