### PR TITLE
Replace usage of `getchildren` and `getiterator` with `list` or `iter`

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -559,7 +559,7 @@ class _TestData(object):
 		tree = etree.ElementTree(file=root + '/tests/data/notebook-wiki.xml')
 
 		test_data = []
-		for node in tree.getiterator(tag='page'):
+		for node in tree.iter(tag='page'):
 			name = node.attrib['name']
 			text = str(node.text.lstrip('\n'))
 			test_data.append((name, text))

--- a/zim/formats/__init__.py
+++ b/zim/formats/__init__.py
@@ -267,7 +267,7 @@ class ParseTree(object):
 		'''Returns True if the tree contains any content at all.'''
 		root = self._etree.getroot()
 		return root is not None and (
-			bool(root.getchildren()) or (root.text and not root.text.isspace())
+			bool(list(root)) or (root.text and not root.text.isspace())
 		)
 
 	@property
@@ -289,14 +289,14 @@ class ParseTree(object):
 		myroot = self._etree.getroot()
 		otherroot = tree._etree.getroot()
 		if otherroot.text:
-			children = myroot.getchildren()
+			children = list(myroot)
 			if children:
 				last = children[-1]
 				last.tail = (last.tail or '') + otherroot.text
 			else:
 				myroot.text = (myroot.text or '') + otherroot.text
 
-		for element in otherroot.getchildren():
+		for element in iter(otherroot):
 			myroot.append(element)
 
 		return self
@@ -317,7 +317,7 @@ class ParseTree(object):
 
 		# HACK: Force sorting of attrib - else change in python3.8 breaks test cases
 		# Ensure all attrib are string, else ElementTree fails
-		for element in self._etree.getiterator('*'):
+		for element in self._etree.iter('*'):
 			myattrib = element.attrib.copy()
 			element.attrib.clear()
 			for key in sorted(myattrib.keys()):
@@ -347,8 +347,8 @@ class ParseTree(object):
 		from zim.notebook.page import HRef # XXX
 		seen = set()
 		for elt in itertools.chain(
-			self._etree.getiterator(LINK),
-			self._etree.getiterator(IMAGE)
+			self._etree.iter(LINK),
+			self._etree.iter(IMAGE)
 		):
 			href = elt.attrib.get('href')
 			if href and href not in seen:
@@ -364,7 +364,7 @@ class ParseTree(object):
 		@returns: yields an unordered list of tag names
 		'''
 		seen = set()
-		for elt in self._etree.getiterator(TAG):
+		for elt in self._etree.iter(TAG):
 			name = elt.text
 			if not name in seen:
 				seen.add(name)
@@ -372,7 +372,7 @@ class ParseTree(object):
 
 	def _get_heading_element(self, level=1):
 		root = self._etree.getroot()
-		children = root.getchildren()
+		children = list(root)
 		if root.text and not root.text.isspace():
 			return None
 
@@ -429,7 +429,7 @@ class ParseTree(object):
 		'''
 		root = self._etree.getroot()
 		roottext = root.text and not root.text.isspace()
-		children = root.getchildren()
+		children = list(root)
 
 		if children and not roottext:
 			first = children[0]
@@ -447,7 +447,7 @@ class ParseTree(object):
 		and a max depth.
 		'''
 		path = []
-		for heading in self._etree.getiterator('h'):
+		for heading in self._etree.iter('h'):
 			level = int(heading.attrib['level'])
 			# find parent header in path using old level
 			while path and path[-1][0] >= level:
@@ -466,11 +466,11 @@ class ParseTree(object):
 		adds a '_src_file' attribute to the elements with the full file path.
 		'''
 		if notebook is None:
-			for element in self._etree.getiterator('img'):
+			for element in self._etree.iter('img'):
 				filepath = element.attrib['src']
 				element.attrib['_src_file'] = File(filepath)
 		else:
-			for element in self._etree.getiterator('img'):
+			for element in self._etree.iter('img'):
 				filepath = element.attrib['src']
 				element.attrib['_src_file'] = notebook.resolve_file(element.attrib['src'], path)
 
