### PR TITLE
Updated translation skeleton (xgettext.sh)

### DIFF
--- a/translations/zim.pot
+++ b/translations/zim.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-09 20:40+0200\n"
+"POT-Creation-Date: 2020-04-11 12:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,13 +19,13 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #. Error message when external application failed, %s is the command
-#: zim/applications.py:87
+#: zim/applications.py:85
 #, python-format
 msgid "Failed to run application: %s"
 msgstr ""
 
 #. Error message when external application failed, %(cmd)s is the command, %(code)i the exit code
-#: zim/applications.py:90
+#: zim/applications.py:88
 #, python-format
 msgid ""
 "%(cmd)s\n"
@@ -33,19 +33,19 @@ msgid ""
 msgstr ""
 
 #. error when application failed to start
-#: zim/applications.py:365
+#: zim/applications.py:361
 #, python-format
 msgid "Failed running: %s"
 msgstr ""
 
 #. label for default webbrowser | 
 #. label for default application
-#: zim/applications.py:386 zim/applications.py:429 zim/gui/applications.py:1013
+#: zim/applications.py:382 zim/applications.py:425 zim/gui/applications.py:1013
 msgid "Default"
 msgstr ""
 
 #. Translate to "calendar:week_start:0" if you want Sunday to be the first day of the week or to "calendar:week_start:1" if you want Monday to be the first day of the week
-#: zim/datetimetz.py:95
+#: zim/datetimetz.py:98
 msgid "calendar:week_start:0"
 msgstr ""
 
@@ -92,7 +92,7 @@ msgid "File changed on disk: %s"
 msgstr ""
 
 #. Heading in a question dialog for creating a folder
-#: zim/gui/applications.py:500 zim/gui/pageview.py:6414
+#: zim/gui/applications.py:500 zim/gui/pageview.py:6429
 msgid "Create folder?"
 msgstr ""
 
@@ -179,10 +179,10 @@ msgstr ""
 #. Input label in the 'rename page' dialog for the new name | 
 #. label for file name
 #: zim/gui/applications.py:1129 zim/gui/customtools.py:651
-#: zim/gui/notebookdialog.py:421 zim/gui/pageview.py:7587
-#: zim/gui/preferencesdialog.py:279 zim/gui/propertiesdialog.py:16
+#: zim/gui/notebookdialog.py:421 zim/gui/pageview.py:7599
+#: zim/gui/preferencesdialog.py:299 zim/gui/propertiesdialog.py:16
 #: zim/gui/templateeditordialog.py:158 zim/gui/uiactions.py:603
-#: zim/plugins/attachmentbrowser/filebrowser.py:377
+#: zim/plugins/attachmentbrowser/filebrowser.py:388
 msgid "Name"
 msgstr ""
 
@@ -222,7 +222,7 @@ msgstr ""
 
 #. Input in "Edit Custom Tool" dialog | 
 #. Heading in plugins tab of preferences dialog
-#: zim/gui/customtools.py:652 zim/gui/preferencesdialog.py:281
+#: zim/gui/customtools.py:652 zim/gui/preferencesdialog.py:301
 msgid "Description"
 msgstr ""
 
@@ -321,10 +321,10 @@ msgstr ""
 #. Column header search dialog | 
 #. Column header Task List dialog | 
 #. page label
-#: zim/gui/exportdialog.py:181 zim/gui/pageview.py:7472
+#: zim/gui/exportdialog.py:181 zim/gui/pageview.py:7484
 #: zim/gui/recentchangesdialog.py:59 zim/gui/searchdialog.py:146
-#: zim/plugins/quicknote.py:247 zim/plugins/tasklist/gui.py:493
-#: zim/plugins/tasklist/gui.py:799
+#: zim/plugins/quicknote.py:247 zim/plugins/tasklist/gui.py:495
+#: zim/plugins/tasklist/gui.py:801
 msgid "Page"
 msgstr ""
 
@@ -345,7 +345,7 @@ msgstr ""
 
 #. Input label in the export dialog | 
 #. label in "insert date" dialog
-#: zim/gui/exportdialog.py:223 zim/gui/pageview.py:6709
+#: zim/gui/exportdialog.py:223 zim/gui/pageview.py:6721
 msgid "Format"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgstr ""
 
 #. Menu title | 
 #. Button label
-#: zim/gui/mainwindow.py:50 zim/gui/pageview.py:6746
+#: zim/gui/mainwindow.py:50 zim/gui/pageview.py:6758
 #: zim/gui/templateeditordialog.py:49 zim/plugins/insertsymbol.py:155
 msgid "_Edit"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 
 #. Menu title | 
 #. Button label
-#: zim/gui/mainwindow.py:52 zim/gui/pageview.py:6696
+#: zim/gui/mainwindow.py:52 zim/gui/pageview.py:6708
 #: zim/plugins/insertsymbol.py:131
 msgid "_Insert"
 msgstr ""
@@ -502,13 +502,13 @@ msgstr ""
 
 #. Menu title | 
 #. Button label
-#: zim/gui/mainwindow.py:57 zim/gui/widgets.py:2868
+#: zim/gui/mainwindow.py:57 zim/gui/widgets.py:2885
 msgid "_Help"
 msgstr ""
 
 #. Menu title | 
 #. Menu item
-#: zim/gui/mainwindow.py:58 zim/gui/mainwindow.py:425
+#: zim/gui/mainwindow.py:58 zim/gui/mainwindow.py:428
 msgid "_Toolbar"
 msgstr ""
 
@@ -535,131 +535,131 @@ msgstr ""
 
 #. Menu item | 
 #. Button label
-#: zim/gui/mainwindow.py:334 zim/gui/widgets.py:2832
+#: zim/gui/mainwindow.py:337 zim/gui/widgets.py:2849
 msgid "_Close"
 msgstr ""
 
 #. page status in statusbar
-#: zim/gui/mainwindow.py:370
+#: zim/gui/mainwindow.py:373
 msgid "readonly"
 msgstr ""
 
 #. label for View->Menubar menu item
-#: zim/gui/mainwindow.py:412
+#: zim/gui/mainwindow.py:415
 msgid "Menubar"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:442
+#: zim/gui/mainwindow.py:445
 msgid "_Statusbar"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:454
+#: zim/gui/mainwindow.py:457
 msgid "_Fullscreen"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:472
+#: zim/gui/mainwindow.py:475
 msgid "_Side Panes"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:522
+#: zim/gui/mainwindow.py:525
 msgid "Icons _And Text"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:523
+#: zim/gui/mainwindow.py:526
 msgid "_Icons Only"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:524
+#: zim/gui/mainwindow.py:527
 msgid "_Text Only"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:546
+#: zim/gui/mainwindow.py:549
 msgid "_Large Icons"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:547
+#: zim/gui/mainwindow.py:550
 msgid "_Small Icons"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:548
+#: zim/gui/mainwindow.py:551
 msgid "_Tiny Icons"
 msgstr ""
 
 #. menu item
