### PR TITLE
Clear translated messages when running msgfmt.make(), fixes #664

### DIFF
--- a/msgfmt.py
+++ b/msgfmt.py
@@ -100,6 +100,10 @@ def make(filename, outfile):
     ID = 1
     STR = 2
 
+    # Clear messages from previous execution. This prevents any untranslated
+    # messages defaulting to translated messages from previous execution.
+    MESSAGES.clear()
+
     # Compute .mo name from .po name and arguments
     if filename.endswith('.po'):
         infile = filename


### PR DESCRIPTION
If current PO file has untranslated messages, and any previously compiled PO files had them, the messages within those previous files are included into the currently compiled MO file. 

For example when I executed `./setup.py build_trans`, it compiled files:
```
running build_trans
compiling locale/zh_TW/LC_MESSAGES/zim.mo
compiling locale/it/LC_MESSAGES/zim.mo
compiling locale/sr/LC_MESSAGES/zim.mo
compiling locale/zh_CN/LC_MESSAGES/zim.mo
compiling locale/pt_BR/LC_MESSAGES/zim.mo
compiling locale/am/LC_MESSAGES/zim.mo
compiling locale/de/LC_MESSAGES/zim.mo
compiling locale/et/LC_MESSAGES/zim.mo
compiling locale/eu/LC_MESSAGES/zim.mo    # <-- Baski
compiling locale/fi/LC_MESSAGES/zim.mo    # <-- Finnish
compiling locale/sk/LC_MESSAGES/zim.mo
compiling locale/ar/LC_MESSAGES/zim.mo
compiling locale/es/LC_MESSAGES/zim.mo
compiling locale/ru/LC_MESSAGES/zim.mo
compiling locale/pl/LC_MESSAGES/zim.mo
compiling locale/gl/LC_MESSAGES/zim.mo
compiling locale/hu/LC_MESSAGES/zim.mo
compiling locale/nb/LC_MESSAGES/zim.mo
compiling locale/en_GB/LC_MESSAGES/zim.mo
compiling locale/ca/LC_MESSAGES/zim.mo
compiling locale/pt/LC_MESSAGES/zim.mo
compiling locale/uk/LC_MESSAGES/zim.mo
compiling locale/fr/LC_MESSAGES/zim.mo
compiling locale/he/LC_MESSAGES/zim.mo
compiling locale/sv/LC_MESSAGES/zim.mo
compiling locale/el/LC_MESSAGES/zim.mo
compiling locale/ro/LC_MESSAGES/zim.mo
compiling locale/cs/LC_MESSAGES/zim.mo
compiling locale/sl/LC_MESSAGES/zim.mo
compiling locale/tr/LC_MESSAGES/zim.mo
compiling locale/da/LC_MESSAGES/zim.mo
compiling locale/ja/LC_MESSAGES/zim.mo
compiling locale/ko/LC_MESSAGES/zim.mo
compiling locale/nl/LC_MESSAGES/zim.mo
```
With my locale of Finnish (FI) I noticed that most texts in UI were in Finnish, but some were in Baski (EU). The resulting Finnish MO file included messages from Baski's PO file, as it was compiled before Finnish PO file. 

The fix in this PR clears global `MESSAGES` variable to prevent translated messages leaking from one file to another.

I'm not entirely sure if this is the correct way to fix this. msgfmt.py's main() seems to be able to take multiple input files and I do not know if this change could brake the functionality for that. However, I didn't see anywhere the command being called from CLI, so may be this is ok?

Also, when I installed Zim from Ubuntu's PPA (see the issue), the UI was mix of Finnish and Itialian, not Baski, as I had when testing this in master. Perhaps the PO files were compiled in different order when the DEB file was packaged?