### PR TITLE
Use code font in style config for sourceview

### DIFF
--- a/zim/plugins/sourceview.py
+++ b/zim/plugins/sourceview.py
@@ -26,7 +26,7 @@ except:
 from zim.plugins import PluginClass, InsertedObjectTypeExtension
 from zim.actions import action
 from zim.utils import WeakSet
-from zim.config import String, Boolean
+from zim.config import String, Boolean, ConfigManager
 from zim.formats.html import html_encode
 
 from zim.gui.pageview import PageViewExtension
@@ -192,7 +192,6 @@ class SourceViewWidget(TextViewWidget):
 
 		self.view = GtkSource.View()
 		self.view.set_buffer(self.buffer)
-		self.view.modify_font(Pango.FontDescription('monospace'))
 		self.view.set_auto_indent(True)
 		self.view.set_smart_home_end(True)
 		self.view.set_highlight_current_line(True)
@@ -200,6 +199,14 @@ class SourceViewWidget(TextViewWidget):
 		self.view.set_show_right_margin(True)
 		self.view.set_tab_width(4)
 		self.view.set_show_line_numbers(self.buffer.object_attrib['linenumbers'])
+
+		text_style = ConfigManager.get_config_dict('style.conf')
+		try:
+			font = text_style['Tag code']['family']
+		except KeyError:
+			font = 'monospace'
+		finally:
+			self.view.modify_font(Pango.FontDescription(font))
 
 		# simple toolbar
 		#~ bar = Gtk.HBox() # FIXME: use Gtk.Toolbar stuff


### PR DESCRIPTION
Given that a custom font can be set for code tags it makes sense that
the sourceview plugin would also use this style.