### PR TITLE
accel without menu item can be called again

### DIFF
--- a/zim/gui/actionextension.py
+++ b/zim/gui/actionextension.py
@@ -43,9 +43,7 @@ class ActionExtensionBase(ExtensionBase):
 	def _uimanager_xml(action, actiongroup, defaultmenu):
 		menuhint = defaultmenu
 		if action.menuhints:
-			if 'accelonly' in action.menuhints:
-				return None
-			elif action.menuhints[0] in \
+			if action.menuhints[0] in \
 				('notebook', 'page', 'edit', 'insert', 'view', 'tools', 'go'):
 					menuhint = action.menuhints[0]
 


### PR DESCRIPTION
Hello,
there was a regression since e7e8f42 – old `uimanager_xml` menu style formatting was removed and Bookmarks disappeared from menus. However, accelerators to that bookmarks stopped working. With the hereby pull-requested change the accelerators work again without being displayed in the menu. (But after 3 hours of debugging I really don't know why :( )

I am open to all comments and ideas how should I do that better :)