-#: zim/gui/mainwindow.py:568
+#: zim/gui/mainwindow.py:571
 msgid "Notebook _Editable"
 msgstr ""
 
 #. Dialog title | 
 #. input label
-#: zim/gui/mainwindow.py:656 zim/gui/searchdialog.py:25
+#: zim/gui/mainwindow.py:659 zim/gui/searchdialog.py:25
 #: zim/gui/searchdialog.py:33
 msgid "Search"
 msgstr ""
 
 #. label in search entry
-#: zim/gui/mainwindow.py:659
+#: zim/gui/mainwindow.py:662
 msgid "Search Pages..."
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:817
+#: zim/gui/mainwindow.py:826
 msgid "_Jump To..."
 msgstr ""
 
 #. Menu item | 
 #. Button label
-#: zim/gui/mainwindow.py:822 zim/gui/widgets.py:3742
+#: zim/gui/mainwindow.py:831 zim/gui/widgets.py:3762
 msgid "_Back"
 msgstr ""
 
 #. Menu item | 
 #. Button label
-#: zim/gui/mainwindow.py:834 zim/gui/widgets.py:3746
+#: zim/gui/mainwindow.py:843 zim/gui/widgets.py:3766
 msgid "_Forward"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:845
+#: zim/gui/mainwindow.py:854
 msgid "_Parent"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:854
+#: zim/gui/mainwindow.py:863
 msgid "_Child"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:870
+#: zim/gui/mainwindow.py:879
 msgid "_Previous in index"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:879
+#: zim/gui/mainwindow.py:888
 msgid "_Next in index"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:888
+#: zim/gui/mainwindow.py:897
 msgid "_Home"
 msgstr ""
 
 #. Menu item
-#: zim/gui/mainwindow.py:893
+#: zim/gui/mainwindow.py:902
 msgid "_Reload"
 msgstr ""
 
 #. Label for button with backlinks in statusbar
-#: zim/gui/mainwindow.py:922
+#: zim/gui/mainwindow.py:931
 #, python-format
 msgid "%i _Backlink"
 msgid_plural "%i _Backlinks"
@@ -667,17 +667,17 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Dialog title
-#: zim/gui/mainwindow.py:976
+#: zim/gui/mainwindow.py:991
 msgid "Jump to"
 msgstr ""
 
 #. Button label
-#: zim/gui/mainwindow.py:977
+#: zim/gui/mainwindow.py:992
 msgid "_Jump"
 msgstr ""
 
 #. Label for page input
-#: zim/gui/mainwindow.py:982
+#: zim/gui/mainwindow.py:997
 msgid "Jump to Page"
 msgstr ""
 
@@ -911,13 +911,13 @@ msgid "Folder with templates for attachment files"
 msgstr ""
 
 #. Heading of error dialog
-#: zim/gui/pageview.py:4873
+#: zim/gui/pageview.py:4888
 #, python-format
 msgid "Could not save page: %s"
 msgstr ""
 
 #. text in error dialog when saving page failed
-#: zim/gui/pageview.py:4877
+#: zim/gui/pageview.py:4892
 msgid ""
 "To continue you can save a copy of this page or discard\n"
 "any changes. If you save a copy changes will be also\n"
@@ -925,77 +925,77 @@ msgid ""
 msgstr ""
 
 #. Button label
-#: zim/gui/pageview.py:4896 zim/gui/searchdialog.py:42 zim/gui/uiactions.py:858
+#: zim/gui/pageview.py:4911 zim/gui/searchdialog.py:42 zim/gui/uiactions.py:860
 #: zim/gui/widgets.py:84
 msgid "_Cancel"
 msgstr ""
 
 #. Button in error dialog
-#: zim/gui/pageview.py:4901
+#: zim/gui/pageview.py:4916
 msgid "_Discard Changes"
 msgstr ""
 
 #. Button in error dialog
-#: zim/gui/pageview.py:4906
+#: zim/gui/pageview.py:4921
 msgid "_Save Copy"
 msgstr ""
 
 #. error when unknown interwiki link is clicked
-#: zim/gui/pageview.py:5792
+#: zim/gui/pageview.py:5807
 #, python-format
 msgid "No such wiki defined: %s"
 msgstr ""
 
 #. menu item for context menu of editor
-#: zim/gui/pageview.py:5885
+#: zim/gui/pageview.py:5900
 msgid "Copy _As..."
 msgstr ""
 
 #. Context menu item for pageview to move selected text to new/other page
-#: zim/gui/pageview.py:5892
+#: zim/gui/pageview.py:5907
 msgid "Move Selected Text..."
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:5940 zim/gui/pageview.py:6172
+#: zim/gui/pageview.py:5955 zim/gui/pageview.py:6187
 msgid "_Remove Link"
 msgstr ""
 
 #. menu item in context menu for image
-#: zim/gui/pageview.py:5947
+#: zim/gui/pageview.py:5962
 msgid "_Edit Properties"
 msgstr ""
 
 #. menu item in context menu
-#: zim/gui/pageview.py:5949
+#: zim/gui/pageview.py:5964
 msgid "_Edit Link"
 msgstr ""
 
 #. context menu item
-#: zim/gui/pageview.py:5969 zim/gui/pageview.py:5975 zim/gui/pageview.py:5982
+#: zim/gui/pageview.py:5984 zim/gui/pageview.py:5990 zim/gui/pageview.py:5997
 msgid "Copy _Link"
 msgstr ""
 
 #. context menu item
-#: zim/gui/pageview.py:5979
+#: zim/gui/pageview.py:5994
 msgid "Copy Email Address"
 msgstr ""
 
 #. menu item to open containing folder of files
-#: zim/gui/pageview.py:5990
+#: zim/gui/pageview.py:6005
 msgid "Open Folder"
 msgstr ""
 
 #. menu item for sub menu with applications | 
 #. menu item
-#: zim/gui/pageview.py:5999 zim/gui/pageview.py:6010
-#: zim/plugins/attachmentbrowser/filebrowser.py:336
+#: zim/gui/pageview.py:6014 zim/gui/pageview.py:6025
+#: zim/plugins/attachmentbrowser/filebrowser.py:347
 msgid "Open With..."
 msgstr ""
 
 #. menu item to open a link | 
 #. Menu item
-#: zim/gui/pageview.py:6020 zim/gui/uiactions.py:143
+#: zim/gui/pageview.py:6035 zim/gui/uiactions.py:143
 #: zim/plugins/backlinkpane.py:105
 msgid "Open in New _Window"
 msgstr ""
@@ -1003,148 +1003,148 @@ msgstr ""
 #. menu item to open a link or file | 
 #. Button label | 
 #. menu item to open file or folder
-#: zim/gui/pageview.py:6030 zim/gui/widgets.py:3420
-#: zim/plugins/attachmentbrowser/filebrowser.py:343
+#: zim/gui/pageview.py:6045 zim/gui/widgets.py:3440
+#: zim/plugins/attachmentbrowser/filebrowser.py:354
 msgid "_Open"
 msgstr ""
 
 #. popup menu menuitem
