### PR TITLE
This PR adds the possibility to change the size of the table of contents 

### DIFF
--- a/data/manual/Plugins/Table_Of_Contents.txt
+++ b/data/manual/Plugins/Table_Of_Contents.txt
@@ -15,6 +15,8 @@ Alternatively if the option **Show ToC as floating widget instead of in sidepane
 
 By default the page title is not show in the table of contents (unless there are multiple title headings in the page). If the option **Show the page title heading in the ToC** is enabled the page title will always been shown in the table of contents.
 
+The option **Set ToC fontsize** allows to set the fontsize of the floating ToC. Set it to 0 to leave this unset. In this case the size of the ToC follows the global font-size.
+
 ===== Style =====
 
 This plugin uses two widget names to allow CSS styling for the floating widget:

--- a/zim/plugins/tableofcontents.py
+++ b/zim/plugins/tableofcontents.py
@@ -88,7 +88,7 @@ This is a core plugin shipping with zim.
 			# T: option for plugin preferences
 		('show_h1', 'bool', _('Show the page title heading in the ToC'), False),
 			# T: option for plugin preferences
-		('fontsize', 'int', _('Set ToC fontsize (use 0 to leave it unset)'), 0, (0, 24)),
+		('fontsize', 'int', _('Set ToC fontsize'), 0, (0, 24)),
 			# T: option for plugin preferences
 	)
 	# TODO disable pane setting if not embedded


### PR DESCRIPTION
This PR implements a user setting (in the plugin's preferences) to set the font size of the table of contents   plugin. The user can set the font size, or set it to 0 to revert to the previous behaviour (this is the default)