### PR TITLE
Update manual to depict calendar plugin renaming

### DIFF
--- a/data/manual/Plugins/Journal.txt
+++ b/data/manual/Plugins/Journal.txt
@@ -29,16 +29,19 @@ The [[Task List|Task List plugin]] has an option to automatically set the due da
 ===== Template Properties =====
 The Calendar plugin adds the following properties to the template for calendar pages:
 
-**calendar_plugin.date**
+**journal_plugin.page_type()**
+Indicates type of the page for which template was used. Contains one of following values: "''day''", "''week''", "''month''" or "''year''"
+
+**journal_plugin.date**
 Date covered by this page
 
-**calendar_plugin.start_date**
+**journal_plugin.start_date**
 First date covered by this page (same as 'calendar_plugin.date')
 
-**calendar_plugin.end_date**
+**journal_plugin.end_date**
 Last date covered by this page
 
-**calendar_plugin.days()**
+**journal_plugin.days()**
 A function that returns a list of all days in the week, month, year covered by this page
 
 All these dates can be used with the templates ''strftime()'' function to format the date as text. See [[Help:Templates|Templates]] for details.


### PR DESCRIPTION
Hopefully will help avoid confusion like in #737