-#: zim/gui/pageview.py:6047
+#: zim/gui/pageview.py:6062
 msgid "Check Checkbox '>'"
 msgstr ""
 
 #. popup menu menuitem
-#: zim/gui/pageview.py:6048
+#: zim/gui/pageview.py:6063
 msgid "Check Checkbox 'X'"
 msgstr ""
 
 #. popup menu menuitem
-#: zim/gui/pageview.py:6049
+#: zim/gui/pageview.py:6064
 msgid "Check Checkbox 'V'"
 msgstr ""
 
 #. popup menu menuitem | 
 #. Menu item
-#: zim/gui/pageview.py:6050 zim/gui/pageview.py:6101
+#: zim/gui/pageview.py:6065 zim/gui/pageview.py:6116
 msgid "Un-check Checkbox"
 msgstr ""
 
 #. Menu item | 
 #. Button label | 
 #. button label
-#: zim/gui/pageview.py:6059 zim/gui/widgets.py:3422
+#: zim/gui/pageview.py:6074 zim/gui/widgets.py:3442
 #: zim/plugins/versioncontrol/__init__.py:756
 msgid "_Save"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6069
+#: zim/gui/pageview.py:6084
 msgid "_Undo"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6075
+#: zim/gui/pageview.py:6090
 msgid "_Redo"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6081
+#: zim/gui/pageview.py:6096
 msgid "Cu_t"
 msgstr ""
 
 #. Menu item | 
 #. Button label | 
 #. menu label
-#: zim/gui/pageview.py:6086 zim/gui/templateeditordialog.py:46
-#: zim/plugins/tasklist/gui.py:771
+#: zim/gui/pageview.py:6101 zim/gui/templateeditordialog.py:46
+#: zim/plugins/tasklist/gui.py:773
 msgid "_Copy"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6091
+#: zim/gui/pageview.py:6106
 msgid "_Paste"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6096
+#: zim/gui/pageview.py:6111
 msgid "_Delete"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6107
+#: zim/gui/pageview.py:6122
 msgid "Toggle Checkbox 'V'"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6116
+#: zim/gui/pageview.py:6131
 msgid "Toggle Checkbox 'X'"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6125
+#: zim/gui/pageview.py:6140
 msgid "Toggle Checkbox '>'"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6134
+#: zim/gui/pageview.py:6149
 msgid "_Edit Link or Object..."
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6190
+#: zim/gui/pageview.py:6205
 msgid "_Date and Time..."
 msgstr ""
 
 #. Menu item for Insert menu
-#: zim/gui/pageview.py:6205
+#: zim/gui/pageview.py:6220
 msgid "Horizontal _Line"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6217
+#: zim/gui/pageview.py:6232
 msgid "_Image..."
 msgstr ""
 
 #. Menu item | 
 #. Menu item,
-#: zim/gui/pageview.py:6234 zim/gui/pageview.py:6261
+#: zim/gui/pageview.py:6249 zim/gui/pageview.py:6276
 msgid "Bulle_t List"
 msgstr ""
 
 #. Menu item | 
 #. Menu item,
-#: zim/gui/pageview.py:6239 zim/gui/pageview.py:6266
+#: zim/gui/pageview.py:6254 zim/gui/pageview.py:6281
 msgid "_Numbered List"
 msgstr ""
 
 #. Menu item | 
 #. Menu item,
-#: zim/gui/pageview.py:6244 zim/gui/pageview.py:6271
+#: zim/gui/pageview.py:6259 zim/gui/pageview.py:6286
 msgid "Checkbo_x List"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6280
+#: zim/gui/pageview.py:6295
 msgid "Text From _File..."
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6324
+#: zim/gui/pageview.py:6339
 msgid "_Link..."
 msgstr ""
 
 #. message when no file templates are found in ~/Templates
-#: zim/gui/pageview.py:6353
+#: zim/gui/pageview.py:6368
 msgid "No templates installed"
 msgstr ""
 
 #. Menu item in "Insert > New File Attachment" submenu
-#: zim/gui/pageview.py:6402
+#: zim/gui/pageview.py:6417
 msgid "File _Templates..."
 msgstr ""
 
 #. Text in a question dialog for creating a folder, %s is the folder path
-#: zim/gui/pageview.py:6416
+#: zim/gui/pageview.py:6431
 #, python-format
 msgid ""
 "The folder\n"
@@ -1154,390 +1154,423 @@ msgid ""
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6425
+#: zim/gui/pageview.py:6440
 msgid "_Clear Formatting"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6530
+#: zim/gui/pageview.py:6542
 msgid "_Find..."
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6551
+#: zim/gui/pageview.py:6563
 msgid "Find Ne_xt"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6557
+#: zim/gui/pageview.py:6569
 msgid "Find Pre_vious"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6563
+#: zim/gui/pageview.py:6575
 msgid "_Replace..."
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6570
+#: zim/gui/pageview.py:6582
 msgid "Word Count..."
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6575
+#: zim/gui/pageview.py:6587
 msgid "_Zoom In"
 msgstr ""
 
 #. Menu item
-#: zim/gui/pageview.py:6580
+#: zim/gui/pageview.py:6592
 msgid "Zoom _Out"
 msgstr ""
 
 #. Menu item to reset zoom
-#: zim/gui/pageview.py:6608
+#: zim/gui/pageview.py:6620
 msgid "_Normal Size"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/pageview.py:6695
+#: zim/gui/pageview.py:6707
 msgid "Insert Date and Time"
 msgstr ""
 
 #. expander label in "insert date" dialog
-#: zim/gui/pageview.py:6727
+#: zim/gui/pageview.py:6739
 msgid "_Calendar"
 msgstr ""
 
 #. check box in InsertDate dialog
-#: zim/gui/pageview.py:6741
+#: zim/gui/pageview.py:6753
 msgid "_Link to date"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/pageview.py:6835
+#: zim/gui/pageview.py:6847
 msgid "Insert Image"
 msgstr ""
 
 #. checkbox in the "Insert Image" dialog
-#: zim/gui/pageview.py:6848
+#: zim/gui/pageview.py:6860
 msgid "Attach image first"
 msgstr ""
 
 #. Error message when trying to insert a not supported file as image
-#: zim/gui/pageview.py:6864
+#: zim/gui/pageview.py:6876
 #, python-format
 msgid "File type not supported: %s"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/pageview.py:6889 zim/gui/uiactions.py:773
+#: zim/gui/pageview.py:6901 zim/gui/uiactions.py:775
 msgid "Attach File"
 msgstr ""
 
 #. Error dialog - %s is the full page name
-#: zim/gui/pageview.py:6899 zim/gui/uiactions.py:782
+#: zim/gui/pageview.py:6911 zim/gui/uiactions.py:784
 #, python-format
 msgid "Page \"%s\" does not have a folder for attachments"
 msgstr ""
 
 #. checkbox in the "Attach File" dialog
-#: zim/gui/pageview.py:6904
+#: zim/gui/pageview.py:6916
 msgid "Insert images as link"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/pageview.py:6925
