### PR TITLE
Evaluate TEXTDOMAINDIR to set locale directory

### DIFF
--- a/zim/__init__.py
+++ b/zim/__init__.py
@@ -165,8 +165,15 @@ try:
 		# We are running from a source dir - use the locale data included there
 		gettext.install('zim', _localedir, names=('_', 'gettext', 'ngettext'))
 	else:
-		# Hope the system knows where to find the data
-		gettext.install('zim', None, names=('_', 'gettext', 'ngettext'))
+		if os.getenv("TEXTDOMAINDIR"):
+			# TEXTDOMAINDIR is actually an official environment variable with
+			# gettext, but there's a catch: it's not being evaluated by the library
+			# itself, only by gettext's CLI tools. So we're repurposing a familiar
+			# name here instead of creating a variable name of our own.
+			gettext.install('zim', os.getenv("TEXTDOMAINDIR"), names=('_', 'gettext', 'ngettext'))
+		else:
+			# Hope the system knows where to find the data.
+			gettext.install('zim', None, names=('_', 'gettext', 'ngettext'))
 except:
 	logger.exception('Error loading translation')
 	trans = gettext.NullTranslations()


### PR DESCRIPTION
Allow an environment variable named `TEXTDOMAINDIR` to set the locale directory if we're not running inside the source directory. This allows the macOS application bundle to set the locale directory to a location inside the bundle itself.

Full disclosure: I've read the contribution guidelines and I admit I have not written nor am I planning to write a test for this. (My plan is to familiarize myself with that at a later date.) If this disqualifies this PR from being merged, that'll be on me.