### PR TITLE
distraction free editing plugin: remove all colors of the window chrome 

### DIFF
--- a/zim/plugins/distractionfree.py
+++ b/zim/plugins/distractionfree.py
@@ -67,10 +67,17 @@ class DistractionFreeMainWindowExtension(MainWindowExtension):
 			color: %s;
 			background-color: %s;
 		}
-		''' % (self.preferences['textcolor'], self.preferences['basecolor'])
+		widget box box scrolledwindow{
+			border-style: none;
+			}
+		box {
+			background-color: %s;
+		}
+		''' % (self.preferences['textcolor'], self.preferences['basecolor'],self.preferences['basecolor'])
 		provider = Gtk.CssProvider()
 		provider.load_from_data(css.encode('UTF-8'))
 		return provider
+
 
 	def on_preferences_changed(self, preferences):
 		if self.window.isfullscreen:


### PR DESCRIPTION
The box colors are set to the same value as the background color for true distraction free editing.

Regular view: 
![](https://i.imgur.com/SdSg4e1.png)

Distraction free before:
![](https://i.imgur.com/8tY176L.png)

Distraction free after patch:
![](https://i.imgur.com/S56811S.png)