+#: zim/gui/pageview.py:6937
 msgid "Edit Image"
 msgstr ""
 
 #. Input in 'edit image' dialog
-#: zim/gui/pageview.py:6945
+#: zim/gui/pageview.py:6957
 msgid "Location"
 msgstr ""
 
 #. Input in 'edit image' dialog | 
 #. Input in 'insert link' dialog
-#: zim/gui/pageview.py:6946 zim/gui/pageview.py:7088
+#: zim/gui/pageview.py:6958 zim/gui/pageview.py:7100
 msgid "Link to"
 msgstr ""
 
 #. Input in 'edit image' dialog
-#: zim/gui/pageview.py:6947
+#: zim/gui/pageview.py:6959
 msgid "Width"
 msgstr ""
 
 #. Input in 'edit image' dialog
-#: zim/gui/pageview.py:6948
+#: zim/gui/pageview.py:6960
 msgid "Height"
 msgstr ""
 
 #. Button in 'edit image' dialog
-#: zim/gui/pageview.py:6956
+#: zim/gui/pageview.py:6968
 msgid "_Reset Size"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/pageview.py:7053
+#: zim/gui/pageview.py:7065
 msgid "Insert Text From File"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/pageview.py:7080
+#: zim/gui/pageview.py:7092
 msgid "Edit Link"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/pageview.py:7082
+#: zim/gui/pageview.py:7094
 msgid "Insert Link"
 msgstr ""
 
 #. Dialog button
-#: zim/gui/pageview.py:7084
+#: zim/gui/pageview.py:7096
 msgid "_Link"
 msgstr ""
 
 #. Input in 'insert link' dialog
-#: zim/gui/pageview.py:7089
+#: zim/gui/pageview.py:7101
 msgid "Text"
 msgstr ""
 
 #. button in find bar and find & replace dialog
-#: zim/gui/pageview.py:7192
+#: zim/gui/pageview.py:7204
 msgid "_Next"
 msgstr ""
 
 #. button in find bar and find & replace dialog
-#: zim/gui/pageview.py:7198
+#: zim/gui/pageview.py:7210
 msgid "_Previous"
 msgstr ""
 
 #. checkbox option in find bar and find & replace dialog
-#: zim/gui/pageview.py:7204
+#: zim/gui/pageview.py:7216
 msgid "Match _case"
 msgstr ""
 
 #. checkbox option in find bar and find & replace dialog
-#: zim/gui/pageview.py:7209
+#: zim/gui/pageview.py:7221
 msgid "Whole _word"
 msgstr ""
 
 #. checkbox option in find bar and find & replace dialog
-#: zim/gui/pageview.py:7214
+#: zim/gui/pageview.py:7226
 msgid "_Regular expression"
 msgstr ""
 
 #. checkbox option in find bar and find & replace dialog
-#: zim/gui/pageview.py:7219
+#: zim/gui/pageview.py:7231
 msgid "_Highlight"
 msgstr ""
 
 #. label for input in find bar on bottom of page
-#: zim/gui/pageview.py:7308
+#: zim/gui/pageview.py:7320
 msgid "Find"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/pageview.py:7354
+#: zim/gui/pageview.py:7366
 msgid "Find and Replace"
 msgstr ""
 
 #. input label in find & replace dialog
-#: zim/gui/pageview.py:7364
+#: zim/gui/pageview.py:7376
 msgid "Find what"
 msgstr ""
 
 #. input label in find & replace dialog
-#: zim/gui/pageview.py:7374
+#: zim/gui/pageview.py:7386
 msgid "Replace with"
 msgstr ""
 
 #. Button in search & replace dialog
-#: zim/gui/pageview.py:7388
+#: zim/gui/pageview.py:7400
 msgid "_Replace"
 msgstr ""
 
 #. Button in search & replace dialog
-#: zim/gui/pageview.py:7393
+#: zim/gui/pageview.py:7405
 msgid "Replace _All"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/pageview.py:7430
+#: zim/gui/pageview.py:7442
 msgid "Word Count"
 msgstr ""
 
 #. label in word count dialog
-#: zim/gui/pageview.py:7473
+#: zim/gui/pageview.py:7485
 msgid "Paragraph"
 msgstr ""
 
 #. label in word count dialog
-#: zim/gui/pageview.py:7474
+#: zim/gui/pageview.py:7486
 msgid "Selection"
 msgstr ""
 
 #. label in word count dialog
-#: zim/gui/pageview.py:7475
+#: zim/gui/pageview.py:7487
 msgid "Words"
 msgstr ""
 
 #. label in word count dialog
-#: zim/gui/pageview.py:7476
+#: zim/gui/pageview.py:7488
 msgid "Lines"
 msgstr ""
 
 #. label in word count dialog
-#: zim/gui/pageview.py:7477
+#: zim/gui/pageview.py:7489
 msgid "Characters"
 msgstr ""
 
 #. label in word count dialog
-#: zim/gui/pageview.py:7478
+#: zim/gui/pageview.py:7490
 msgid "Characters excluding spaces"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/pageview.py:7521
+#: zim/gui/pageview.py:7533
 msgid "Move Text to Other Page"
 msgstr ""
 
 #. Button label
-#: zim/gui/pageview.py:7522
+#: zim/gui/pageview.py:7534
 msgid "_Move"
 msgstr ""
 
 #. Input in 'move text' dialog
-#: zim/gui/pageview.py:7538
+#: zim/gui/pageview.py:7550
 msgid "Move text to"
 msgstr ""
 
 #. Input in 'move text' dialog
-#: zim/gui/pageview.py:7539
+#: zim/gui/pageview.py:7551
 msgid "Leave link to new page"
 msgstr ""
 
 #. Input in 'move text' dialog
-#: zim/gui/pageview.py:7540
+#: zim/gui/pageview.py:7552
 msgid "Open new page"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/pageview.py:7585
+#: zim/gui/pageview.py:7597
 msgid "New File"
 msgstr ""
 
 #. Tab in preferences dialog
-#: zim/gui/preferencesdialog.py:29
+#: zim/gui/preferencesdialog.py:31
 msgid "Interface"
 msgstr ""
 
 #. Tab in preferences dialog
-#: zim/gui/preferencesdialog.py:30
+#: zim/gui/preferencesdialog.py:32
 msgid "Editing"
 msgstr ""
 
+#: zim/gui/preferencesdialog.py:39
+#, python-format
+msgid ""
+"Your system encoding is set to %s, if you want support for special "
+"characters\n"
+"or see errors due to encoding, please ensure to configure your system to use "
+"\"UTF-8\""
+msgstr ""
+
 #. Dialog title
-#: zim/gui/preferencesdialog.py:36
+#: zim/gui/preferencesdialog.py:50
 msgid "Preferences"
 msgstr ""
 
 #. Heading in preferences dialog
-#: zim/gui/preferencesdialog.py:96
+#: zim/gui/preferencesdialog.py:111
+msgid "Key bindings"
+msgstr ""
+
+#. Heading in preferences dialog
+#: zim/gui/preferencesdialog.py:116
 msgid "Plugins"
 msgstr ""
 
 #. Heading in preferences dialog