@@ -478,7 +478,7 @@ class ParseTree(object):
 		'''Undo effect of L{resolve_images()}, mainly intended for
 		testing.
 		'''
-		for element in self._etree.getiterator('img'):
+		for element in self._etree.iter('img'):
 			if '_src_file' in element.attrib:
 				element.attrib.pop('_src_file')
 
@@ -486,7 +486,7 @@ class ParseTree(object):
 		'''Calls encode_url() on all links that contain urls.
 		See zim.parsing for details. Modifies the parse tree.
 		'''
-		for link in self._etree.getiterator('link'):
+		for link in self._etree.iter('link'):
 			href = link.attrib['href']
 			if href and is_url_re.match(href):
 				link.attrib['href'] = url_encode(href, mode=mode)
@@ -497,7 +497,7 @@ class ParseTree(object):
 		'''Calls decode_url() on all links that contain urls.
 		See zim.parsing for details. Modifies the parse tree.
 		'''
-		for link in self._etree.getiterator('link'):
+		for link in self._etree.iter('link'):
 			href = link.attrib['href']
 			if href and is_url_re.match(href):
 				link.attrib['href'] = url_decode(href, mode=mode)
@@ -507,7 +507,7 @@ class ParseTree(object):
 	def count(self, text):
 		'''Returns the number of occurences of 'text' in this tree.'''
 		count = 0
-		for element in self._etree.getiterator():
+		for element in self._etree.iter():
 			if element.text:
 				count += element.text.count(text)
 			if element.tail:
@@ -520,7 +520,7 @@ class ParseTree(object):
 		in this tree.
 		'''
 		count = 0
-		for element in self._etree.getiterator():
+		for element in self._etree.iter():
 			if element.text:
 				newstring, n = regex.subn('', element.text)
 				count += n
@@ -540,7 +540,7 @@ class ParseTree(object):
 			elif element.tag in ('li', 'h'):
 				return True # implicit newline
 			else:
-				children = element.getchildren()
+				children = list(element)
 				if children:
 					return self._get_element_ends_with_newline(children[-1]) # recurs
 				elif element.text:
@@ -591,7 +591,7 @@ class ParseTree(object):
 		@param tag: tag name
 		@returns: yields L{Node} objects
 		'''
-		for elt in self._etree.getiterator(tag):
+		for elt in self._etree.iter(tag):
 			yield Element.new_from_etree(elt)
 
 	def replace(self, tag, func):
@@ -937,7 +937,7 @@ class OldParseTreeBuilder(object):
 		if len(self._stack) > 1 and not (
 			tag in (IMAGE, OBJECT, HEADDATA, TABLEDATA)
 			or (self._last.text and not self._last.text.isspace())
-			or self._last.getchildren()
+			or iter(self._last)
 		):
 			# purge empty tags
 			if self._last.text and self._last.text.isspace():
@@ -945,7 +945,7 @@ class OldParseTreeBuilder(object):
 
 			empty = self._stack.pop()
 			self._stack[-1].remove(empty)
-			children = self._stack[-1].getchildren()
+			children = list(self._stack[-1])
 			if children:
 				self._last = children[-1]
 				if not self._last.tail is None:
@@ -1058,7 +1058,7 @@ class OldParseTreeBuilder(object):
 	def _append_to_previous(self, text):
 		'''Add text before current element'''
 		parent = self._stack[-2]
-		children = parent.getchildren()[:-1]
+		children = list(parent)[:-1]
 		if children:
 			if children[-1].tail:
 				children[-1].tail = children[-1].tail + text

--- a/zim/gui/pageview.py
+++ b/zim/gui/pageview.py
@@ -839,7 +839,7 @@ class TextBuffer(Gtk.TextBuffer):
 				if not iter.starts_line():
 					self.insert_at_cursor('\n')
 
-		for element in node.getchildren():
+		for element in iter(node):
 			if element.tag in ('p', 'div'):
 				# No force line start here on purpose
 				if 'indent' in element.attrib:


### PR DESCRIPTION
Methods getchildren() and getiterator() of classes ElementTree and Element in
the ElementTree module have been deprecated since Python 3.2 and removed since
Python 3.9.

Fixes #1258

Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>