### PR TITLE
Fix for copy/paste images between pages

### DIFF
--- a/zim/formats/__init__.py
+++ b/zim/formats/__init__.py
@@ -469,6 +469,16 @@ class ParseTree(object):
 				filepath = element.attrib['src']
 				element.attrib['_src_file'] = notebook.resolve_file(element.attrib['src'], path)
 
+	def relative_images(self, notebook=None, path=None):
+		'''Counterpart to resolve_images
+		'''
+		if notebook is not None:
+			for element in self._etree.iter('img'):
+				if '_src_file' in element.attrib:
+					filepath = element.attrib['_src_file']
+					element.attrib['src'] = notebook.relative_filepath(File(filepath), path)
+					element.attrib.pop('_src_file')
+
 	def unresolve_images(self):
 		'''Undo effect of L{resolve_images()}, mainly intended for
 		testing.

--- a/zim/gui/clipboard.py
+++ b/zim/gui/clipboard.py
@@ -223,7 +223,9 @@ def parsetree_from_selectiondata(selectiondata, notebook=None, path=None):
 
 	targetname = selectiondata.get_target().name()
 	if targetname == PARSETREE_TARGET_NAME:
-		return ParseTree().fromstring(selectiondata.get_data())
+		tree = ParseTree().fromstring(selectiondata.get_data())
+		tree.relative_images(notebook, path)
+		return tree
 	elif targetname in (INTERNAL_PAGELIST_TARGET_NAME, PAGELIST_TARGET_NAME) \
 	or targetname in URI_TARGET_NAMES:
 		links = selectiondata.get_uris()
@@ -543,6 +545,7 @@ class ClipboardManager(object):
 		@param parsetree: the actual L{ParseTree} to be set on the clipboard
 		@keyword format: the format to use for pasting text, e.g. 'wiki' or 'plain'
 		'''
+		parsetree.resolve_images(notebook, path)
 		self.set_clipboard_data(
 			ParseTreeData(notebook, path, parsetree, format) )
 


### PR DESCRIPTION
Copying/pasting image links between pages doesn't work when pages belong to different branches or depth levels of notebook hierarchy. Relative links to images are transferred verbatim without proper resolution.

Here is the fix to the problem.