### PR TITLE
Fix crash in Edit Image dialog when the image file does not exist

### DIFF
--- a/zim/gui/pageview.py
+++ b/zim/gui/pageview.py
@@ -6925,6 +6925,9 @@ class EditImageDialog(Dialog):
 		else:
 			width.set_sensitive(True)
 			height.set_sensitive(True)
+			if w <= 0 and h <= 0:
+				# image file does not exist
+				return
 			self._block = True
 			width.set_range(0, 4 * w)
 			width.set_value(w)

--- a/zim/gui/pageview.py
+++ b/zim/gui/pageview.py
@@ -6964,7 +6964,7 @@ class EditImageDialog(Dialog):
 			if type == 'file':
 				# Try making the path relative
 				linkfile = self.form.widgets['href'].get_file()
-				href = self.notebook.relative_filepath(linkfile, self.page) or linkfile.uri
+				href = self.notebook.relative_filepath(linkfile, self.path) or linkfile.uri
 			attrib['href'] = href
 
 		iter = self.buffer.get_iter_at_offset(self._iter)


### PR DESCRIPTION
When the image file does not exist, Edit Image dialog failed to come up.
It was caused by ZeroDivisionError exception (shown by zim -V).

This simple change will the problem.