### PR TITLE
Update markdown.py

### DIFF
--- a/zim/formats/markdown.py
+++ b/zim/formats/markdown.py
@@ -22,8 +22,7 @@ info = {
 	'name': 'markdown',
 	'desc': 'Markdown Text (pandoc)',
 	'mimetype': 'text/x-markdown',
-	'extension': 'markdown',
-		# No official file extension, but this is often used
+	'extension': 'md', # Most common extention used on github.
 	'native': False,
 	'import': False,
 	'export': True,

--- a/zim/formats/markdown.py
+++ b/zim/formats/markdown.py
@@ -21,7 +21,7 @@ from zim.formats.plain import Dumper as TextDumper
 info = {
 	'name': 'markdown',
 	'desc': 'Markdown Text (pandoc)',
-	'mimetype': 'text/x-markdown',
+	'mimetype': 'text/markdown',
 	'extension': 'md', # Most common extention used on github.
 	'native': False,
 	'import': False,


### PR DESCRIPTION
This pull request outlines two changes:

1. The de-facto filename extension for markdown files has changed from `.markdown` to `.md`.
2. As per [[RFC7763](https://www.iana.org/go/rfc7763)], Markdown has the default mime type of `text/markdown`
