### PR TITLE
Slight improvments to the statusbar

### DIFF
--- a/translations/am.po
+++ b/translations/am.po
@@ -685,10 +685,10 @@ msgstr "_እንደገና መጫኛ"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i የ  _ዌብ ምንጭ..."
-msgstr[1] "%i የ  _ዌብ ምንጮች..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i የ  _ዌብ ምንጭ"
+msgstr[1] "%i የ  _ዌብ ምንጮች"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/ar.po
+++ b/translations/ar.po
@@ -676,14 +676,14 @@ msgstr "أعد التحميل"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _إشارة خلفية..."
-msgstr[1] "%i _Backlinks..."
-msgstr[2] "%i _Backlinks..."
-msgstr[3] "%i _Backlinks..."
-msgstr[4] "%i _Backlinks..."
-msgstr[5] "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _إشارة خلفية"
+msgstr[1] "%i _Backlinks"
+msgstr[2] "%i _Backlinks"
+msgstr[3] "%i _Backlinks"
+msgstr[4] "%i _Backlinks"
+msgstr[5] "%i _Backlinks"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976
@@ -1782,7 +1782,7 @@ msgstr ""
 #. Menu item
 #: zim/gui/uiactions.py:305
 msgid "Search _Backlinks..."
-msgstr "إبحث الوصلات الخلفية"
+msgstr "إبحث الوصلات الخلفية..."
 
 #. Menu item
 #: zim/gui/uiactions.py:313

--- a/translations/ca.po
+++ b/translations/ca.po
@@ -689,10 +689,10 @@ msgstr "_Refresca"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _retroenllaç..."
-msgstr[1] "%i _retroenllaços..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _retroenllaç"
+msgstr[1] "%i _retroenllaços"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976
@@ -1796,7 +1796,7 @@ msgstr "Cercar a aquesta secció"
 #. Menu item
 #: zim/gui/uiactions.py:305
 msgid "Search _Backlinks..."
-msgstr "_Cerca els retroenllaços"
+msgstr "_Cerca els retroenllaços..."
 
 #. Menu item
 #: zim/gui/uiactions.py:313

--- a/translations/cs.po
+++ b/translations/cs.po
@@ -687,8 +687,8 @@ msgstr "Z_novu načíst"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
 msgstr[0] "%i zpětný odkaz"
 msgstr[1] "%i zpětné odkazy"
 msgstr[2] "%i zpětných odkazů"

--- a/translations/da.po
+++ b/translations/da.po
@@ -689,10 +689,10 @@ msgstr "_Genindlæs"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _henvisning hertil..."
-msgstr[1] "%i _henvisninger hertil..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _henvisning hertil"
+msgstr[1] "%i _henvisninger hertil"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/de.po
+++ b/translations/de.po
@@ -687,10 +687,10 @@ msgstr "_Neu laden"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _Backlink..."
-msgstr[1] "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _Backlink"
+msgstr[1] "%i _Backlinks"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/el.po
+++ b/translations/el.po
@@ -679,10 +679,10 @@ msgstr "_Επαναφόρτωση"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _Backlink..."
-msgstr[1] "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _Backlink"
+msgstr[1] "%i _Backlinks"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/en_GB.po
+++ b/translations/en_GB.po
@@ -692,10 +692,10 @@ msgstr "_Reload"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _Backlink..."
-msgstr[1] "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _Backlink"
+msgstr[1] "%i _Backlinks"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/es.po
+++ b/translations/es.po
@@ -689,10 +689,10 @@ msgstr "_Recargar"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _Enlace hacia atrás..."
-msgstr[1] "%i _Enlaces hacia atrás..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _Enlace hacia atrás"
+msgstr[1] "%i _Enlaces hacia atrás"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/et.po
+++ b/translations/et.po
@@ -669,10 +669,10 @@ msgstr "La_e uuesti"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i Ta_gasiviide..."
-msgstr[1] "%i Ta_gasiviited..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i Ta_gasiviide"
+msgstr[1] "%i Ta_gasiviited"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/eu.po
+++ b/translations/eu.po
@@ -690,10 +690,10 @@ msgstr "_Birkargatu"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i_Bueltako esteka..."
-msgstr[1] "%i_Bueltako estekak..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i_Bueltako esteka"
+msgstr[1] "%i_Bueltako estekak"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -673,10 +673,10 @@ msgstr "La_taa uudelleen"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _Paluulinkki..."
-msgstr[1] "%i _Paluulinkit..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _Paluulinkki"
+msgstr[1] "%i _Paluulinkit"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -692,8 +692,8 @@ msgstr "_Actualiser"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
 msgstr[0] "%i _rétro-lien"
 msgstr[1] "%i _rétro-liens"
 