-#: zim/gui/preferencesdialog.py:106
+#: zim/gui/preferencesdialog.py:126
 msgid "Applications"
 msgstr ""
 
 #. option in preferences dialog
-#: zim/gui/preferencesdialog.py:113
+#: zim/gui/preferencesdialog.py:133
 msgid "Use a custom font"
 msgstr ""
 
 #. Button in plugin tab
-#: zim/gui/preferencesdialog.py:224
+#: zim/gui/preferencesdialog.py:244
 msgid "_More"
 msgstr ""
 
 #. Button in plugin tab
-#: zim/gui/preferencesdialog.py:229
+#: zim/gui/preferencesdialog.py:249
 msgid "C_onfigure"
 msgstr ""
 
 #. button label
-#: zim/gui/preferencesdialog.py:244
+#: zim/gui/preferencesdialog.py:264
 msgid "Open plugins folder"
 msgstr ""
 
 #. label for button with URL
-#: zim/gui/preferencesdialog.py:253
+#: zim/gui/preferencesdialog.py:273
 msgid "Get more plugins online"
 msgstr ""
 
 #. Heading in plugins tab of preferences dialog
-#: zim/gui/preferencesdialog.py:283
+#: zim/gui/preferencesdialog.py:303
 msgid "Dependencies"
 msgstr ""
 
 #. label in plugin info in preferences dialog
-#: zim/gui/preferencesdialog.py:287
+#: zim/gui/preferencesdialog.py:307
 msgid "No dependencies"
 msgstr ""
 
 #. dependency is OK
-#: zim/gui/preferencesdialog.py:293
+#: zim/gui/preferencesdialog.py:313
 msgid "OK"
 msgstr ""
 
 #. dependency failed
-#: zim/gui/preferencesdialog.py:295 zim/gui/preferencesdialog.py:298
+#: zim/gui/preferencesdialog.py:315 zim/gui/preferencesdialog.py:318
 msgid "Failed"
 msgstr ""
 
 #. optional dependency
-#: zim/gui/preferencesdialog.py:299
+#: zim/gui/preferencesdialog.py:319
 msgid "Optional"
 msgstr ""
 
 #. Heading in plugins tab of preferences dialog | 
 #. Column header versions dialog
-#: zim/gui/preferencesdialog.py:303 zim/plugins/versioncontrol/__init__.py:1070
+#: zim/gui/preferencesdialog.py:323 zim/plugins/versioncontrol/__init__.py:1070
 msgid "Author"
 msgstr ""
 
 #. Column in plugin tab
-#: zim/gui/preferencesdialog.py:387
+#: zim/gui/preferencesdialog.py:407
 msgid "Enabled"
 msgstr ""
 
 #. Column in plugin tab
-#: zim/gui/preferencesdialog.py:390
+#: zim/gui/preferencesdialog.py:410
 msgid "Plugin"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/preferencesdialog.py:397
+#: zim/gui/preferencesdialog.py:417
 msgid "Configure Plugin"
 msgstr ""
 
 #. Heading for 'configure plugin' dialog - %s is the plugin name
-#: zim/gui/preferencesdialog.py:402
+#: zim/gui/preferencesdialog.py:422
 #, python-format
 msgid "Options for plugin %s"
 msgstr ""
 
 #. info text in the preferences dialog
-#: zim/gui/preferencesdialog.py:420
+#: zim/gui/preferencesdialog.py:440
 msgid ""
 "This plugin also has properties,\n"
 "see the notebook properties dialog"
 msgstr ""
 
 #. button in preferences dialog to change default text editor
-#: zim/gui/preferencesdialog.py:440
+#: zim/gui/preferencesdialog.py:460
 msgid "Set default text editor"
+msgstr ""
+
+#. help text in preferences dialog for modifying keybindings
+#: zim/gui/preferencesdialog.py:489
+msgid ""
+"Key bindings can be changed by selecting the action in the list and pressing "
+"the new key binding.\n"
+"To disable a keybinding, select it in the list and use <tt>&lt;Backspace&gt;"
+"</tt>."
+msgstr ""
+
+#. Column header for keybinding list
+#: zim/gui/preferencesdialog.py:507
+msgid "Action"
+msgstr ""
+
+#. Column header for keybinding list
+#: zim/gui/preferencesdialog.py:518
+msgid "Key Binding"
 msgstr ""
 
 #. label for properties dialog
@@ -1705,7 +1738,7 @@ msgid "_Delete Page"
 msgstr ""
 
 #. Title of progressbar dialog
-#: zim/gui/uiactions.py:230 zim/gui/uiactions.py:760
+#: zim/gui/uiactions.py:230 zim/gui/uiactions.py:762
 msgid "Removing Links"
 msgstr ""
 
@@ -1885,7 +1918,7 @@ msgid "Rename page \"%s\""
 msgstr ""
 
 #. label in MovePage dialog - %i is number of backlinks
-#: zim/gui/uiactions.py:597 zim/gui/uiactions.py:659
+#: zim/gui/uiactions.py:597 zim/gui/uiactions.py:661
 #, python-format
 msgid "Update %i page linking to this page"
 msgid_plural "Update %i pages linking to this page"
@@ -1898,7 +1931,7 @@ msgid "Update the heading of this page"
 msgstr ""
 
 #. label for progress dialog
-#: zim/gui/uiactions.py:634 zim/gui/uiactions.py:686
+#: zim/gui/uiactions.py:634 zim/gui/uiactions.py:688
 msgid "Updating Links"
 msgstr ""
 
@@ -1915,23 +1948,23 @@ msgstr ""
 
 #. Input label for the section to move a page to | 
 #. input label
-#: zim/gui/uiactions.py:664 zim/plugins/journal.py:121
+#: zim/gui/uiactions.py:666 zim/plugins/journal.py:121
 msgid "Section"
 msgstr ""
 
 #. Dialog title
-#: zim/gui/uiactions.py:699
+#: zim/gui/uiactions.py:701
 msgid "Delete Page"
 msgstr ""
 
 #. Heading in 'delete page' dialog - %s is the page name
-#: zim/gui/uiactions.py:714
+#: zim/gui/uiactions.py:716
 #, python-format
 msgid "Delete page \"%s\"?"
 msgstr ""
 
 #. Text in 'delete page' dialog - %s is the page name
-#: zim/gui/uiactions.py:716
+#: zim/gui/uiactions.py:718
 #, python-format
 msgid ""
 "Page \"%s\" and all of it's\n"
@@ -1939,7 +1972,7 @@ msgid ""
 msgstr ""
 
 #. label in the DeletePage dialog to warn user of attachments being deleted
-#: zim/gui/uiactions.py:730
+#: zim/gui/uiactions.py:732
 #, python-format
 msgid "%i file will be deleted"
 msgid_plural "%i files will be deleted"
@@ -1947,12 +1980,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Dialog title
-#: zim/gui/uiactions.py:830
+#: zim/gui/uiactions.py:832
 msgid "File Exists"
 msgstr ""
 
 #. Dialog text in 'new filename' dialog
