### PR TITLE
Sourceview: setting to have linenumbers off for newly created items.

### DIFF
--- a/zim/plugins/sourceview.py
+++ b/zim/plugins/sourceview.py
@@ -97,11 +97,11 @@ class SourceViewObjectType(InsertedObjectTypeExtension):
 		self.connectto(self.preferences, 'changed', self.on_preferences_changed)
 
 	def new_model_interactive(self, parent, notebook, page):
-		lang = InsertCodeBlockDialog(parent).run()
+		lang, linenumbers = InsertCodeBlockDialog(parent).run()
 		if lang is None:
 			raise ValueError # dialog cancelled
 		else:
-			attrib = self.parse_attrib({'lang': lang})
+			attrib = self.parse_attrib({'lang': lang, 'linenumbers': linenumbers})
 			return SourceViewBuffer(attrib, '')
 
 	def model_from_data(self, notebook, page, attrib, text):
@@ -280,6 +280,7 @@ class InsertCodeBlockDialog(Dialog):
 	def __init__(self, parent):
 		Dialog.__init__(self, parent, _('Insert Code Block')) # T: dialog title
 		self.uistate.define(lang=String(None))
+		self.uistate.define(line_numbers=Boolean(True))
 		defaultlang = self.uistate['lang']
 
 		menu = {}
@@ -311,8 +312,14 @@ class InsertCodeBlockDialog(Dialog):
 			combobox.set_active_iter(defaultiter)
 		hbox.add(combobox)
 		self.combobox = combobox
-
 		self.vbox.add(hbox)
+		self.checkbox = Gtk.CheckButton("Display line numbers")
+		self.checkbox.set_active(self.uistate['line_numbers'])
+		self.vbox.add(self.checkbox)
+
+	def run(self):
+		result = super().run()
+		return result, self.checkbox.get_active()
 
 	def do_response_ok(self):
 		model = self.combobox.get_model()
@@ -322,6 +329,7 @@ class InsertCodeBlockDialog(Dialog):
 			name = model[iter][0]
 			self.result = LANGUAGES[name]
 			self.uistate['lang'] = LANGUAGES[name]
+			self.uistate['line_numbers'] = self.checkbox.get_active()
 			return True
 		else:
 			return False # no syntax selected


### PR DESCRIPTION
Configurable, by default it is is same as it has been, linenumbers are visible. This affects behaviour for newly created blocks. After it has been created, line numbers can be displayed or hidden, just as it has been poissible until now. 

There are currently no tests - I can write some if you want and explain me basic logic of manipulating tree. 
My idea is to create codeblock, check linenumbers, change setting and create new codeblock. 
I was looking into it and don't understand how `tree.find('object')` works, and after calling action.activate for the second time, tree (tried `print(tree.tostring())`) doesn't appear to change. 