--- a/translations/gl.po
+++ b/translations/gl.po
@@ -677,8 +677,8 @@ msgstr "A_ctualizar"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
 msgstr[0] "%i Ligazón _inversa"
 msgstr[1] "%i Ligazóns _inversas"
 

--- a/translations/he.po
+++ b/translations/he.po
@@ -671,10 +671,10 @@ msgstr "_רענון"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i קישור מ_פנה אחד..."
-msgstr[1] "%i קישורים מ_פנים..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i קישור מ_פנה אחד"
+msgstr[1] "%i קישורים מ_פנים"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/hu.po
+++ b/translations/hu.po
@@ -695,10 +695,10 @@ msgstr "_Frissítés"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _visszacsatolás..."
-msgstr[1] "%i _visszacsatolás..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _visszacsatolás"
+msgstr[1] "%i _visszacsatolás"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/it.po
+++ b/translations/it.po
@@ -692,10 +692,10 @@ msgstr "_Ricarica"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _link entranti..."
-msgstr[1] "%i _link entranti..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _link entranti"
+msgstr[1] "%i _link entranti"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -681,9 +681,9 @@ msgstr "再読み込み(_R)"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "逆リンク: %i (_B)..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "逆リンク: %i (_B)"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/ko.po
+++ b/translations/ko.po
@@ -680,9 +680,9 @@ msgstr "새로고침(_R)"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i 역링크(_B)..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i 역링크(_B)"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/nb.po
+++ b/translations/nb.po
@@ -673,8 +673,8 @@ msgstr "_Oppdatere"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
 msgstr[0] "%i _Link hit"
 msgstr[1] "%i_Linker hit"
 

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -690,10 +690,10 @@ msgstr "_Herladen"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _Verwijzing..."
-msgstr[1] "%i _Verwijzingen..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _Verwijzing"
+msgstr[1] "%i _Verwijzingen"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/pl.po
+++ b/translations/pl.po
@@ -674,8 +674,8 @@ msgstr "_Odśwież"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
 msgstr[0] "%i _Link zwrotny"
 msgstr[1] "%i _Linków zwrotnych"
 msgstr[2] "%i odnośniki do tej strony"

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -688,10 +688,10 @@ msgstr "_Recarregar"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _Ligação de Entrada..."
-msgstr[1] "%i _Ligações de Entrada..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _Ligação de Entrada"
+msgstr[1] "%i _Ligações de Entrada"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/pt_BR.po
+++ b/translations/pt_BR.po
@@ -688,10 +688,10 @@ msgstr "_Recarregar"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _Link de Entrada..."
-msgstr[1] "%i _Links de entrada..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _Link de Entrada"
+msgstr[1] "%i _Links de entrada"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/ro.po
+++ b/translations/ro.po
@@ -677,8 +677,8 @@ msgstr "_Reîncarcă"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
 msgstr[0] "%i _Antelegătură"
 msgstr[1] "%i _Antelegături"
 msgstr[2] "%i de _Antelegături"

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -690,11 +690,11 @@ msgstr "_Обновить"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _Обратных ссылок…"
-msgstr[1] "%i _Обратная ссылка..."
-msgstr[2] "%i _Обратные ссылки…"
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _Обратных ссылок"
+msgstr[1] "%i _Обратная ссылка"
+msgstr[2] "%i _Обратные ссылки"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/sk.po
+++ b/translations/sk.po
@@ -666,8 +666,8 @@ msgstr "_Obnoviť"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/translations/sl.po
+++ b/translations/sl.po
@@ -676,12 +676,12 @@ msgstr "_Znova naloži"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i_Povratnih povezav ..."
-msgstr[1] "%i_Povratna povezava ..."
-msgstr[2] "%i_Povratni povezavi ..."
-msgstr[3] "%i_Povratne povezave ..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i_Povratnih povezav"
+msgstr[1] "%i_Povratna povezava"
+msgstr[2] "%i_Povratni povezavi"
+msgstr[3] "%i_Povratne povezave"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/sr.po
+++ b/translations/sr.po
@@ -672,11 +672,11 @@ msgstr "_Поново учитај"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _Повратна веза..."
-msgstr[1] "%i _Повратне везе..."
-msgstr[2] "%i _Повратних веза..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _Повратна веза"
+msgstr[1] "%i _Повратне везе"
+msgstr[2] "%i _Повратних веза"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -675,10 +675,10 @@ msgstr "_Läs om"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _bakåtlänk..."
-msgstr[1] "%i _bakåtlänkar..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _bakåtlänk"
+msgstr[1] "%i _bakåtlänkar"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/tr.po
+++ b/translations/tr.po
@@ -685,10 +685,10 @@ msgstr "_Yenile"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i_Geri bağlantı..."
-msgstr[1] "%i_Geri bağlantı..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i_Geri bağlantı"
+msgstr[1] "%i_Geri bağlantı"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -673,11 +673,11 @@ msgstr "_Перезавантажити"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i _Зворотнє посилання..."
-msgstr[1] "%i _Зворотні посилання..."
-msgstr[2] "%i _Зворотніх посилань..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i _Зворотнє посилання"
+msgstr[1] "%i _Зворотні посилання"
+msgstr[2] "%i _Зворотніх посилань"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/zh_CN.po
+++ b/translations/zh_CN.po
@@ -678,9 +678,9 @@ msgstr "重新载入(_R)"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i 个反向链接..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i 个反向链接"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/zh_TW.po
+++ b/translations/zh_TW.po
@@ -664,9 +664,9 @@ msgstr "重新載入(_R)"
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
-msgstr[0] "%i 個反向鏈結(_B)..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
+msgstr[0] "%i 個反向鏈結(_B)"
 
 #. Dialog title
 #: zim/gui/mainwindow.py:976

