### PR TITLE
Documentation: more details and examples on how to customize Zim's appearence in GTK3

### DIFF
--- a/data/manual/Help/Config_Files.txt
+++ b/data/manual/Help/Config_Files.txt
@@ -144,7 +144,35 @@ Specific ones are:
 
 More names are documented in the manual page of specific plugins.
 
-To identify these in the code, search for use of ''widget_set_css(...)'' and ''widget.set_name(...)''. The name used will be accessible from the CSS config as an "id"
+To identify these in the code, search for use of ''widget_set_css(...)'' and ''widget.set_name(...)''. The name used will be accessible from the CSS config as an "id".
+
+Another way to identify CSS selector IDs is to use GTK Inspector, which can be invoked when calling Zim from the command line as follows: 
+
+'''
+GTK_DEBUG=interactive zim
+'''
+
+==== CSS configuration examples ====
+The following snippets that can be used directly in ''~/.config/gtk-3.0/gtk.css''
+
+'''
+#zim-pageview text {
+    background-color: #1A2E38;  /* changes the background color of the Zim's page editor */
+    color: #BABABA; /* foreground text color */
+  }
+
+#zim-toc-widget {
+  color: #2b2b2b;  /* sets the color of the border line of the Table of Content plugin */
+  opacity: 0.9;    /* give the ToC some nice transparency */
+  font-size: 12px; /* ToC font size */
+  }
+
+#zim-toc-widget scrolledwindow treeview {
+  color: #BABABA;  /* sets the color of the text within the Table of Content plugin */
+  opacity: 1;
+  }
+'''
+
 
 
 ===== Notebook config file =====


### PR DESCRIPTION
Included specific and working CSS examples (for ~/.config/gtk-3.0/gtk.css)
