### PR TITLE
Added new context menu entries in attachmentbrowser for renaming and deleting files

### DIFF
--- a/zim/plugins/attachmentbrowser/__init__.py
+++ b/zim/plugins/attachmentbrowser/__init__.py
@@ -7,6 +7,7 @@
 # !! NOTE: when changing this plugin, do test performance on a folder with lots of photos!
 #
 # ChangeLog
+# 2021-01-16 Added rename and delete functionality to file browsers context menu (Thomas Engel)
 # 2015-10-04 Reworked threads to better avoid blocking user interface (Jaap)
 # 2013-03-03 Change to new plugin extension structure (Jaap)
 # 2013-02-25 Added zooming icon size, made icon rendering more robust (Jaap)
@@ -26,7 +27,6 @@
 # 2010-06-29 1st working version
 #
 # TODO:
-# [ ] Action for deleting files in context menu
 # [ ] Copy / cut files in context menu
 # [ ] Button to clean up the folder - only show when the folder is empty
 # [ ] Avoid scaling up small images when thumbnailing (check spec on this)
@@ -71,7 +71,9 @@ class AttachmentBrowserPlugin(PluginClass):
 This plugin shows the attachments folder of the current page as an
 icon view at bottom pane.
 '''), # T: plugin description
-		'author': 'Thorsten Hackbarth <thorsten.hackbarth@gmx.de>\nJaap Karssenberg <jaap.karssenberg@gmail.com>',
+		'author': 'Thorsten Hackbarth <thorsten.hackbarth@gmx.de>\n'
+			      'Jaap Karssenberg <jaap.karssenberg@gmail.com>\n'
+				  'Thomas Engel <realdatenwurm@gmail.com>',
 		'help': 'Plugins:Attachment Browser',
 	}
 

--- a/zim/plugins/attachmentbrowser/filebrowser.py
+++ b/zim/plugins/attachmentbrowser/filebrowser.py
@@ -8,6 +8,8 @@
 #
 
 import datetime
+import os
+import ntpath
 
 from gi.repository import Gtk
 from gi.repository import GObject
@@ -22,10 +24,10 @@ logger = logging.getLogger('zim.plugins.attachmentbrowser')
 from zim.newfs import LocalFile, FileNotFoundError
 from zim.newfs.helpers import format_file_size, FSObjectMonitor
 
-from zim.gui.widgets import gtk_popup_at_pointer
+from zim.gui.widgets import gtk_popup_at_pointer, QuestionDialog
 
 from zim.gui.applications import get_mime_icon, get_mime_description, \
-	OpenWithMenu, open_file
+	OpenWithMenu, open_file, adapt_from_newfs, File, Dir
 
 from zim.gui.clipboard import \
 	URI_TARGETS, URI_TARGET_NAMES, \
@@ -35,9 +37,57 @@ from zim.gui.clipboard import \
 from .thumbnailer import ThumbnailQueue, ThumbnailManager, \
 	THUMB_SIZE_NORMAL, THUMB_SIZE_LARGE
 
+from .filerenamedialog import FileRenameDialog
 
 MIN_THUMB_SIZE = 64 # don't render thumbs when icon size is smaller than this
 MAX_ICON_SIZE = 128 # never render icons larger than this - thumbs go up
+
+
+def path_leaf(path):
+	""" Returns the real name of the file without the path. """
+	head, tail = ntpath.split(path)
+	return tail or ntpath.basename(head)
+
+
+def delete_file(widget, file):
+	'''Delete a file
+
+	@param widget: parent for new dialogs, C{Gtk.Widget} or C{None}
+	@param file: a L{File} object
+
+	@raises FileNotFoundError: if C{file} does not exist
+	'''
+	logger.debug('delete_file(%s)', file)
+	file = adapt_from_newfs(file)
+	assert isinstance(file, File) and not isinstance(file, Dir)
+
+	if not file.exists():
+		raise FileNotFoundError(file)
+
+	dialog = QuestionDialog(widget, _('Are you sure you want to delete the file \'%s\'?') % path_leaf(file.path))
+	if dialog.run():
+		file.remove()
+
+
+def rename_file(widget, file):
+	'''Rename a file
+
+	@param widget: parent for new dialogs, C{Gtk.Widget} or C{None}
+	@param file: a L{File} object
+
+	@raises FileNotFoundError: if C{file} does not exist
+	'''
+	logger.debug('rename_file(%s)', file)
+	file = adapt_from_newfs(file)
+	assert isinstance(file, File) and not isinstance(file, Dir)
+
+	if not file.exists():
+		raise FileNotFoundError(file)
+
+	dialog = FileRenameDialog(widget, file.path)
+	if dialog.run() == Gtk.ResponseType.OK:
+		if file.path != dialog.new_filename:
+			os.rename(file.path, dialog.new_filename)
 
 
 def render_file_icon(widget, size):
@@ -332,9 +382,9 @@ class FileBrowserIconView(Gtk.IconView):
 			pathinfo = iconview.get_path_at_pos(x, y)
 			if pathinfo is not None:
 				iconview.grab_focus()
-				gtk_popup_at_pointer(popup_menu, event)
 				self.do_populate_popup(popup_menu, pathinfo)
 					# FIXME should use a signal here
+				gtk_popup_at_pointer(popup_menu, event)
 				return True
 		return False
 
@@ -343,6 +393,14 @@ class FileBrowserIconView(Gtk.IconView):
 		store = self.get_model()
 		iter = store.get_iter(pathinfo)
 		file = self.folder.file(store[iter][BASENAME_COL])
+
+		item = Gtk.MenuItem.new_with_mnemonic(_('_Delete...')) # T: menu item to delete file
+		item.connect('activate', lambda o: delete_file(self, file))
+		menu.prepend(item)
+
+		item = Gtk.MenuItem.new_with_mnemonic(_('_Rename...')) # T: menu item to rename file
+		item.connect('activate', lambda o: rename_file(self, file))
+		menu.prepend(item)
 
 		item = Gtk.MenuItem.new_with_mnemonic(_('Open With...')) # T: menu item
 		menu.prepend(item)

--- a/zim/plugins/attachmentbrowser/filerenamedialog.py
+++ b/zim/plugins/attachmentbrowser/filerenamedialog.py
@@ -1,0 +1,89 @@
+import ntpath
+import os
+import pathlib
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
+from zim.gui.widgets import Dialog
+
+
+def path_leaf(path):
+    """ Returns the real name of the file without the path. """
+    head, tail = ntpath.split(path)
+    return tail or ntpath.basename(head)
+
+
+class FileRenameDialog(Dialog):
+    """ A dialog for renaming a file. """
+
+    def __init__(self, parent, file):
+        title = _('Rename file')
+        Dialog.__init__(self, parent, title)
+
+        assert os.path.isfile(file)
+        self.original_filename = path_leaf(file)
+        self.original_filepath = pathlib.Path(file).parent.absolute()
+        self.new_filename = file
+
+        # Add field for entering new filename.
+        self.txt_filename = Gtk.Entry()
+        self.txt_filename.set_text(self.original_filename)
+        self.txt_filename.set_activates_default(True)  # Make ENTER key press trigger the OK button.
+        self.txt_filename.connect("changed", self.do_validate, parent)
+
+        # Add field for showing hints when an error occurs (e.g. filename already exists).
+        self.txt_error = Gtk.Label()
+        self.txt_error.set_visible(False)
+
+        # Add ok button.
+        self.btn_ok = self.get_widget_for_response(response_id=Gtk.ResponseType.OK)
+        self.btn_ok.set_can_default(True)
+        self.btn_ok.grab_default()
+        self.btn_ok.set_sensitive(False)
+
+        # Configure dialog.
+        self.set_modal(True)
+        self.set_default_size(380, 100)
+        self.vbox.pack_start(self.txt_filename, False, True, 0)
+        self.vbox.pack_start(self.txt_error, False, True, 0)
+
+        # Set focus to search field
+        self.txt_filename.grab_focus()
+
+    def do_validate(self, entry, data):
+        """ Validating new file name, show error when validation fails and enable/disable ok button. """
+
+        def is_filename(filename):
+            """ Returns True when filename does not contain any path. """
+            return filename == path_leaf(filename)
+
+        def does_file_already_exist(filename):
+            """ Checks whether the new filename is already taken (note, the initial filename is allowed). """
+            return os.path.isfile(os.path.join(self.original_filepath, filename))
+
+        def show_error(text):
+            """ Displays an error and disables the OK button. """
+            self.txt_error.set_text(text)
+            self.txt_error.set_visible(True)
+            self.btn_ok.set_sensitive(False)
+            return False
+
+        if not self.txt_filename.get_text():
+            return show_error(_('File name should not be blank.'))
+
+        if not is_filename(self.txt_filename.get_text()):
+            return show_error(_('File name should not contain path declaration.'))
+
+        if does_file_already_exist(self.txt_filename.get_text()):
+            return show_error(_('A file with that name already exists.'))
+
+        # No errors, hide error label and enable OK button.
+        self.txt_error.hide()
+        self.btn_ok.set_sensitive(True)
+
+    def do_response_ok(self):
+        self.new_filename = os.path.join(self.original_filepath, self.txt_filename.get_text())
+        self.result = Gtk.ResponseType.OK
+        self.close()

--- a/zim/plugins/attachmentbrowser/filerenamedialog.py
+++ b/zim/plugins/attachmentbrowser/filerenamedialog.py
@@ -3,87 +3,83 @@ import os
 import pathlib
 
 import gi
+
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
-from zim.gui.widgets import Dialog
-
-
-def path_leaf(path):
-    """ Returns the real name of the file without the path. """
-    head, tail = ntpath.split(path)
-    return tail or ntpath.basename(head)
+from zim.gui.widgets import Dialog, InputEntry
+from zim.newfs import localFileOrFolder, LocalFile, LocalFolder
 
 
 class FileRenameDialog(Dialog):
-    """ A dialog for renaming a file. """
+	""" A dialog for renaming a file. """
 
-    def __init__(self, parent, file):
-        title = _('Rename file')
-        Dialog.__init__(self, parent, title)
+	def __init__(self, parent, file):
+		title = _('Rename file')
+		Dialog.__init__(self, parent, title)
 
-        assert os.path.isfile(file)
-        self.original_filename = path_leaf(file)
-        self.original_filepath = pathlib.Path(file).parent.absolute()
-        self.new_filename = file
+		assert isinstance(file, LocalFile) and not isinstance(file, LocalFolder)
+		self.old_file = file
+		self.new_file = file
 
-        # Add field for entering new filename.
-        self.txt_filename = Gtk.Entry()
-        self.txt_filename.set_text(self.original_filename)
-        self.txt_filename.set_activates_default(True)  # Make ENTER key press trigger the OK button.
-        self.txt_filename.connect("changed", self.do_validate, parent)
+		# Add field for entering new filename.
+		self.txt_filename = InputEntry()
+		self.txt_filename.set_text(self.old_file.basename)
+		self.txt_filename.set_activates_default(True)  # Make ENTER key press trigger the OK button.
+		self.txt_filename.connect("changed", self.do_validate, parent)
 
-        # Add field for showing hints when an error occurs (e.g. filename already exists).
-        self.txt_error = Gtk.Label()
-        self.txt_error.set_visible(False)
+		# Add field for showing hints when an error occurs (e.g. filename already exists).
+		self.txt_error = Gtk.Label()
+		self.txt_error.set_visible(False)
 
-        # Add ok button.
-        self.btn_ok = self.get_widget_for_response(response_id=Gtk.ResponseType.OK)
-        self.btn_ok.set_can_default(True)
-        self.btn_ok.grab_default()
-        self.btn_ok.set_sensitive(False)
+		# Add ok button.
+		self.btn_ok = self.get_widget_for_response(response_id=Gtk.ResponseType.OK)
+		self.btn_ok.set_can_default(True)
+		self.btn_ok.grab_default()
+		self.btn_ok.set_sensitive(False)
 
-        # Configure dialog.
-        self.set_modal(True)
-        self.set_default_size(380, 100)
-        self.vbox.pack_start(self.txt_filename, False, True, 0)
-        self.vbox.pack_start(self.txt_error, False, True, 0)
+		# Configure dialog.
+		self.set_modal(True)
+		self.set_default_size(380, 100)
+		self.vbox.pack_start(self.txt_filename, False, True, 0)
+		self.vbox.pack_start(self.txt_error, False, True, 0)
 
-        # Set focus to search field
-        self.txt_filename.grab_focus()
+		# Set focus to search field
+		self.txt_filename.grab_focus()
 
-    def do_validate(self, entry, data):
-        """ Validating new file name, show error when validation fails and enable/disable ok button. """
+	def do_validate(self, widget, data):
+		""" Validating new file name, show error when validation fails and enable/disable ok button. """
 
-        def is_filename(filename):
-            """ Returns True when filename does not contain any path. """
-            return filename == path_leaf(filename)
+		def is_filename(filename):
+			""" Returns True when filename does not contain any path declaration. """
+			return filename == os.path.basename(filename)
 
-        def does_file_already_exist(filename):
-            """ Checks whether the new filename is already taken (note, the initial filename is allowed). """
-            return os.path.isfile(os.path.join(self.original_filepath, filename))
+		def does_file_already_exist(filename):
+			""" Checks whether the new filename is already taken. """
+			return self.old_file.parent().file(filename).exists()
 
-        def show_error(text):
-            """ Displays an error and disables the OK button. """
-            self.txt_error.set_text(text)
-            self.txt_error.set_visible(True)
-            self.btn_ok.set_sensitive(False)
-            return False
+		def show_error(msg):
+			""" Displays an error and disables the OK button. """
+			self.txt_error.set_text(msg)
+			self.txt_error.set_visible(True)
+			self.btn_ok.set_sensitive(False)
+			return False
 
-        if not self.txt_filename.get_text():
-            return show_error(_('File name should not be blank.'))
+		if not widget.get_text():
+			return show_error(_('File name should not be blank.'))
 
-        if not is_filename(self.txt_filename.get_text()):
-            return show_error(_('File name should not contain path declaration.'))
+		if does_file_already_exist(widget.get_text()):
+			return show_error(_('A file with that name already exists.'))
 
-        if does_file_already_exist(self.txt_filename.get_text()):
-            return show_error(_('A file with that name already exists.'))
+		if not is_filename(widget.get_text()):
+			return show_error(_('File name should not contain path declaration.'))
 
-        # No errors, hide error label and enable OK button.
-        self.txt_error.hide()
-        self.btn_ok.set_sensitive(True)
+		# No errors, hide error label and enable OK button.
+		self.txt_error.hide()
+		self.btn_ok.set_sensitive(True)
+		return True
 
-    def do_response_ok(self):
-        self.new_filename = os.path.join(self.original_filepath, self.txt_filename.get_text())
-        self.result = Gtk.ResponseType.OK
-        self.close()
+	def do_response_ok(self):
+		self.new_file = self.old_file.parent().file(self.txt_filename.get_text())
+		self.result = Gtk.ResponseType.OK
+		self.close()


### PR DESCRIPTION
Adds two new context menu entries in attachmentbrowser for renaming and deleting files.

![unnamed](https://user-images.githubusercontent.com/41708465/104853598-39d50300-5902-11eb-8380-32ab6afab6ac.png)

## Rename
The rename context menu entry will open a dialog in which a new name can be entered. 

There are a few validation rules in place so not any arbitrary name can be choosen:
* new name should not be empty
* new name should not already exist
* new name should not contain any path information

When validation fails the error is shown in the dialog.

![image](https://user-images.githubusercontent.com/41708465/104853568-05614700-5902-11eb-9418-f8ff55734ef7.png)

## Delete
When clicking the delete context menu entry a confirmation dialog is shown. Since it is not always clear which file is actually selected, the name of the file is shown. 

![image](https://user-images.githubusercontent.com/41708465/104853637-799bea80-5902-11eb-8aaa-06f3b8dcf1ba.png)
