### PR TITLE
Replace auto redirecting http:// with https://

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Based on template here:
-# http://editorconfig.org/
+# https://editorconfig.org/
 
 # top-most EditorConfig file
 root = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ and
 * Bug tracker and feature requests:
   https://github.com/zim-desktop-wiki/zim-desktop-wiki/issues
 * Public wiki:
-  http://www.zim-wiki.org/wiki/
+  https://www.zim-wiki.org/wiki/
 * Mailing list:
   https://launchpad.net/~zim-wiki
 * IRC Channel:
@@ -131,7 +131,7 @@ to do, you probably need a more heavy duty text editor.
 
 ## Translations
 
-To contribute to translations onlne please go to http://launchpad.net.
+To contribute to translations onlne please go to https://launchpad.net.
 
 To test a new translation you can either download the snapshot from launchpad and run:
 

--- a/data/manual/FAQ.txt
+++ b/data/manual/FAQ.txt
@@ -37,7 +37,7 @@ See [[Usage:Publishing]] for some tips
 Yes. Copy "''/usr/share/zim/style.conf''" to "''~/.config/zim/''" and edit as you see fit. See the [[Help:Config Files|Config Files]] page for the syntax of this file.
 
 ===== Can I have encrypted notebooks? =====
-Zim notebooks do not support encryption or password protection natively. However you can use for example [[http://www.arg0.net/encfs|encfs]] to encrypt your notebooks.
+Zim notebooks do not support encryption or password protection natively. However you can use for example [[https://www.arg0.net/encfs|encfs]] to encrypt your notebooks.
 
 ===== Can I have full calendaring in zim? =====
 Well, if you really want to, you can use zim as your agenda. However, the Calendar feature is more intended to keep various kinds of journals or logbooks. I'm very hesitant to add calendaring features because these are usually tied to email applications. I admit that it would be really cool to link notes, emails and appointments, but I have no plans to extend zim to become an email reader.
@@ -49,7 +49,7 @@ You can change this by modifying the gtk css file, see [[Help:Config Files|Confi
 Yes it does. See the download page on the website for more notes on installing on the win32 platform.
 
 ===== Does it run on OS X? =====
-Yes it does. See the install instructions on our [[http://zim-wiki.org/install.html|webpage]], or check in the [[http://www.zim-wiki.org/wiki/|zim documentation wiki]] for additional tips how to install it.
+Yes it does. See the install instructions on our [[https://zim-wiki.org/install.html|webpage]], or check in the [[https://www.zim-wiki.org/wiki/|zim documentation wiki]] for additional tips how to install it.
 
 ===== I want to move/backup/synchronize a zim notebook. Which files do I need to take care of? =====
 The visible files in the notebook folder contain all data of notes and [[Help:Attachments|attachments]].
@@ -64,5 +64,5 @@ By synchronizing all visible files in the notebook. E.g. by putting the zim note
 Zim is written as a "single user" program, so it is not intended for multiple people using the same notebook. However it can be used with version control like Bazaar, Git or Mercurial. This way multiple users can work on the same notebook and merge their changes. See the [[Plugins:Version Control|Version Control plugin]].
 
 ===== I have a useful trick or tip. How can I share it with other users? =====
-You can have a look at the [[http://www.zim-wiki.org/wiki/|zim documentation wiki]]. It has a section dedicated to tricks and tips. Or write a mail to the mailing list, see the [[https://launchpad.net/~zim-wiki|team page]] on launchpad
+You can have a look at the [[https://www.zim-wiki.org/wiki/|zim documentation wiki]]. It has a section dedicated to tricks and tips. Or write a mail to the mailing list, see the [[https://launchpad.net/~zim-wiki|team page]] on launchpad
 

--- a/data/manual/Help/Default_Applications.txt
+++ b/data/manual/Help/Default_Applications.txt
@@ -47,4 +47,4 @@ If you want to clean up custom application entries, have a look at the folder ''
 
 See [[Config Files]] for an overview of the various XDG file paths.
 
-The XDG Desktop Entry spec and the XDG MimeInfo spec can be found here: http://www.freedesktop.org/wiki/Specifications
+The XDG Desktop Entry spec and the XDG MimeInfo spec can be found here: https://www.freedesktop.org/wiki/Specifications

--- a/data/manual/Help/Export/HTML.txt
+++ b/data/manual/Help/Export/HTML.txt
@@ -25,7 +25,7 @@ backspace         previous page
 This is a plain template intended for printing pages. It is use by the "Print to Browser" plugin.
 
 **"SlideShow (S5)"**
-Template based on S5. S5 is "A Simple Standards-Based Slide Show System", which mean a slide show system completely written in html and javascript. Therefor these slide shows can be presented using a browser and be put on a website. See [[http://meyerweb.com/eric/tools/s5/|the S5 website]] for more information.
+Template based on S5. S5 is "A Simple Standards-Based Slide Show System", which mean a slide show system completely written in html and javascript. Therefor these slide shows can be presented using a browser and be put on a website. See [[https://meyerweb.com/eric/tools/s5/|the S5 website]] for more information.
 
 When using this template, each new "heading 1" in the page will become a new slide. When exporting multiple pages to a single file each page becomes a slide. But within a page you can also have multiple "heading 1" headings to start new slides.
 

--- a/data/manual/Help/Importing_external_files.txt
+++ b/data/manual/Help/Importing_external_files.txt
@@ -8,7 +8,7 @@ Creation-Date: 2010-04-03T23:35:33.816582
 Pages in Zim are stored as text files in normal folders and subfolders in your file system.
 The file name is used as page name. The hierarchical structure is similar to the one appearing in the index. The file names should contain **no blanks**; instead use underlines. So a filename can look like this: "Help_on_creating_notebooks.txt" or "HelpOnCreatingNotebooks.txt".
 
-Important: The content of the text file must be UTF-8 or ASCII encoded.  If you are not familiar with character encoding, please read http://en.wikipedia.org/wiki/Character_encoding. If files contain different encoding and zim tries to read them as UTF-8 an error will occur.
+Important: The content of the text file must be UTF-8 or ASCII encoded.  If you are not familiar with character encoding, please read https://en.wikipedia.org/wiki/Character_encoding. If files contain different encoding and zim tries to read them as UTF-8 an error will occur.
 
 Some word processors allow checking the encoding, e.g. with the small editor Mousepad load the file, then click Save as, then the button on the bottom right just above the save button should show UTF-8. If not and if you cannot save with this configuration Zim will not work. You can also use the Geany editor for the same purposes.
 

--- a/data/manual/Plugins/Equation_Editor.txt
+++ b/data/manual/Plugins/Equation_Editor.txt
@@ -36,4 +36,4 @@ x_{1,2}=\frac{-b\pm\sqrt{\color{Red}b^2-4ac}}{2a}
 
 * [1] http://www.ams.org/tex/amslatex.html
 * [2] http://www.latex-project.org/guides/
-* http://en.wikipedia.org/wiki/Help:Formula (latex parts only)
+* https://en.wikipedia.org/wiki/Help:Formula (latex parts only)

--- a/data/manual/Plugins/Version_Control.txt
+++ b/data/manual/Plugins/Version_Control.txt
@@ -4,7 +4,7 @@ Creation-Date: 2010-02-22T15:44:37.508437
 
 ====== Version Control ======
 
-Zim's default installation ships with a Version Control Plugin. To enable it, go to ''Edit -> Preferences -> Plugins'' and check the box next to Version Control. Zim supports [[http://bazaar.canonical.com/|Bazaar]],  [[http://git-scm.com/|Git]], [[http://mercurial.selenic.com/|Mercurial]], and [[http://www.fossil-scm.org/|Fossil]]  as backends.
+Zim's default installation ships with a Version Control Plugin. To enable it, go to ''Edit -> Preferences -> Plugins'' and check the box next to Version Control. Zim supports [[http://bazaar.canonical.com/|Bazaar]],  [[https://git-scm.com/|Git]], [[http://mercurial.selenic.com/|Mercurial]], and [[https://www.fossil-scm.org/|Fossil]]  as backends.
 
 **Dependencies:** This plugin requires one of the supported version control systems to be installed. Currently Bazaar, Git, Mercurial and Fossil are supported, so one of these applications is required. In specific the "''bzr''", "''git''", "''hg''" or "''fossil''" command should be available in the system path.
 
@@ -34,7 +34,7 @@ TODO here should be documented how to share the newly created repository with yo
 See the [[http://bazaar.canonical.com/|Bazaar]] user manual for various scenarios of collaboration (follow the "documentation" link on their website).
 
 ===== Technical Details =====
-Technically speaking a local repository is created when enabling Version Control, depending on the backend you choose, this repository is managed by  [[http://bazaar.canonical.com/|Bazaar]],  [[http://git-scm.com/|Git]], [[http://mercurial.selenic.com/|Mercurial]] or [[http://www.fossil-scm.org/|Fossil]]. Every time you save a version, another revision is checked in. Zim just uses standard version control systems as backend, so you can always view and export your history using standard tools.
+Technically speaking a local repository is created when enabling Version Control, depending on the backend you choose, this repository is managed by  [[http://bazaar.canonical.com/|Bazaar]],  [[https://git-scm.com/|Git]], [[http://mercurial.selenic.com/|Mercurial]] or [[https://www.fossil-scm.org/|Fossil]]. Every time you save a version, another revision is checked in. Zim just uses standard version control systems as backend, so you can always view and export your history using standard tools.
 
 On startup zim tries to detect the version control system used for a specific notebook, and use it if supported. So you can manually initialize repository (e.g. by branching) and then open them with zim. No need to tell Zim that the notebook is managed explicitly.
 

--- a/data/symbols.list
+++ b/data/symbols.list
@@ -276,7 +276,7 @@
 \ohm	937	 # same as \omega
 
 ## Additional typography ##
-# See http://en.wikipedia.org/wiki/Arrow_%28symbol%29 for more codes
+# See https://en.wikipedia.org/wiki/Arrow_%28symbol%29 for more codes
 # convert hex -> decimal before using here
 -->	8594  # same as \right
 <-- 8592  # same as \left

--- a/data/urls.list
+++ b/data/urls.list
@@ -9,21 +9,21 @@
 
 # You can add more InterWiki shortcuts here.
 
-wp        http://en.wikipedia.org/wiki/
-wpde      http://de.wikipedia.org/wiki/
+wp        https://en.wikipedia.org/wiki/
+wpde      https://de.wikipedia.org/wiki/
 wpmeta    http://meta.wikipedia.org/wiki/
 doku      http://wiki.splitbrain.org/
 freecache http://freecache.org/{NAME}
 rfc       http://www.ietf.org/rfc/rfc{NAME}.txt
-amazon    http://www.amazon.com/exec/obidos/ASIN/
+amazon    https://www.amazon.com/exec/obidos/ASIN/
 amazon.de http://www.amazon.de/exec/obidos/ASIN/{URL}/ballermannsyndic/
-amazon.uk http://www.amazon.co.uk/exec/obidos/ASIN/
+amazon.uk https://www.amazon.co.uk/exec/obidos/ASIN/
 google    http://www.google.com/search?q=
 google.de http://www.google.de/search?q=
 phpfn     http://www.php.net/{NAME}
 go        http://www.google.com/search?q={URL}&btnI=lucky
 cpan      http://search.cpan.org/search?query={URL}&mode=all
-perldoc   http://perldoc.perl.org/search.html?q=
+perldoc   https://perldoc.perl.org/search.html?q=
 
 
 # Standards from http://usemod.com/intermap.txt follow
@@ -42,14 +42,14 @@ BenefitsWiki http://www.benefitslink.com/cgi-bin/wiki.cgi?
 BridgesWiki http://c2.com/w2/bridges/
 C2find http://c2.com/cgi/wiki?FindPage&value=
 Cache http://www.google.com/search?q=cache:
-CLiki http://ww.telent.net/cliki/
+CLiki https://ww.telent.net/cliki/
 CmWiki http://www.ourpla.net/cgi-bin/wiki.pl?
 CreationMatters http://www.ourpla.net/cgi-bin/wiki.pl?
 DejaNews http://www.deja.com/=dnc/getdoc.xp?AN=
 DeWikiPedia http://www.wikipedia.de/wiki.cgi?
 Dictionary http://www.dict.org/bin/Dict?Database=*&Form=Dict1&Strategy=*&Query=
 DiveIntoOsx http://diveintoosx.org/
-DocBook http://docbook.org/wiki/moin.cgi/
+DocBook https://docbook.org/wiki/moin.cgi/
 DolphinWiki http://www.object-arts.com/wiki/html/Dolphin/
 EfnetCeeWiki http://purl.net/wiki/c/
 EfnetCppWiki http://purl.net/wiki/cpp/
@@ -75,7 +75,7 @@ KmWiki http://www.voght.com/cgi-bin/pywiki?
 KnowHow http://www2.iro.umontreal.ca/~paquetse/cgi-bin/wiki.cgi?
 LanifexWiki http://opt.lanifex.com/cgi-bin/wiki.pl?
 LegoWiki http://www.object-arts.com/wiki/html/Lego-Robotics/
-LinuxWiki http://www.linuxwiki.de/
+LinuxWiki https://www.linuxwiki.de/
 LugKR http://lug-kr.sourceforge.net/cgi-bin/lugwiki.pl?
 MathSongsWiki http://SeedWiki.com/page.cfm?wikiid=237&doc=
 MbTest http://www.usemod.com/cgi-bin/mbtest.pl?
@@ -100,14 +100,14 @@ SeaPig http://www.seapig.org/
 SeattleWireless http://seattlewireless.net/?
 SenseisLibrary http://senseis.xmp.net/?
 Shakti http://cgi.algonet.se/htbin/cgiwrap/pgd/ShaktiWiki/
-SourceForge http://sourceforge.net/
+SourceForge https://sourceforge.net/
 Squeak http://minnow.cc.gatech.edu/squeak/
 StrikiWiki http://ch.twi.tudelft.nl/~mostert/striki/teststriki.pl?
 SVGWiki http://www.protocol7.com/svg-wiki/default.asp?
 Tavi http://tavi.sourceforge.net/index.php?
 TmNet http://www.technomanifestos.net/?
 TMwiki http://www.EasyTopicMaps.com/?page=
-TWiki http://twiki.org/cgi-bin/view/
+TWiki https://twiki.org/cgi-bin/view/
 TwistedWiki http://purl.net/wiki/twisted/
 Unreal http://wiki.beyondunreal.com/wiki/
 UseMod http://www.usemod.com/cgi-bin/wiki.pl?

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ X-Python3-Version: > 3.2
 
 Package: zim
 Architecture: all
-Homepage: http://zim-wiki.org/
+Homepage: https://zim-wiki.org/
 Depends: ${python3:Depends}, ${misc:Depends}, python3 (>= 3.2), libgtk-3-0 (>= 3.18), gir1.2-gtk-3.0, python3-gi, python3-xdg
 # python-gtkspell required for the spell checker plugin
 # Recommends: python-gtkspellcheck

--- a/tests/notebook.py
+++ b/tests/notebook.py
@@ -121,7 +121,7 @@ class TestNotebookInfoList(tests.TestCase):
 		self.assertEqual(list.default.uri, uri1)
 
 		# Check interwiki parsing - included here since it interacts with the notebook list
-		self.assertEqual(interwiki_link('wp?Foo'), 'http://en.wikipedia.org/wiki/Foo')
+		self.assertEqual(interwiki_link('wp?Foo'), 'https://en.wikipedia.org/wiki/Foo')
 		self.assertEqual(interwiki_link('foo?Foo'), 'zim+' + dir.uri + '?Foo')
 		self.assertEqual(interwiki_link('foobar?Foo'), 'zim+' + uri1 + '?Foo') # interwiki key
 		self.assertEqual(interwiki_link('FooBar?Foo'), 'zim+' + uri1 + '?Foo') # interwiki key

--- a/tests/pageview.py
+++ b/tests/pageview.py
@@ -1713,7 +1713,7 @@ foo
 		page = tests.new_page_from_text('[[wp?foobar]]')
 		pageview.set_page(page)
 		click(_('Copy _Link'))
-		self.assertEqual(Clipboard.get_text(), 'http://en.wikipedia.org/wiki/foobar')
+		self.assertEqual(Clipboard.get_text(), 'https://en.wikipedia.org/wiki/foobar')
 		tree = Clipboard.get_parsetree(pageview.notebook, page)
 		self.assertEqual(tree.tostring(),
 			'<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<zim-tree><link href="wp?foobar">wp?foobar</link></zim-tree>')

--- a/website/pages/contribute.txt
+++ b/website/pages/contribute.txt
@@ -11,7 +11,7 @@ INSERT_PAYPAL_BUTTON_HERE
 In the paypal form there is a link "Suggestions and Comments" (it is a bit small but it is there when you confirm the donation). Feel free to use this text field to tell me what is on your whish list for future development. I can not promise to implement every feature that gets mentioned in a donation, but it will certainly be taken into consideration. If enough funds come in we will set up bounties for other developers that want to work on nominated features as well.
 
 ===== User Manual Updates =====
-Updates for the user manual can be submitted in [[http://www.zim-wiki.org/wiki/|the wiki]] or as patches (see below).
+Updates for the user manual can be submitted in [[https://www.zim-wiki.org/wiki/|the wiki]] or as patches (see below).
 
 ===== Translation updates =====
 See [[translations]] on how to update translation files.

--- a/website/pages/downloads.txt
+++ b/website/pages/downloads.txt
@@ -37,12 +37,12 @@ A windows installer can be found [[https://zim.glump.net/windows/|here]].
 
 The following Linux distributions are known to include zim:
 * Archlinux (extra/zim)
-* [[http://packages.debian.org/unstable/x11/zim|Debian]] (x11/zim)
+* [[https://packages.debian.org/unstable/x11/zim|Debian]] (x11/zim)
 * Gentoo (x11-misc/zim)
 * Sourcemage (zim)
 * [[https://apps.fedoraproject.org/packages/Zim|Fedora]]
 * Ubuntu (universe)
 
 BSD flavors with a zim port:
-* [[http://www.freshports.org/deskutils/zim|FreeBSD]]
+* [[https://www.freshports.org/deskutils/zim|FreeBSD]]
 * [[http://www.openbsd.org/cgi-bin/cvsweb/ports/productivity/zim/|OpenBSD]]

--- a/windows/src/help.html
+++ b/windows/src/help.html
@@ -16,7 +16,7 @@
 Zim Desktop Wiki Portable
 </h1>
 
-<p><a href="http://www.zim-wiki.org">www.zim-wiki.org</a></p>
+<p><a href="https://www.zim-wiki.org">www.zim-wiki.org</a></p>
 
 <p><b>Zim</b> is a graphical text editor used to maintain a collection of wiki pages. Each page can contain links to other pages, simple formatting and images. Pages are stored in a folder structure, like in an outliner, and can have attachments. Creating a new page is as easy as linking to a nonexistent page. All data is stored in plain text files with wiki formatting. Various plugins provide additional functionality, like a task list manager, an equation editor, a tray icon, and support for version control.</p>
 

--- a/zim/__init__.py
+++ b/zim/__init__.py
@@ -94,7 +94,7 @@ Some generic base classes and functions can be found in L{zim.utils}
 
 # Bunch of meta data, used at least in the about dialog
 __version__ = '0.70'
-__url__ = 'http://www.zim-wiki.org'
+__url__ = 'https://www.zim-wiki.org'
 __author__ = 'Jaap Karssenberg <jaap.karssenberg@gmail.com>'
 __copyright__ = 'Copyright 2008 - 2019 Jaap Karssenberg <jaap.karssenberg@gmail.com>'
 __license__ = '''\

--- a/zim/gui/preferencesdialog.py
+++ b/zim/gui/preferencesdialog.py
@@ -249,7 +249,7 @@ class PluginsTab(Gtk.VBox):
 		hbox.pack_start(open_button, False, True, 0)
 
 		url_button = Gtk.LinkButton(
-			'http://zim-wiki.org/more_plugins.html',
+			'https://zim-wiki.org/more_plugins.html',
 			_('Get more plugins online') # T: label for button with URL
 		)
 		hbox.pack_start(url_button, False, True, 0)

--- a/zim/gui/templateeditordialog.py
+++ b/zim/gui/templateeditordialog.py
@@ -66,7 +66,7 @@ class TemplateEditorDialog(Dialog):
 
 		## Same button appears in export dialog
 		url_button = Gtk.LinkButton(
-			'http://zim-wiki.org/more_templates.html',
+			'https://zim-wiki.org/more_templates.html',
 			_('Get more templates online') # T: label for button with URL
 		)
 		self.vbox.pack_start(url_button, False, True, 0)


### PR DESCRIPTION
Replaced with https:// http:// links which redirect to https:// anyway
(Only in places which seemed safe to do this replacement)

Used following script to find such links:

```bash
#!/bin/bash

IFS= readarray -d '' FILES < <(git --no-pager grep --null -l http:// ":(exclude)*svg")
for FILE in "${FILES[@]}"; do 
    echo "$FILE"
    sed -i 's|http://www.zim-wiki.org|https://www.zim-wiki.org|' "$FILE"
    for URL in $(grep --extended-regexp --only-matching 'http://[^| ]*[^.|]' "$FILE"); do
        HTTPS_URL="https:${URL#http:}"
        REDIRECT_URL=$(curl --max-time 5 -L --head --output /dev/null --silent --write-out '%{url_effective}' "$URL")
        if [[ "$REDIRECT_URL" == "$HTTPS_URL"* ]]; then
            sed -i "s|${URL}|${HTTPS_URL}|" "$FILE"
        fi
        echo "$URL -> $REDIRECT_URL"
    done
    git add -p "$FILE"
done
```