### PR TITLE
spawn_async: missing working_directory argument

### DIFF
--- a/zim/applications.py
+++ b/zim/applications.py
@@ -353,7 +353,7 @@ class Application(object):
 		try:
 			try:
 				pid, stdin, stdout, stderr = \
-					GObject.spawn_async(argv, flags=flags, **opts)
+					GObject.spawn_async(argv, flags=flags, working_directory=cwd, **opts)
 			except GObject.GError:
 				if _CAN_CALL_FLATPAK_HOST_COMMAND:
 					pid, stdin, stdout, stderr = \

--- a/zim/applications.py
+++ b/zim/applications.py
@@ -345,6 +345,9 @@ class Application(object):
 			flags |= GObject.SPAWN_DO_NOT_REAP_CHILD
 			# without this flag child is reaped automatically -> no zombies
 
+		if not cwd:
+			cwd = os.getcwd()
+
 		logger.info('Spawning: %s (cwd: %s)', argv, cwd)
 		if TEST_MODE:
 			TEST_MODE_RUN_CB(argv)


### PR DESCRIPTION
Pretty straight forward... we go through the trouble of passing in an optional working directory just to drop it on the floor.