--- a/translations/zim.pot
+++ b/translations/zim.pot
@@ -661,8 +661,8 @@ msgstr ""
 #. Label for button with backlinks in statusbar
 #: zim/gui/mainwindow.py:922
 #, python-format
-msgid "%i _Backlink..."
-msgid_plural "%i _Backlinks..."
+msgid "%i _Backlink"
+msgid_plural "%i _Backlinks"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/zim/gui/mainwindow.py
+++ b/zim/gui/mainwindow.py
@@ -232,10 +232,11 @@ class MainWindow(Window):
 		self.statusbar.push(0, '<page>')
 		self.add_bar(self.statusbar, start=False)
 		self.statusbar.set_property('margin', 0)
+		self.statusbar.set_property('spacing', 0)
 
 		def statusbar_element(string, size):
 			frame = Gtk.Frame()
-			frame.set_shadow_type(Gtk.ShadowType.IN)
+			frame.set_shadow_type(Gtk.ShadowType.NONE)
 			self.statusbar.pack_end(frame, False, True, 0)
 			label = Gtk.Label(label=string)
 			label.set_size_request(size, 10)
@@ -244,15 +245,17 @@ class MainWindow(Window):
 			return label
 
 		# specify statusbar elements right-to-left
-		self.statusbar_style_label = statusbar_element('<style>', 100)
 		self.statusbar_insert_label = statusbar_element('INS', 60)
+		self.statusbar_style_label = statusbar_element('<style>', 100)
 
 		# and build the widget for backlinks
 		self.statusbar_backlinks_button = \
 			BackLinksMenuButton(self.notebook, self.open_page, status_bar_style=True)
 		frame = Gtk.Frame()
-		frame.set_shadow_type(Gtk.ShadowType.IN)
+		frame.set_shadow_type(Gtk.ShadowType.NONE)
+		self.statusbar.pack_end(Gtk.Separator(), False, True, 0)
 		self.statusbar.pack_end(frame, False, True, 0)
+		self.statusbar.pack_end(Gtk.Separator(), False, True, 0)
 		frame.add(self.statusbar_backlinks_button)
 
 		self.move_bottom_minimized_tabs_to_statusbar(self.statusbar)
@@ -919,7 +922,7 @@ class BackLinksMenuButton(MenuButton):
 			n = 0
 
 		self.label.set_text_with_mnemonic(
-			ngettext('%i _Backlink...', '%i _Backlinks...', n) % n)
+			ngettext('%i _Backlink', '%i _Backlinks', n) % n)
 			# T: Label for button with backlinks in statusbar
 		self.set_sensitive(n > 0)
 

