### PR TITLE
Plugins tab Properties button

### DIFF
--- a/zim/gui/preferencesdialog.py
+++ b/zim/gui/preferencesdialog.py
@@ -50,6 +50,7 @@ class PreferencesDialog(Dialog):
 	def __init__(self, widget, default_tab=None, select_plugin=None):
 		Dialog.__init__(self, widget, _('Preferences')) # T: Dialog title
 		self.preferences = ConfigManager.preferences
+		self.main_window = widget
 
 		# warning for locale
 		_pref_enc = locale.getpreferredencoding()
@@ -251,6 +252,11 @@ class PluginsTab(Gtk.VBox):
 		self.configure_button.connect('clicked', self.on_configure_button_clicked)
 		hbox.pack_start(self.configure_button, False, True, 0)
 
+		self.properties_button = \
+			Gtk.Button.new_with_mnemonic(_('_Properties'))  # T: Button in plugin tab
+		hbox.pack_start(self.properties_button, False, True, 0)
+		self.properties_button.connect('clicked', self.on_properties_button_clicked)
+
 		try:
 			self.treeselection.select_path(0)
 		except:
@@ -325,6 +331,7 @@ class PluginsTab(Gtk.VBox):
 		insert(klass.plugin_info['author'].strip())
 
 		self.configure_button.set_sensitive(active and bool(klass.plugin_preferences))
+		self.properties_button.set_sensitive(active and bool(klass.plugin_notebook_properties))
 		self.plugin_help_button.set_sensitive('help' in klass.plugin_info)
 
 	def on_help_button_clicked(self, button):
@@ -336,6 +343,12 @@ class PluginsTab(Gtk.VBox):
 	def on_configure_button_clicked(self, button):
 		plugin = self.plugins[self._current_plugin]
 		PluginConfigureDialog(self.dialog, plugin).run()
+
+	def on_properties_button_clicked(self, button):
+		from zim.gui.propertiesdialog import PropertiesDialog
+		PropertiesDialog(self.dialog.main_window,
+						 self.dialog.main_window.notebook,
+						 chosen_plugin=self._current_plugin).run()
 
 	def select_plugin(self, name):
 		model = self.treeview.get_model()

--- a/zim/gui/propertiesdialog.py
+++ b/zim/gui/propertiesdialog.py
@@ -24,7 +24,7 @@ notebook_properties = (
 
 class PropertiesDialog(Dialog):
 
-	def __init__(self, parent, notebook):
+	def __init__(self, parent, notebook, chosen_plugin=None):
 		Dialog.__init__(self, parent, _('Properties'), help='Help:Properties') # T: Dialog title
 		self.notebook = notebook
 
@@ -37,17 +37,22 @@ class PropertiesDialog(Dialog):
 		hbox.add(stack)
 		self.vbox.add(hbox)
 
+		def add_widget(form, name, title):
+			if chosen_plugin and chosen_plugin != name:
+				return
+			if self.notebook.readonly:
+				for widget in list(form.widgets.values()):
+					widget.set_sensitive(False)
+			box = Gtk.VBox()
+			box.pack_start(form, False, False, 0)
+			stack.add_titled(box, name, title)
+
 		self.form = InputForm(
 			inputs=notebook_properties,
 			values=notebook.config['Notebook']
 		)
 		self.form.widgets['icon'].set_use_relative_paths(self.notebook)
-		if self.notebook.readonly:
-			for widget in list(self.form.widgets.values()):
-				widget.set_sensitive(False)
-		box = Gtk.VBox()
-		box.pack_start(self.form, False, False, 0)
-		stack.add_titled(box, 'notebook', _('Notebook'))
+		add_widget(self.form, 'notebook', _('Notebook'))
 
 		self.plugin_forms = {}
 		plugins = PluginManager()
@@ -60,13 +65,7 @@ class PropertiesDialog(Dialog):
 					values=notebook.config[key]
 				)
 				self.plugin_forms[key] = form
-				if self.notebook.readonly:
-					for widget in list(form.widgets.values()):
-						widget.set_sensitive(False)
-
-				box = Gtk.VBox()
-				box.pack_start(form, False, False, 0)
-				stack.add_titled(box, name, plugin.plugin_info['name'])
+				add_widget(form, name, plugin.plugin_info['name'])
 
 	def do_response_ok(self):
 		if not self.notebook.readonly:


### PR DESCRIPTION
Since it is little bit confusing the user has to close the Plugins tab and open `File / Properties` to see all options of some plugins, `Edit / Preferences / Plugins / Properties` button has been added

![image](https://user-images.githubusercontent.com/6942231/84696910-86f88d00-af4d-11ea-9994-afc8a6c740f8.png)
