### PR TITLE
Fix 'jump to' not providing completions with non-ascii characters

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -843,3 +843,22 @@ def gtk_activate_menu_item(menu, id):
 	'''
 	item = gtk_get_menu_item(menu, id)
 	item.activate()
+
+
+def find_widgets(type):
+	'''Iterate through all top level windows and recursively walk through their
+	children, returning all childs which are of given type.
+	@param type: any class inherited from C{Gtk.Widget}
+	@returns: list of widgets of given type
+	'''
+	widgets = []
+	def walk_containers(root_container):
+		if not hasattr(root_container, 'get_children'):
+			return
+		for child in root_container.get_children():
+			if isinstance(child, type):
+				widgets.append(child)
+			walk_containers(child)
+	for window in Gtk.Window.list_toplevels():
+		walk_containers(window)
+	return widgets

--- a/zim/gui/widgets.py
+++ b/zim/gui/widgets.py
@@ -27,6 +27,7 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import Pango
 from gi.repository import GdkPixbuf
+from gi.repository import GLib
 
 
 import logging
@@ -162,6 +163,16 @@ def gtk_window_set_default_icon():
 	if len(iconlist) < 3:
 		logger.warn('Could not find all icon sizes for the application icon')
 	Gtk.Window.set_default_icon_list(iconlist)
+
+
+def to_utf8_normalized_casefolded(text):
+	'''Convert text to utf8 normalized and casefolded form.
+	@param text: text string to convert
+	@returns: converted text
+	'''
+	result = GLib.utf8_normalize(text, -1, GLib.NormalizeMode.ALL)
+	result = GLib.utf8_casefold(result, -1)
+	return result
 
 
 
@@ -1663,9 +1674,9 @@ def gtk_entry_completion_match_func(completion, key, iter, column):
 		return False
 
 	model = completion.get_model()
-	text = model.get_value(iter, column)
+	text = to_utf8_normalized_casefolded(model.get_value(iter, column))
 	if text is not None:
-		return key in text.lower()
+		return key in text
 	else:
 		return False
 
@@ -1675,9 +1686,9 @@ def gtk_entry_completion_match_func_startswith(completion, key, iter, column):
 		return False
 
 	model = completion.get_model()
-	text = model.get_value(iter, column)
+	text = to_utf8_normalized_casefolded(model.get_value(iter, column))
 	if text is not None:
-		return text.lower().startswith(key)
+		return text.startswith(key)
 	else:
 		return False
 


### PR DESCRIPTION
See #84 for details.

I went with the normalizing/casefolding approach as the Gtk.EntryCompletionMatchFunc's documentation seemed to prefer that. 

Includes also a few additional tests with non-ascii test strings.
