### PR TITLE
souceblock: Feature - add highlightjs compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ ENV/
 # debian pybuild
 .pybuild/
 debian/python-module-stampdir/
+
+# IDEs, editors
+.idea/
+.vscode/

--- a/tests/sourceview.py
+++ b/tests/sourceview.py
@@ -135,6 +135,10 @@ class TestSourceViewObject(tests.TestCase):
 		item.activate()
 		self.assertEqual(widget.buffer.get_language().get_name(), 'Python')
 
+		item = tests.gtk_get_menu_item(menu, _('Use highlightjs classes'))
+		item.activate()
+		self.assertEqual(widget.buffer.get_use_highlightjs(), True)
+
 	def testDumpHtml(self):
 		xml = '''\
 <?xml version='1.0' encoding='utf-8'?>
@@ -149,5 +153,23 @@ def foo(a, b):
 		#print('>>', html)
 		self.assertIn(
 			'<pre><code class="python">\ndef foo(a, b):\n\tprint "FOO", a &gt;= b\n\n</code></pre>',
+			''.join(html)
+		)
+
+	def testDumpHtml_WithHighlightClasses(self):
+		xml = '''\
+<?xml version='1.0' encoding='utf-8'?>
+<zim-tree><object lang="c-sharp" linenumbers="false" use_highlightjs="true" type="code">
+		public void AddContact(T contact)
+		{
+			Contacts.Add(contact);
+		}
+</object></zim-tree>'''
+		tree = ParseTree().fromstring(xml)
+		dumper = HtmlDumper(StubLinker())
+		html = dumper.dump(tree)
+		#print('>>', html)
+		self.assertIn(
+			'<div class="zim-object">\n<pre><code class="csharp">\n\t\tpublic void AddContact(T contact)\n\t\t{\n\t\t\tContacts.Add(contact);\n\t\t}\n</code></pre>\n</div>\n',
 			''.join(html)
 		)


### PR DESCRIPTION
I wanted to implement code highlightning so after checking the codebase I found that at some point there was an attempt to provide compatibility with highlight.js as an alternative for class generation on the html code blocks so the formatter can pick them. The decoupling between the template engine and the plugin itself makes this difficult to implement it in one pass because having highlighted blocks requires specific codes in the </head> section of the implementers only (namely, the highlight.js imports and load code)

Also, another issue (which is solved in the PR) is the mapping between the GTKSource and highlightjs language ids. An intermediate mapping is done between both to solve this

In this PR I propose the following

- Add a checkbox to decide whether to use highlight.js classes on the HTML generated code or not
- Add a mapping GTKSource and highlightjs language ids to solve the internal inconsistencies

#### Open questions / TODOs 

- Since the template has to explicitly have the link refs, does this call for a fork of ZeroFiveEight with said functionality as a default template or is there another (cleaner) solution?
- Can we default to plaintext for HTML generation if no highlighting is selected? to my understanding there is no code formatter that uses the GTK ids, although the correct matches may be several for common language ids like c and javascript

For a live demo you can see the following:
- https://lggomez.github.io/Software_Development/Misc/Test.html
- Fork of ZeroFiveEight with the relevant changes: https://github.com/lggomez/zim-templates-gh/blob/main/templates/html/ZeroFiveEight_luisgg.html#L13-L24