### PR TITLE
Show plugins that failed to load in the list

### DIFF
--- a/zim/gui/preferencesdialog.py
+++ b/zim/gui/preferencesdialog.py
@@ -363,14 +363,13 @@ class PluginsTreeModel(Gtk.ListStore):
 
 		allplugins = []
 		for key in self.plugins.list_installed_plugins():
-			klass, name, loaded = None, "", False
+			klass, name, loaded = None, key, False
 
 			try:
 				klass = self.plugins.get_plugin_class(key)
 				name = klass.plugin_info['name']
 				loaded = True
 			except:
-				name = key
 				logger.exception('Could not load plugin %s', key)
 			finally:
 				allplugins.append((name, key, klass, loaded))

--- a/zim/gui/preferencesdialog.py
+++ b/zim/gui/preferencesdialog.py
@@ -297,12 +297,30 @@ class PluginsTab(Gtk.VBox):
 
 		buffer.delete(*buffer.get_bounds()) # clear
 
+		check, dependencies = klass.check_dependencies() if klass else (False, [])
+
 		if not activatable:
-			insert(_('This plugin failed to load') + '\n\n', 'red')
-			if not klass:
-				self.configure_button.set_sensitive(False)
-				self.plugin_help_button.set_sensitive(False)
-				return
+			# Each dependency is a 3-tuple of (name, available, required). If any
+			# dependency is required but not available we can inform the user.
+			if any(dep for dep in dependencies if not dep[1] and dep[2]):
+				insert(
+					_(
+						'This plugin could not be loaded due to missing dependencies.\n'
+						'Please see the dependencies section below for details.\n\n'
+					),
+					'red'
+				)
+			else:
+				# Dependencies are ok so there is some other reason for this plugin
+				# not being loaded. This can happen if there is a problem
+				# (e.g. syntax error) in the extension's Python module. Such issues
+				# are caught when the PluginsTreeModel is init'ed.
+				insert(_('There was a problem loading this plugin\n\n'), 'red')
+
+				if not klass:
+					self.configure_button.set_sensitive(False)
+					self.plugin_help_button.set_sensitive(False)
+					return
 
 		insert(_('Name') + '\n', 'bold') # T: Heading in plugins tab of preferences dialog
 		insert(klass.plugin_info['name'].strip() + '\n\n')
@@ -310,8 +328,7 @@ class PluginsTab(Gtk.VBox):
 		insert(klass.plugin_info['description'].strip() + '\n\n')
 		insert(_('Dependencies') + '\n', 'bold') # T: Heading in plugins tab of preferences dialog
 
-		check, dependencies = klass.check_dependencies()
-		if not(dependencies):
+		if not dependencies:
 			insert(_('No dependencies') + '\n') # T: label in plugin info in preferences dialog
 		else:
 			# Construct dependency list, missing dependencies are marked red

--- a/zim/gui/preferencesdialog.py
+++ b/zim/gui/preferencesdialog.py
@@ -370,7 +370,7 @@ class PluginsTreeModel(Gtk.ListStore):
 				name = klass.plugin_info['name']
 				loaded = True
 			except:
-				name = name or key
+				name = key
 				logger.exception('Could not load plugin %s', key)
 			finally:
 				allplugins.append((name, key, klass, loaded))

--- a/zim/gui/preferencesdialog.py
+++ b/zim/gui/preferencesdialog.py
@@ -300,6 +300,8 @@ class PluginsTab(Gtk.VBox):
 		if not activatable:
 			insert(_('This plugin failed to load') + '\n\n', 'red')
 			if not klass:
+				self.configure_button.set_sensitive(False)
+				self.plugin_help_button.set_sensitive(False)
 				return
 
 		insert(_('Name') + '\n', 'bold') # T: Heading in plugins tab of preferences dialog


### PR DESCRIPTION
This change addresses #668, which requires failed plugins to be
displayed in the list of plugins. This is only a minor improvement
which:
* includes a plugin that failed to load in the list
* displays a generic error message in the details pane
* uses the plugin's key (file or directory name) in the list if the
  plugin's proper name can't be read due to the load problem

The generic error message is also displayed at the top of the details
pane for plugins that can't be activated due to missing dependencies.
This may not be desired or it might be useful to state that loading
failed due to missing dependencies (marked in red in the
dependencies list).