-#: zim/gui/uiactions.py:831
+#: zim/gui/uiactions.py:833
 #, python-format
 msgid ""
 "A file with the name <b>\"%s\"</b> already exists.\n"
@@ -1960,120 +1993,120 @@ msgid ""
 msgstr ""
 
 #. Input label
-#: zim/gui/uiactions.py:840
+#: zim/gui/uiactions.py:842
 msgid "Filename"
 msgstr ""
 
 #. Button label
-#: zim/gui/uiactions.py:849 zim/gui/widgets.py:1054 zim/gui/widgets.py:1078
+#: zim/gui/uiactions.py:851 zim/gui/widgets.py:1069 zim/gui/widgets.py:1093
 msgid "_Browse"
 msgstr ""
 
 #. Button label
-#: zim/gui/uiactions.py:854
+#: zim/gui/uiactions.py:856
 msgid "Overwrite"
 msgstr ""
 
 #. Button label
-#: zim/gui/uiactions.py:859 zim/gui/widgets.py:85
+#: zim/gui/uiactions.py:861 zim/gui/widgets.py:85
 msgid "_OK"
 msgstr ""
 
 #. General description of zim itself
-#: zim/gui/uiactions.py:903
+#: zim/gui/uiactions.py:905
 msgid "A desktop wiki"
 msgstr ""
 
 #. This string needs to be translated with names of the translators for this language
-#: zim/gui/uiactions.py:911
+#: zim/gui/uiactions.py:913
 msgid "translator-credits"
 msgstr ""
 
 #. dialog title
-#: zim/gui/widgets.py:523 zim/gui/widgets.py:1600
+#: zim/gui/widgets.py:533 zim/gui/widgets.py:1615
 msgid "Select File"
 msgstr ""
 
 #. menu item in context menu
-#: zim/gui/widgets.py:651
+#: zim/gui/widgets.py:661
 msgid "Expand _All"
 msgstr ""
 
 #. menu item in context menu
-#: zim/gui/widgets.py:653
+#: zim/gui/widgets.py:663
 msgid "_Collapse All"
 msgstr ""
 
 #. tooltip for the inline icon to clear a text entry widget
-#: zim/gui/widgets.py:1456
+#: zim/gui/widgets.py:1471
 msgid "Clear"
 msgstr ""
 
 #. dialog title
-#: zim/gui/widgets.py:1596
+#: zim/gui/widgets.py:1611
 msgid "Select Folder"
 msgstr ""
 
 #. dialog title
-#: zim/gui/widgets.py:1598
+#: zim/gui/widgets.py:1613
 msgid "Select Image"
 msgstr ""
 
 #. default text for empty page section selection
-#: zim/gui/widgets.py:1728
+#: zim/gui/widgets.py:1743
 msgid "<Top>"
 msgstr ""
 
 #. Option for placement of plugin widgets
-#: zim/gui/widgets.py:2031
+#: zim/gui/widgets.py:2046
 msgid "Left Side Pane"
 msgstr ""
 
 #. Option for placement of plugin widgets
-#: zim/gui/widgets.py:2032
+#: zim/gui/widgets.py:2047
 msgid "Right Side Pane"
 msgstr ""
 
 #. Option for placement of plugin widgets
-#: zim/gui/widgets.py:2033
+#: zim/gui/widgets.py:2048
 msgid "Bottom Pane"
 msgstr ""
 
 #. Option for placement of plugin widgets
-#: zim/gui/widgets.py:2034
+#: zim/gui/widgets.py:2049
 msgid "Top Pane"
 msgstr ""
 
 #. Menu item
-#: zim/gui/widgets.py:2632
+#: zim/gui/widgets.py:2649
 msgid "_All Panes"
 msgstr ""
 
 #. generic error dialog text
-#: zim/gui/widgets.py:3171
+#: zim/gui/widgets.py:3191
 msgid ""
 "When reporting this bug please include\n"
 "the information from the text box below"
 msgstr ""
 
 #. Filter in open file dialog, shows all files (*)
-#: zim/gui/widgets.py:3553
+#: zim/gui/widgets.py:3573
 msgid "All Files"
 msgstr ""
 
 #. Filter in open file dialog, shows image files only
-#: zim/gui/widgets.py:3580
+#: zim/gui/widgets.py:3600
 msgid "Images"
 msgstr ""
 
 #. lable in progressbar giving number of items and total
-#: zim/gui/widgets.py:3676
+#: zim/gui/widgets.py:3696
 #, python-brace-format
 msgid "{count} of {total}"
 msgstr ""
 
 #. dialog title for log view dialog - e.g. for Equation Editor
-#: zim/gui/widgets.py:3698
+#: zim/gui/widgets.py:3718
 msgid "Log file"
 msgstr ""
 
@@ -2117,6 +2150,32 @@ msgstr ""
 #. error message for export
 #: zim/main/__init__.py:481
 msgid "Need output folder to export full notebook"
+msgstr ""
+
+#. Error explanation
+#: zim/newfs/local.py:43
+msgid ""
+"Cannot write this file. Probably this is due to the lenght\n"
+"of the file name, please try using a name with less\n"
+"than 255 characters"
+msgstr ""
+
+#: zim/newfs/local.py:49
+#, python-format
+msgid "File name too long: %s"
+msgstr ""
+
+#. Error explanation
+#: zim/newfs/local.py:53
+msgid ""
+"Cannot write this file. Probably this is due to the lenght\n"
+"of the file path, please try using a folder structure resulting in less\n"
+"than 4096 characters"
+msgstr ""
+
+#: zim/newfs/local.py:59
+#, python-format
+msgid "File path too long: %s"
 msgstr ""
 
 #. Title of progressbar dialog
@@ -2184,37 +2243,37 @@ msgid "_Arithmetic"
 msgstr ""
 
 #. unspecified value for file modification time
-#: zim/plugins/attachmentbrowser/filebrowser.py:365
+#: zim/plugins/attachmentbrowser/filebrowser.py:376
 msgid "Unknown"
 msgstr ""
 
 #. label for file type
-#: zim/plugins/attachmentbrowser/filebrowser.py:378
+#: zim/plugins/attachmentbrowser/filebrowser.py:389
 msgid "Type"
 msgstr ""
 
 #. label for file size
-#: zim/plugins/attachmentbrowser/filebrowser.py:379
+#: zim/plugins/attachmentbrowser/filebrowser.py:390
 msgid "Size"
 msgstr ""
 
 #. label for file modification date
-#: zim/plugins/attachmentbrowser/filebrowser.py:380
+#: zim/plugins/attachmentbrowser/filebrowser.py:391
 msgid "Modified"
 msgstr ""
 
 #. popup menu action on drag-drop of a file
-#: zim/plugins/attachmentbrowser/filebrowser.py:416
+#: zim/plugins/attachmentbrowser/filebrowser.py:427
 msgid "_Move Here"
 msgstr ""
 
 #. popup menu action on drag-drop of a file
