### PR TITLE
Add an option to disable autosave on focus_out in preferences.conf

### DIFF
--- a/zim/gui/pageview.py
+++ b/zim/gui/pageview.py
@@ -5245,6 +5245,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		if_preferences = ConfigManager.preferences['GtkInterface']
 		if_preferences.setdefault('autosave_timeout', 15)
 		if_preferences.setdefault('autosave_use_thread', True)
+		if_preferences.setdefault('autosave_on_focus_out', True)
 		logger.debug('Autosave interval: %r - use threads: %r',
 			if_preferences['autosave_timeout'],
 			if_preferences['autosave_use_thread']
@@ -5257,7 +5258,8 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		)
 
 		def on_focus_out_event(*a):
-			self._save_page_handler.try_save_page()
+			if if_preferences['autosave_on_focus_out']:
+				self._save_page_handler.try_save_page()
 			return False # don't block the event
 		self.textview.connect('focus-out-event', on_focus_out_event)
 


### PR DESCRIPTION
Possible fix for #393 , this reads an option from preferences.conf under GtkInterface overrides the default foucus_out behavior. Autosave on focus out is enabled by default (as before), and is disabled if explicitly turned off in the configuration file using this option.

Another small thing I noticed is that the default autosave time out here seems to be 15 minutes, while the wiki says that the default is 10 minutes.