### PR TITLE
Workaround for #390

### DIFF
--- a/zim/plugins/pageindex/__init__.py
+++ b/zim/plugins/pageindex/__init__.py
@@ -476,8 +476,13 @@ class PageTreeView(BrowserTreeView):
 		logger.debug('Drag data requested, we have internal path "%s"', path.name)
 		data = pack_urilist((path.name,))
 		selectiondata.set(selectiondata.get_target(), 8, data)
+		self.__selectiondata__ = selectiondata # GNOME/pygobject/issues/104
 
 	def do_drag_data_received(self, dragcontext, x, y, selectiondata, info, time):
+		if self.__selectiondata__ is not None:
+			selectiondata = self.__selectiondata__ # GNOME/pygobject/issues/104
+			self.__selectiondata__ = None
+
 		assert selectiondata.get_target().name() == INTERNAL_PAGELIST_TARGET_NAME
 		names = unpack_urilist(selectiondata.get_data())
 		assert len(names) == 1


### PR DESCRIPTION
Workaround for drag-and-drop in pageindex pane (#390) using a temporary class variable, since gtk would otherwise fail to pass the correct `selectiondata` and only give an empty one.

Dragging from pageindex _to_ the editor (for creating hyperlinks) is still broken.

Drag-and-drop from other sources, such as the PathBar, were never affected by the bug. They will work both with or without this fix.

The global variable isn't a problem in practice because you'll never be dragging and dropping from multiple sources at once, so by the time one operation is done the variable will have been reset. Still, it is somewhat hacky so use as you wish.