-#: zim/plugins/attachmentbrowser/filebrowser.py:420
+#: zim/plugins/attachmentbrowser/filebrowser.py:431
 msgid "_Copy Here"
 msgstr ""
 
 #. popup menu action on drag-drop of a file
-#: zim/plugins/attachmentbrowser/filebrowser.py:425
+#: zim/plugins/attachmentbrowser/filebrowser.py:436
 msgid "Cancel"
 msgstr ""
 
@@ -2234,18 +2293,28 @@ msgstr ""
 #. preferences option
 #: zim/plugins/attachmentbrowser/__init__.py:80 zim/plugins/backlinkpane.py:35
 #: zim/plugins/journal.py:116 zim/plugins/pageindex/__init__.py:59
-#: zim/plugins/tableofcontents.py:85 zim/plugins/tags.py:48
+#: zim/plugins/tableofcontents.py:96 zim/plugins/tags.py:48
 #: zim/plugins/tasklist/__init__.py:54
 msgid "Position in the window"
 msgstr ""
 
+#. option for plugin preferences
+#: zim/plugins/attachmentbrowser/__init__.py:82
+msgid "Use thumbnails"
+msgstr ""
+
+#. option for plugin preferences
+#: zim/plugins/attachmentbrowser/__init__.py:84
+msgid "Support thumbnails for SVG"
+msgstr ""
+
 #. label for attachment browser pane
-#: zim/plugins/attachmentbrowser/__init__.py:123
+#: zim/plugins/attachmentbrowser/__init__.py:128
 msgid "Attachments"
 msgstr ""
 
 #. Label for the statusbar, %i is the number of attachments for the current page
-#: zim/plugins/attachmentbrowser/__init__.py:169
+#: zim/plugins/attachmentbrowser/__init__.py:180
 #, python-format
 msgid "%i Attachment"
 msgid_plural "%i Attachments"
@@ -2701,12 +2770,12 @@ msgid "Index"
 msgstr ""
 
 #. plugin name
-#: zim/plugins/pathbar.py:30
+#: zim/plugins/pathbar.py:38
 msgid "Path Bar"
 msgstr ""
 
 #. plugin description
-#: zim/plugins/pathbar.py:31
+#: zim/plugins/pathbar.py:39
 msgid ""
 "This plugin adds a \"path bar\" to the top of the window.\n"
 "This \"path bar\" can show the notebook path for the current page,\n"
@@ -2714,32 +2783,32 @@ msgid ""
 msgstr ""
 
 #. Menu title
-#: zim/plugins/pathbar.py:72
+#: zim/plugins/pathbar.py:80
 msgid "P_athbar"
 msgstr ""
 
 #. Menu option for View->Pathbar
-#: zim/plugins/pathbar.py:73
+#: zim/plugins/pathbar.py:81
 msgid "_None"
 msgstr ""
 
 #. Menu option for View->Pathbar
-#: zim/plugins/pathbar.py:74
+#: zim/plugins/pathbar.py:82
 msgid "_Recent pages"
 msgstr ""
 
 #. Menu option for View->Pathbar
-#: zim/plugins/pathbar.py:75
+#: zim/plugins/pathbar.py:83
 msgid "Recently _Changed pages"
 msgstr ""
 
 #. Menu option for View->Pathbar
-#: zim/plugins/pathbar.py:76
+#: zim/plugins/pathbar.py:84
 msgid "_History"
 msgstr ""
 
 #. Menu option for View->Pathbar
-#: zim/plugins/pathbar.py:77
+#: zim/plugins/pathbar.py:85
 msgid "_Page Hierarchy"
 msgstr ""
 
@@ -2839,12 +2908,12 @@ msgstr ""
 
 #. plugin name | 
 #. dialog title
-#: zim/plugins/screenshot.py:94 zim/plugins/screenshot.py:161
+#: zim/plugins/screenshot.py:107 zim/plugins/screenshot.py:174
 msgid "Insert Screenshot"
 msgstr ""
 
 #. plugin description
-#: zim/plugins/screenshot.py:95
+#: zim/plugins/screenshot.py:108
 msgid ""
 "This plugin  allows taking a screenshot and directly insert it\n"
 "in a zim page.\n"
@@ -2853,37 +2922,37 @@ msgid ""
 msgstr ""
 
 #. plugin preference
-#: zim/plugins/screenshot.py:106
+#: zim/plugins/screenshot.py:119
 msgid "Screenshot Command"
 msgstr ""
 
 #. menu item for insert screenshot plugin
-#: zim/plugins/screenshot.py:148
+#: zim/plugins/screenshot.py:161
 msgid "_Screenshot..."
 msgstr ""
 
 #. option in 'insert screenshot' dialog
-#: zim/plugins/screenshot.py:166
+#: zim/plugins/screenshot.py:179
 msgid "Capture whole screen"
 msgstr ""
 
 #. option in 'insert screenshot' dialog
-#: zim/plugins/screenshot.py:168
+#: zim/plugins/screenshot.py:181
 msgid "Select window or region"
 msgstr ""
 
 #. input in 'insert screenshot' dialog
-#: zim/plugins/screenshot.py:177
+#: zim/plugins/screenshot.py:190
 msgid "Delay"
 msgstr ""
 
 #. label behind timer
-#: zim/plugins/screenshot.py:183
+#: zim/plugins/screenshot.py:196
 msgid "seconds"
 msgstr ""
 
 #. Error message in "insert screenshot" dialog, %s will be replaced by application name
-#: zim/plugins/screenshot.py:208
+#: zim/plugins/screenshot.py:221
 #, python-format
 msgid "Some error occurred while running \"%s\""
 msgstr ""
@@ -2958,13 +3027,18 @@ msgid "Show Line Numbers"
 msgstr ""
 
 #. input label
-#: zim/plugins/sourceview.py:264 zim/plugins/sourceview.py:303
+#: zim/plugins/sourceview.py:264 zim/plugins/sourceview.py:305
 msgid "Syntax"
 msgstr ""
 
 #. dialog title
 #: zim/plugins/sourceview.py:281
 msgid "Insert Code Block"
+msgstr ""
+
+#. input checkbox
+#: zim/plugins/sourceview.py:317
+msgid "Display line numbers"
 msgstr ""
 
 #. plugin name
@@ -3186,12 +3260,12 @@ msgid "A table needs to have at least one column."
 msgstr ""
 
 #. plugin name
-#: zim/plugins/tableofcontents.py:71
+#: zim/plugins/tableofcontents.py:82
 msgid "Table of Contents"
 msgstr ""
 
 #. plugin description
-#: zim/plugins/tableofcontents.py:72
+#: zim/plugins/tableofcontents.py:83
 msgid ""
 "This plugin adds an extra widget showing a table of\n"
 "contents for the current page.\n"
@@ -3200,27 +3274,27 @@ msgid ""
 msgstr ""
 
 #. option for plugin preferences
-#: zim/plugins/tableofcontents.py:87
+#: zim/plugins/tableofcontents.py:98
 msgid "Show ToC as floating widget instead of in sidepane"
 msgstr ""
 
 #. option for plugin preferences
