### PR TITLE
fixes handling of non-existent pages

### DIFF
--- a/tests/notebook.py
+++ b/tests/notebook.py
@@ -600,6 +600,31 @@ class TestUpdateLinksOnMovePage(tests.TestCase):
 		self.assertEqual(self.getNotebookContent(notebook), post[0])
 		self.assertEqual(self.getNotebookLinks(notebook), set(post[1]))
 
+	def testMoveNonPageLink(self):
+		self.movePage(
+			pre=(
+				{'A': 'test 123\n', 'B': '[[C]]\n'},
+				[('B', 'C')]
+			),
+			move=('C', 'A'),
+			post=(
+				{'A': 'test 123\n', 'B': '[[A]]\n'},
+				[('B', 'A')]
+			)
+		)
+
+	def testRenameNonPageLink(self):
+		self.movePage(
+			pre=(
+				{'A': 'test 123\n', 'B': '[[C]]\n'},
+				[('B', 'C')]
+			),
+			move=('C', 'D'),
+			post=(
+				{'A': 'test 123\n', 'B': '[[D]]\n', 'D': ''},
+				[('B', 'D')]
+			)
+		)
 	def testFloatingLink(self):
 		self.movePage(
 			pre=(

--- a/zim/notebook/notebook.py
+++ b/zim/notebook/notebook.py
@@ -576,14 +576,18 @@ class Notebook(ConnectorMixin, SignalEmitter):
 			n_links = self.links.n_list_links_section(path, LINK_DIR_BACKWARD)
 		except IndexNotFoundError:
 			raise PageNotFoundError(path)
-		self._move_file_and_folder(path, newpath)
-		self.flush_page_cache(path)
-		self.emit('moved-page', path, newpath)
+
+		file, folder = self.layout.map_page(path)
+		if (file.exists() or folder.exists()):
+			self._move_file_and_folder(path, newpath)
+			self.flush_page_cache(path)
+			self.emit('moved-page', path, newpath)
+
+			if update_links:
+				for p in self._update_links_in_moved_page(path, newpath):
+					yield p
 
 		if update_links:
-			for p in self._update_links_in_moved_page(path, newpath):
-				yield p
-
 			for p in self._update_links_to_moved_page(path, newpath):
 				yield p
 


### PR DESCRIPTION
When the name of a non-existent page is changed, the pages that link to this non-existent page don't get updated.

Also fixes moving of non-existent pages.