### PR TITLE
Add menu item to attachment browser to copy path to clipboard

### DIFF
--- a/zim/gui/applications.py
+++ b/zim/gui/applications.py
@@ -489,6 +489,24 @@ def open_file(widget, file, mimetype=None, callback=None):
 		_open_with_filebrowser(widget, file, callback)
 
 
+def test_folder_prompt_create(widget, folder):
+	'''Test if a folder exists, and prompt to create it if it doesn't exist yet.
+	@param widget: parent for new dialogs, C{Gtk.Widget} or C{None}
+	@param folder: a L{Folder} object
+	@returns: True if the folder already exists or has been created, false otherwise
+	'''
+
+	if not folder.exists():
+            if QuestionDialog(widget, (
+                    _('Create folder?'),
+                            # T: Heading in a question dialog for creating a folder
+                    _('The folder "%s" does not yet exist.\nDo you want to create it now?') % folder.basename
+                            # T: Text in a question dialog for creating a folder, %s will be the folder base name
+            )).run():
+                    folder.touch()
+
+	return folder.exists()
+
 def open_folder_prompt_create(widget, folder):
 	'''Open a folder and prompts to create it if it doesn't exist yet.
 	@param widget: parent for new dialogs, C{Gtk.Widget} or C{None}

--- a/zim/plugins/attachmentbrowser/__init__.py
+++ b/zim/plugins/attachmentbrowser/__init__.py
@@ -206,8 +206,8 @@ class AttachmentBrowserPluginWidget(Gtk.HBox, WindowSidePaneWidget):
 		self.update_title()
 
 	def on_copy_path_button(self):
-            if test_folder_prompt_create(self, self.iconview.folder):
-                    Clipboard.set_text(self.iconview.folder.path)
+		if test_folder_prompt_create(self, self.iconview.folder):
+			Clipboard.set_text(self.iconview.folder.path)
 
 	def on_zoom_in(self):
 		self.set_icon_size(

--- a/zim/plugins/attachmentbrowser/__init__.py
+++ b/zim/plugins/attachmentbrowser/__init__.py
@@ -45,7 +45,7 @@ from zim.plugins import PluginClass
 from zim.actions import toggle_action
 
 from zim.gui.pageview import PageViewExtension
-from zim.gui.applications import open_folder_prompt_create
+from zim.gui.applications import open_folder_prompt_create, test_folder_prompt_create
 from zim.gui.clipboard import Clipboard
 
 from zim.gui.widgets import BOTTOM_PANE, PANE_POSITIONS, \
@@ -206,7 +206,8 @@ class AttachmentBrowserPluginWidget(Gtk.HBox, WindowSidePaneWidget):
 		self.update_title()
 
 	def on_copy_path_button(self):
-		Clipboard.set_text(self.iconview.folder.path)
+            if test_folder_prompt_create(self, self.iconview.folder):
+                    Clipboard.set_text(self.iconview.folder.path)
 
 	def on_zoom_in(self):
 		self.set_icon_size(

--- a/zim/plugins/attachmentbrowser/__init__.py
+++ b/zim/plugins/attachmentbrowser/__init__.py
@@ -46,6 +46,7 @@ from zim.actions import toggle_action
 
 from zim.gui.pageview import PageViewExtension
 from zim.gui.applications import open_folder_prompt_create
+from zim.gui.clipboard import Clipboard
 
 from zim.gui.widgets import BOTTOM_PANE, PANE_POSITIONS, \
 	IconButton, ScrolledWindow, \
@@ -154,6 +155,10 @@ class AttachmentBrowserPluginWidget(Gtk.HBox, WindowSidePaneWidget):
 		refresh_button.connect('clicked', lambda o: self.on_refresh_button())
 		self.buttonbox.pack_start(refresh_button, False, True, 0)
 
+		copy_path_button = IconButton(Gtk.STOCK_COPY, relief=False)
+		copy_path_button.connect('clicked', lambda o: self.on_copy_path_button())
+		self.buttonbox.pack_start(copy_path_button, False, True, 0)
+
 		zoomin = IconButton(Gtk.STOCK_ZOOM_IN, relief=False)
 		zoomout = IconButton(Gtk.STOCK_ZOOM_OUT, relief=False)
 		zoomin.connect('clicked', lambda o: self.on_zoom_in())
@@ -199,6 +204,9 @@ class AttachmentBrowserPluginWidget(Gtk.HBox, WindowSidePaneWidget):
 	def on_refresh_button(self):
 		self.iconview.refresh()
 		self.update_title()
+
+	def on_copy_path_button(self):
+		Clipboard.set_text(self.iconview.folder.path)
 
 	def on_zoom_in(self):
 		self.set_icon_size(


### PR DESCRIPTION
Implement a copy path button in the attachment browser, see issue #1347