### PR TITLE
Add a key binding for copying the current line

### DIFF
--- a/data/menubar.xml
+++ b/data/menubar.xml
@@ -46,6 +46,7 @@
 			<separator/>
 			<placeholder name='plugin_items'/>
 			<separator/>
+			<menuitem action='copy_current_line'/>
 			<menuitem action='copy_location'/>
 			<separator/>
 			<menuitem action='show_templateeditor'/>

--- a/tests/pageview.py
+++ b/tests/pageview.py
@@ -2510,6 +2510,31 @@ class TestPageViewActions(tests.TestCase):
 		pageview.zoom_reset()
 		#self.assertEqual(pageview.text_style['TextView']['font'], 'Arial 10') # FIXME
 
+	def testCopyCurrentLine(self):
+		# Check that the current line, where the cursor is located, can be
+		# copied from one page to another via the copy current line feature.
+		pageView1Text = 'test 123\ntest 456\ntest 789\n'
+		pageview1 = setUpPageView(self.setUpNotebook(), pageView1Text)
+		pageview2 = setUpPageView(self.setUpNotebook())
+
+		buffer1 = pageview1.textview.get_buffer()
+		buffer2 = pageview2.textview.get_buffer()
+
+		buffer1.place_cursor(buffer1.get_iter_at_offset(12))
+		pageview1.copy_current_line()
+		pageview2.paste()
+
+		self.assertEqual(get_text(buffer1), pageView1Text)
+		self.assertEqual(get_text(buffer2), 'test 456\n')
+
+		# Ensure copying a line with no text does not add anything
+		# to the clipboard.
+		Clipboard.clear()
+		pageview3 = setUpPageView(self.setUpNotebook())
+		buffer3 = pageview3.textview.get_buffer()
+		buffer3.place_cursor(buffer3.get_iter_at_offset(0))
+		pageview3.copy_current_line()
+		self.assertIsNone(Clipboard.get_parsetree())
 
 class TestPageviewDialogs(tests.TestCase):
 

--- a/zim/gui/pageview.py
+++ b/zim/gui/pageview.py
@@ -6202,6 +6202,22 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		if bounds:
 			buffer.remove_link(*bounds)
 
+	@action(_('Copy Line'), accelerator='<Primary><Shift>C', menuhints='edit')
+	def copy_current_line(self):
+		'''Menu action to copy the current line to the clipboard'''
+		buffer = self.textview.get_buffer()
+		mark = buffer.create_mark(None, buffer.get_insert_iter())
+		buffer.select_line()
+
+		if buffer.get_has_selection():
+			bounds = buffer.get_selection_bounds()
+			tree = buffer.get_parsetree(bounds)
+			Clipboard.set_parsetree(self.notebook, self.page, tree)
+			buffer.unset_selection()
+			buffer.place_cursor(buffer.get_iter_at_mark(mark))
+
+		buffer.delete_mark(mark)
+
 	@action(_('_Date and Time...'), accelerator='<Primary>D', menuhints='insert') # T: Menu item
 	def insert_date(self):
 		'''Menu action to insert a date, shows the L{InsertDateDialog}'''


### PR DESCRIPTION
This change addresses issue #730 which proposes a new keybinding to
copy the current line. I'm not sure if this change is desired by many,
or if the code achieves this in a nice way, but it was a good exercise
in gaining some familiarity with the Zim codebase.