### PR TITLE
Fix reading preformatted text under Python 3.9

### DIFF
--- a/zim/formats/__init__.py
+++ b/zim/formats/__init__.py
@@ -822,7 +822,7 @@ class ParseTreeBuilder(Builder):
 		self._last_char = None
 
 	def append(self, tag, attrib=None, text=None):
-		attrib = attrib.copy() if attrib is not None else None
+		attrib = attrib.copy() if attrib is not None else {}
 		if tag in BLOCK_LEVEL:
 			if text and not text.endswith('\n'):
 				text += '\n'


### PR DESCRIPTION
This change is similar to feba6b2cf2b23c4c019a7bc770da44064cc6dd42 and fixes error described in https://github.com/zim-desktop-wiki/zim-desktop-wiki/issues/1212#issuecomment-694513278