### PR TITLE
paste short relative link names fix #100

### DIFF
--- a/zim/gui/clipboard.py
+++ b/zim/gui/clipboard.py
@@ -297,15 +297,18 @@ def _link_tree(links, notebook, path):
 			# FIXME - is this ever used ??
 			builder.append(TAG, {'name': links[i][1:]}, links[i])
 		else:
+			name = None
 			if type == 'page':
 				target = Path(Path.makeValidPageName(link)) # Assume links are always absolute
 				href = notebook.pages.create_link(path, target)
 				link = href.to_wiki_link()
+				if notebook.config['Notebook']['short_relative_links']:
+					name = href.parts()[-1]
 			elif type == 'file':
 				file = File(link) # Assume links are always URIs
 				link = notebook.relative_filepath(file, path) or file.uri
 
-			builder.append(LINK, {'href': link}, link)
+			builder.append(LINK, {'href': link}, name or link)
 
 	builder.end(FORMATTEDTEXT)
 	tree = builder.get_parsetree()

--- a/zim/gui/propertiesdialog.py
+++ b/zim/gui/propertiesdialog.py
@@ -18,6 +18,7 @@ notebook_properties = (
 	('home', 'page', _('Home Page')), # T: label for properties dialog
 	('icon', 'image', _('Icon')), # T: label for properties dialog
 	('document_root', 'dir', _('Document Root')), # T: label for properties dialog
+	('short_relative_links', 'bool', _('Paste short relative link names'), False), # T: label for properties dialog
 	# 'shared' property is not shown in properties anymore
 )
 

--- a/zim/notebook/notebook.py
+++ b/zim/notebook/notebook.py
@@ -53,6 +53,7 @@ class NotebookConfig(INIConfigFile):
 			('home', ConfigDefinitionByClass(Path('Home'))),
 			('icon', String(None)), # XXX should be file, but resolves relative
 			('document_root', String(None)), # XXX should be dir, but resolves relative
+			('short_relative_links', Boolean(False)),
 			('shared', Boolean(True)),
 			('endofline', Choice(endofline, {'dos', 'unix'})),
 			('disable_trash', Boolean(False)),
@@ -799,6 +800,11 @@ class Notebook(ConnectorMixin, SignalEmitter):
 		text = newhref.to_wiki_link()
 		if elt.gettext() == elt.get('href'):
 			elt[:] = [text]
+		elif self.config['Notebook']['short_relative_links'] and elt.gettext() == oldhref.parts()[-1] and len(elt) == 1:
+			# we are using short links and the link text was short link
+			# and there were no sub-node (like bold text) that would be cancelled
+			elt[:] = [newhref.parts()[-1]]  # 'Journal:2020:01:20' -> '20'
+
 		elt.set('href', text)
 		return elt
 


### PR DESCRIPTION
I'd like to have shorter links from Journal. So I have added new notebook property that sets whether an internal wiki link should be pasted in shorter form. This was initially PR'd in #100 and now I've re-implemented as a generic option as Jaap suggested years ago.