### PR TITLE
Task list: setting to display due date in sidepane view.

### DIFF
--- a/data/manual/Plugins/Task_List.txt
+++ b/data/manual/Plugins/Task_List.txt
@@ -20,7 +20,8 @@ If **Use date from journal pages** is enabled, tasks found in pages that belong 
 
 The options **Section(s) to index** and **Section(s) to ignore** can be used to limit the namespaces that are indexed for tasks. By default the whole notebook is used, but if either or both of these options are used, only the specified set of sections is indexed. Multiple namespaces can be given separated by a "'',''".
 
-The options **Show tasklist in sidepane** and **Position in the window** allow you to embed the tasklist in one of the side panes of the window.
+The options **Show tasklist in sidepane** and **Position in the window** allow you to embed the tasklist in one of the side panes of the window; **Show due date in sidepane** selects whether a tasklist in a side pane displays the due date of a task.
+
 
 ==== Context menu ====
 The context menu of the tasklist (the "right click" menu) has two further options to control the view:


### PR DESCRIPTION
For my personal task list workflow both priority and due date are essential properties, hence I need the ability to sort after either of these in the side pane view. Maybe that is appropriate and worthy to be included into zim in general.

This discontinues the TODO comment to split the different views of the task list into different classes: different column layouts can be specified by an explicit enum parameter.

This pull request is the python3/gtk3 successor of a now withdrawn pull request for python2/gtk2.

I am open to criticism and would contribute a German translation after merge.