### PR TITLE
Improve find bar behaviour (fixes #317 and #128)

### DIFF
--- a/zim/gui/pageview.py
+++ b/zim/gui/pageview.py
@@ -5339,7 +5339,14 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		def set_actiongroup_sensitive(window, widget):
 			#~ print('!! FOCUS SET:', widget)
 			sensitive = widget is self.textview
-			self._set_menuitems_sensitive(sensitive)
+
+			# Enable keybindings and buttons for find functionality if find bar is in focus
+			force_sensitive = ()
+			if widget and widget.get_parent() is self.find_bar:
+				force_sensitive = ("show_find", "find_next", "find_previous",
+					"show_find_alt1", "find_next_alt1", "find_previous_alt1")
+
+			self._set_menuitems_sensitive(sensitive, force_sensitive)
 
 		window = self.get_toplevel()
 		if window and window != self:
@@ -5592,7 +5599,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 			self.preferences['read_only_cursor'] or not self.readonly)
 		self._set_menuitems_sensitive(True) # XXX not sure why this is here
 
-	def _set_menuitems_sensitive(self, sensitive):
+	def _set_menuitems_sensitive(self, sensitive, force_sensitive=()):
 		'''Batch update global menu sensitivity while respecting
 		sensitivities set due to cursor position, readonly state etc.
 		'''
@@ -5610,7 +5617,10 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 			self.do_mark_set(buffer, iter, mark)
 		else:
 			for action in self.actiongroup.list_actions():
-				action.set_sensitive(False)
+				if action.get_name() not in force_sensitive:
+					action.set_sensitive(False)
+				else:
+					action.set_sensitive(True)
 
 	def set_cursor_pos(self, pos):
 		'''Set the cursor position in the buffer and scroll the TextView

--- a/zim/gui/pageview.py
+++ b/zim/gui/pageview.py
@@ -5596,6 +5596,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		'''Batch update global menu sensitivity while respecting
 		sensitivities set due to cursor position, readonly state etc.
 		'''
+
 		if sensitive:
 			# partly overrule logic in window.toggle_editable()
 			for action in self.actiongroup.list_actions():
@@ -7272,13 +7273,11 @@ class FindWidget(object):
 		buffer = self.textview.get_buffer()
 		buffer.finder.find_next()
 		self.textview.scroll_to_mark(buffer.get_insert(), SCROLL_TO_MARK_MARGIN, False, 0, 0)
-		self.textview.grab_focus()
 
 	def find_previous(self):
 		buffer = self.textview.get_buffer()
 		buffer.finder.find_previous()
 		self.textview.scroll_to_mark(buffer.get_insert(), SCROLL_TO_MARK_MARGIN, False, 0, 0)
-		self.textview.grab_focus()
 
 
 class FindBar(FindWidget, Gtk.HBox):
@@ -7321,7 +7320,7 @@ class FindBar(FindWidget, Gtk.HBox):
 
 	def on_find_entry_activate(self):
 		self.on_find_entry_changed()
-		self.textview.grab_focus()
+		self.find_next()
 
 	def do_key_press_event(self, event):
 		keyval = strip_boolean_result(event.get_keyval())


### PR DESCRIPTION
This makes the find bar behaviour match other common applications.

* When a match is found don't defocus the find bar.
* Press Ctrl+G or Enter to go to next occurence.
* If Ctrl+F is pressed and there is already text inside the find bar then the text is highlighed (even if it is already visible).

Also fixes launchpad bugs:
https://bugs.launchpad.net/zim/+bug/1036821
https://bugs.launchpad.net/zim/+bug/1589085
https://bugs.launchpad.net/zim/+bug/1685371