### PR TITLE
plugins/versioncontrol/git: Configure new repo to not quote non-ascii…

### DIFF
--- a/zim/plugins/versioncontrol/git.py
+++ b/zim/plugins/versioncontrol/git.py
@@ -131,6 +131,10 @@ class GITApplicationBackend(VCSApplicationBase):
 
 	def init_repo(self):
 		self.init()
+		# Configure git to not quote non-ascii filenames. By default,
+		# they are quoted as octal escapes, making it complicated to
+		# deal with page names in non-Latin scripts.
+		self.run(['config', 'core.quotepath', 'off'])
 		self.ignore(".zim/\n")
 		self.add('.') # add all existing files
 


### PR DESCRIPTION
… paths

By default, git quotes (using octal escapes) non-ascii characters in file
names, e.g. "\320\244\320\260\320\271\320\273.txt". Of course, this makes
life complicated for user of non-Latin scripts who name pages in their
native languages. This behavior can be turned off with
"git config core.quotepath off" config setting, so do that by default
when initializing the repository for notebook.

Fixes: #1104

Signed-off-by: Paul Sokolovsky <pfalcon@users.sourceforge.net>