### PR TITLE
Fixes to TableOfContents plugin

### DIFF
--- a/zim/plugins/tableofcontents.py
+++ b/zim/plugins/tableofcontents.py
@@ -541,7 +541,7 @@ class FloatingToC(Gtk.VBox, ConnectorMixin):
 			handler=DelayedCallback(10, self.update_size_and_position),
 				# Callback wrapper to prevent glitches for fast resizing of the window
 		)
-		self.connectto(self.tocwidget, 'changed', handler=self.update_size_and_position)
+		self.connectto(self.tocwidget, 'changed', handler=self.update_size_and_position_after_change)
 
 		self._event_box.show_all()
 
@@ -560,6 +560,10 @@ class FloatingToC(Gtk.VBox, ConnectorMixin):
 		self.tocwidget.set_visible(
 			not self.tocwidget.get_visible()
 		)
+		self.update_size_and_position()
+
+	def update_size_and_position_after_change(self, *a):
+		self.tocwidget.treeview.expand_all()
 		self.update_size_and_position()
 
 	def update_size_and_position(self, *a):

--- a/zim/plugins/tableofcontents.py
+++ b/zim/plugins/tableofcontents.py
@@ -324,7 +324,8 @@ class ToCWidget(ConnectorMixin, Gtk.ScrolledWindow):
 		if tree is None:
 			model.clear()
 		else:
-			model.update(get_headings(tree, self.include_hr), self.show_h1)
+			if model is not None:
+				model.update(get_headings(tree, self.include_hr), self.show_h1)
 		self.emit('changed')
 
 	def on_heading_activated(self, treeview, path, column):


### PR DESCRIPTION
These commits make small fixes to ToC plugin:

1. Elimination of annoying exception polluting the log each time new page is opened. Actually it seems more like a workaround as tree data model is set only once at widget construction time and theoretically should never become None, Maybe clearing the model is implemented as setting it to None or something.
2. Fix incorrect sizing of ToC in floating mode. When complex page gets loaded (by complex I mean - more than 3 headings inside) ToC treeview fails to recompute it's preferred size in sync with tree data model changes. That leads to shortened ToC (it may be made to recompute size by hand by minimize/maximize window or clip by another windows etc). Commit fixes this by forcing all tree entries to expand via TreeView method call, so this is more of workaround too. I suspect that's more of Gtk+ issue when somehow TreeView and TreeModel get out of sync during model manipulations but actually I won't to dive in that muddy waters.