### PR TITLE
Exclude formatting when copying headings

### DIFF
--- a/tests/data/formats/plain.txt
+++ b/tests/data/formats/plain.txt
@@ -1,5 +1,4 @@
 Head 1
-======
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
 eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
 ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -17,7 +16,6 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.
 	sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 head 2
-------
 
 bold, italic and underline and verbatim
 and also strike through
@@ -30,7 +28,7 @@ And some empty space here:
 
 
 
-### head 3
+head 3
 foo  links to page in the current namespace or parents
 :foo links to page in the root namespace
 +foo links to page in a subnamespace
@@ -61,7 +59,7 @@ Foo Bar
 Tags: @foo @bar
 
 
-#### head 4
+head 4
 
 * item 1
 * item 2
@@ -105,7 +103,7 @@ D. bar
 	3. sub item start with 3
 E. baz
 
-##### head 5
+head 5
 some verbatim blocks:
 
 Sing, O goddess, the rage of
@@ -127,9 +125,8 @@ the Achaeans.
 		returen "foo" + bar % baz
 
 Internationalization
---------------------
 
-### 中文
+中文
 This section has a chinese heading
 
 Lines below are in right to left script:
@@ -144,7 +141,6 @@ aaa
 
 
 Some Objects
-------------
 
 def dump():
 	for i in range(1, 5):
@@ -157,7 +153,6 @@ brought countless ills upon
 the Achaeans.
 
 A table
--------
 
 +------------------+-----------+------+
 |        H1        |     H2 h2 | H3   |

--- a/zim/formats/plain.py
+++ b/zim/formats/plain.py
@@ -81,6 +81,7 @@ class Dumper(DumperClass):
 		TAG: ('', ''),
 		SUBSCRIPT: ('', ''),
 		SUPERSCRIPT: ('', ''),
+		HEADING: ('', ''),
 	}
 
 	def dump_indent(self, tag, attrib, strings):


### PR DESCRIPTION
This addresses issue #752, which concerns the behaviour of copying
headings in plain text.

Prior to this change, copying a heading in a notebook and pasting it
into another text editor would include the formatting. For example, the
level three heading `Title` would be pasted into a plain text document
as `### Title`.

This is inconsistent with the copying and pasting of text with other
formatting, such as bold or italics. A bold word, such as `test`, is
pasted as `test`, not `**test**`.

This change also affects the plain text export, meaning that headings
are not exported with any formatting.