-#: zim/plugins/tableofcontents.py:89
+#: zim/plugins/tableofcontents.py:100
 msgid "Show the page title heading in the ToC"
 msgstr ""
 
 #. action to lower level of heading in the text
-#: zim/plugins/tableofcontents.py:271
+#: zim/plugins/tableofcontents.py:344
 msgid "Demote"
 msgstr ""
 
 #. action to raise level of heading in the text
-#: zim/plugins/tableofcontents.py:273
+#: zim/plugins/tableofcontents.py:346
 msgid "Promote"
 msgstr ""
 
 #. widget label
-#: zim/plugins/tableofcontents.py:376 zim/plugins/tableofcontents.py:406
+#: zim/plugins/tableofcontents.py:440 zim/plugins/tableofcontents.py:470
 msgid "ToC"
 msgstr ""
 
@@ -3228,7 +3302,7 @@ msgstr ""
 #. title for sidepane tab | 
 #. Column header for tag list in Task List dialog
 #: zim/plugins/tags.py:38 zim/plugins/tags.py:82
-#: zim/plugins/tasklist/gui.py:245
+#: zim/plugins/tasklist/gui.py:247
 msgid "Tags"
 msgstr ""
 
@@ -3260,7 +3334,7 @@ msgid "Show Tasks as Flat List"
 msgstr ""
 
 #. Checkbox in task list - this options hides tasks that are not yet started
-#: zim/plugins/tasklist/gui.py:43 zim/plugins/tasklist/gui.py:170
+#: zim/plugins/tasklist/gui.py:43 zim/plugins/tasklist/gui.py:172
 msgid "Only Show Active Tasks"
 msgstr ""
 
@@ -3271,20 +3345,20 @@ msgstr ""
 
 #. label for filtering/searching tasks | 
 #. Input label
-#: zim/plugins/tasklist/gui.py:86 zim/plugins/tasklist/gui.py:154
+#: zim/plugins/tasklist/gui.py:88 zim/plugins/tasklist/gui.py:156
 msgid "Filter"
 msgstr ""
 
 #. dialog title | 
 #. plugin name | 
 #. menu item
-#: zim/plugins/tasklist/gui.py:111 zim/plugins/tasklist/__init__.py:38
-#: zim/plugins/tasklist/__init__.py:156
+#: zim/plugins/tasklist/gui.py:113 zim/plugins/tasklist/__init__.py:38
+#: zim/plugins/tasklist/__init__.py:159
 msgid "Task List"
 msgstr ""
 
 #. Label for task List, %i is the number of tasks
-#: zim/plugins/tasklist/gui.py:183
+#: zim/plugins/tasklist/gui.py:185
 #, python-format
 msgid "%i open item"
 msgid_plural "%i open items"
@@ -3292,33 +3366,33 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. "tag" for showing all tasks
-#: zim/plugins/tasklist/gui.py:309
+#: zim/plugins/tasklist/gui.py:311
 msgid "All Tasks"
 msgstr ""
 
 #. label in tasklist plugins for tasks without a tag
-#: zim/plugins/tasklist/gui.py:319
+#: zim/plugins/tasklist/gui.py:321
 msgid "Untagged"
 msgstr ""
 
 #. Column header Task List dialog
-#: zim/plugins/tasklist/gui.py:433
+#: zim/plugins/tasklist/gui.py:435
 msgid "Task"
 msgstr ""
 
 #. Column header Task List dialog | 
 #. Column header versions dialog
-#: zim/plugins/tasklist/gui.py:484 zim/plugins/versioncontrol/__init__.py:1069
+#: zim/plugins/tasklist/gui.py:486 zim/plugins/versioncontrol/__init__.py:1069
 msgid "Date"
 msgstr ""
 
 #. start date for task
-#: zim/plugins/tasklist/gui.py:795
+#: zim/plugins/tasklist/gui.py:797
 msgid "Start"
 msgstr ""
 
 #. due date for task
-#: zim/plugins/tasklist/gui.py:797
+#: zim/plugins/tasklist/gui.py:799
 msgid "Due"
 msgstr ""
 
@@ -3337,58 +3411,63 @@ msgstr ""
 msgid "Show tasklist in sidepane"
 msgstr ""
 
+#. preferences option
+#: zim/plugins/tasklist/__init__.py:56
+msgid "Show due date in sidepane"
+msgstr ""
+
 #. label for plugin preferences dialog
-#: zim/plugins/tasklist/__init__.py:60
+#: zim/plugins/tasklist/__init__.py:62
 msgid "Consider all checkboxes as tasks"
 msgstr ""
 
 #. label for plugin preferences dialog - labels are e.g. "FIXME", "TODO"
-#: zim/plugins/tasklist/__init__.py:62
+#: zim/plugins/tasklist/__init__.py:64
 msgid "Labels marking tasks"
 msgstr ""
 
 #. label for preference with multiple options
-#: zim/plugins/tasklist/__init__.py:64
+#: zim/plugins/tasklist/__init__.py:66
 msgid "Use date from journal pages"
 msgstr ""
 
 #. choice for "Use date from journal pages"
-#: zim/plugins/tasklist/__init__.py:65
+#: zim/plugins/tasklist/__init__.py:67
 msgid "do not use"
 msgstr ""
 
 #. choice for "Use date from journal pages"
-#: zim/plugins/tasklist/__init__.py:66
+#: zim/plugins/tasklist/__init__.py:68
 msgid "as start date for tasks"
 msgstr ""
 
 #. choice for "Use date from journal pages"
-#: zim/plugins/tasklist/__init__.py:67
+#: zim/plugins/tasklist/__init__.py:69
 msgid "as due date for tasks"
 msgstr ""
 
 #. Notebook sections to search for tasks - default is the whole tree (empty string means everything)
-#: zim/plugins/tasklist/__init__.py:69
+#: zim/plugins/tasklist/__init__.py:71
 msgid "Section(s) to index"
 msgstr ""
 
 #. Notebook sections to exclude when searching for tasks - default is none
-#: zim/plugins/tasklist/__init__.py:71
+#: zim/plugins/tasklist/__init__.py:73
 msgid "Section(s) to ignore"
 msgstr ""
 
 #. label for plugin preferences dialog
-#: zim/plugins/tasklist/__init__.py:76
+#: zim/plugins/tasklist/__init__.py:78
 msgid "Tags for non-actionable tasks"
 msgstr ""
 
 #. label for plugin preferences dialog
-#: zim/plugins/tasklist/__init__.py:78
+#: zim/plugins/tasklist/__init__.py:80
 msgid "Turn page name into tags for task items"
 msgstr ""
 
 #. label for plugin preferences dialog
-#: zim/plugins/tasklist/__init__.py:80
+#: zim/plugins/tasklist/__init__.py:82
 msgid "Flag tasks due on Monday or Tuesday before the weekend"
 msgstr ""
 


### PR DESCRIPTION
This is a formal update of the translation skeleton using the tools/xgettext.sh, updating references and inserting so far missing messages to translate.

With that, missing messages to translate will appear as such in launchpad.