--- a/zim/gui/widgets.py
+++ b/zim/gui/widgets.py
@@ -747,7 +747,11 @@ def widget_set_css(widget, name, css):
 
 def button_set_statusbar_style(button):
 	# Set up a style for the statusbar variant to decrease spacing of the button
-	widget_set_css(button, 'zim-statusbar-button', 'padding: 0px')
+	widget_set_css(button, 'zim-statusbar-button',	'''
+													border: none;
+													border-radius: 0px; 
+													padding: 0px 8px 0px 8px; 
+													''')
 	button.set_relief(Gtk.ReliefStyle.NONE)
 
 
@@ -782,12 +786,11 @@ class MenuButton(Gtk.HBox):
 		self.button = Gtk.ToggleButton()
 		if status_bar_style:
 			button_set_statusbar_style(self.button)
-			widget = self.label
-		else:
-			arrow = Gtk.Arrow(Gtk.ArrowType.UP, Gtk.ShadowType.NONE)
-			widget = Gtk.HBox(spacing=3)
-			widget.pack_start(self.label, False, True, 0)
-			widget.pack_start(arrow, False, True, 0)
+
+		arrow = Gtk.Arrow(Gtk.ArrowType.UP, Gtk.ShadowType.NONE)
+		widget = Gtk.HBox(spacing=3)
+		widget.pack_start(self.label, False, True, 0)
+		widget.pack_start(arrow, False, True, 0)
 
 
 		self.button.add(widget)
@@ -829,11 +832,13 @@ class MenuButton(Gtk.HBox):
 		self.button.handler_unblock(self._clicked_signal)
 		self.menu.connect('deactivate', self._deactivate_menu)
 		self.menu.show_all()
+		self.menu.set_property('rect_anchor_dx', -1) # This is needed to line up menu with borderless button 
 		self.menu.popup_at_widget(self, Gdk.Gravity.NORTH_WEST, Gdk.Gravity.SOUTH_WEST, event)
 
 	def _deactivate_menu(self, menu):
 		self.button.handler_block(self._clicked_signal)
 		self.button.set_active(False)
+		self.button.unset_state_flags(Gtk.StateFlags.PRELIGHT)
 		self.button.handler_unblock(self._clicked_signal)
 
 
@@ -2220,6 +2225,8 @@ class MinimizedTabs(object):
 			button.connect('clicked', self._on_click, child.tab_key)
 			if self._angle != 0:
 				button.get_child().set_angle(self._angle)
+			else:
+				self.pack_start(Gtk.Separator(), False, True, 0)
 			self.pack_start(button, False, True, 0)
 			button.show_all()
 
@@ -2236,7 +2243,7 @@ class HMinimizedTabs(Gtk.HBox, MinimizedTabs):
 
 	def __init__(self, sidepane, angle=0):
 		GObject.GObject.__init__(self)
-		self.set_spacing(12)
+		self.set_spacing(0)
 		MinimizedTabs.__init__(self, sidepane, angle)
 
 
@@ -2475,7 +2482,7 @@ class Window(Gtk.Window):
 
 	def move_bottom_minimized_tabs_to_statusbar(self, statusbar):
 		frame = Gtk.Frame()
-		frame.set_shadow_type(Gtk.ShadowType.IN)
+		frame.set_shadow_type(Gtk.ShadowType.NONE)
 		self._zim_window_bottom_minimized.reparent(frame)
 		self._zim_window_bottom_minimized.status_bar_style = True
 		statusbar.pack_end(frame, False, True, 0)


### PR DESCRIPTION
- Gtk.Frames in statusbar are no longer inset. 
- Statusbar buttons are now CSS styled to have no borders. 
- Three dots are removed from Backlinks label in favor of an arrow by default.
- Style indicator and INS/OVR indicator switched places.

Fixes #618.

This is my first proper pull request, so I probably messed some things up :-)

| Old  |
| ----- |
| ![Old](https://user-images.githubusercontent.com/36744029/63468289-9071af80-c478-11e9-9490-4a4c7f074754.png)|

| New |
| ----- |
|![New](https://user-images.githubusercontent.com/36744029/63468337-b1d29b80-c478-11e9-892f-5eabc3143d1c.png)|
