### PR TITLE
Include helper to spawn external processes

### DIFF
--- a/windows/src/zim.spec
+++ b/windows/src/zim.spec
@@ -7,7 +7,9 @@ block_cipher = None
 a = Analysis( # noqa
     ['../build/venv/bin/zim_launch.py'],
     pathex=['../build'],
-    binaries=[],
+    binaries=[
+        ('C:\\msys64\\mingw64\\bin\\gspawn-win64-helper.exe', '.'),
+    ],
     datas=[
         ('../build/venv/share', 'share'),
         ('../../zim/plugins', 'share/zim/plugins'),

--- a/windows/src/zim.spec
+++ b/windows/src/zim.spec
@@ -1,15 +1,22 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 import os.path
+import subprocess
+import sys
 
 block_cipher = None
+binaries = []
+
+if sys.platform == "win32":
+    posix2win = lambda cyg_path: subprocess.check_output(["cygpath", "-w", cyg_path]).strip(b"\n").decode()
+
+    binaries.append((posix2win('/mingw64/bin/gspawn-win64-helper'), '.'))
+    binaries.append((posix2win('/mingw64/bin/gspawn-win64-helper-console'), '.'))
 
 a = Analysis( # noqa
     ['../build/venv/bin/zim_launch.py'],
     pathex=['../build'],
-    binaries=[
-        ('C:\\msys64\\mingw64\\bin\\gspawn-win64-helper.exe', '.'),
-    ],
+    binaries=binaries,
     datas=[
         ('../build/venv/share', 'share'),
         ('../../zim/plugins', 'share/zim/plugins'),


### PR DESCRIPTION
This should fix #1097 

gspawn-win64-helper-console.exe does not seem to be necessary according to my testing.