### PR TITLE
Fix crash in Edit Image dialog when "Link to" set to a file.

### DIFF
--- a/zim/gui/pageview.py
+++ b/zim/gui/pageview.py
@@ -6964,7 +6964,7 @@ class EditImageDialog(Dialog):
 			if type == 'file':
 				# Try making the path relative
 				linkfile = self.form.widgets['href'].get_file()
-				href = self.notebook.relative_filepath(linkfile, self.page) or linkfile.uri
+				href = self.notebook.relative_filepath(linkfile, self.path) or linkfile.uri
 			attrib['href'] = href
 
 		iter = self.buffer.get_iter_at_offset(self._iter)


### PR DESCRIPTION
A small typo in the code causes the "Edit Image" dialog crashing
on "OK" button click. This happens when the field "Link to" on
the dialog is set to a file name.

This simple patch will fix the problem.