### PR TITLE
Remove the prepended interpreter.

### DIFF
--- a/zim/applications.py
+++ b/zim/applications.py
@@ -201,12 +201,6 @@ class Application(object):
 			argv = list(argv)
 			argv[0] = cmd
 
-		# if it is a python script, insert interpreter as the executable
-		if argv[0].endswith('.py') and not _main_is_frozen():
-			argv = list(argv)
-			argv.insert(0, sys.executable)
-		# TODO: consider an additional commandline arg to re-use compiled python interpreter
-
 		if hasattr(cwd, 'path'):
 			cwd = cwd.path
 


### PR DESCRIPTION
The Windows version of [Python 3.3 and later](https://docs.python.org/3/using/windows.html#python-launcher-for-windows) has native shebang support via [PEP 397](https://www.python.org/dev/peps/pep-0397/), so this mechanism is no longer necessary. Relevant bug report:

https://github.com/zim-desktop-wiki/zim-desktop-wiki/issues/1182