### PR TITLE
fix(tableeditor): multiline text in table cell

### DIFF
--- a/tests/tableeditor.py
+++ b/tests/tableeditor.py
@@ -34,7 +34,7 @@ TABLE_WIKI_TEXT = '''\
 |        H1       <|         H2 h2 | H3                    <|
 |:----------------:|--------------:|:-----------------------|
 |    Column A1     |     Column A2 | a \\\\name               |
-| a very long cell | **bold text** | two\\nlines             |
+| a very long cell | **bold text** | two<br/>lines          |
 |    hyperlinks    |   [[wp?wiki]] | [[http://x.org\|Xorg]] |
 
 '''
@@ -64,7 +64,7 @@ TABLE_TOKENS = [
 			('trow', {}),
 				('td', {}), ('T', 'a very long cell'), ('/', 'td'),
 				('td', {}), ('strong', {}), ('T', 'bold text'), ('/', 'strong'), ('/', 'td'),
-				('td', {}), ('T', 'two\n'), ('T', 'lines'), ('/', 'td'),
+				('td', {}), ('T', 'two<br/>lines'), ('/', 'td'),
 			('/', 'trow'),
 			('trow', {}),
 				('td', {}), ('T', 'hyperlinks'), ('/', 'td'),

--- a/zim/formats/__init__.py
+++ b/zim/formats/__init__.py
@@ -131,6 +131,7 @@ VERBATIM = 'code'
 STRIKE = 'strike'
 SUBSCRIPT = 'sub'
 SUPERSCRIPT = 'sup'
+LINE_RETURN = 'br'
 
 LINK = 'link'
 TAG = 'tag'

--- a/zim/formats/html.py
+++ b/zim/formats/html.py
@@ -47,6 +47,7 @@ class Dumper(DumperClass):
 		TAG: ('<span class="zim-tag">', '</span>'),
 		SUBSCRIPT: ('<sub>', '</sub>'),
 		SUPERSCRIPT: ('<sup>', '</sup>'),
+		LINE_RETURN: ('', ''), # TODO
 
 	}
 

--- a/zim/formats/latex.py
+++ b/zim/formats/latex.py
@@ -87,6 +87,7 @@ class Dumper(TextDumper):
 		TAG: ('', ''), # No additional annotation (apart from the visible @)
 		SUBSCRIPT: ('$_{', '}$'),
 		SUPERSCRIPT: ('$^{', '}$'),
+		LINE_RETURN: ('\\linebreak', ''), # TODO
 	}
 
 	TEMPLATE_OPTIONS = {

--- a/zim/formats/markdown.py
+++ b/zim/formats/markdown.py
@@ -52,6 +52,7 @@ class Dumper(TextDumper):
 		TAG: ('', ''), # No additional annotation (apart from the visible @)
 		SUBSCRIPT: ('~', '~'),
 		SUPERSCRIPT: ('^', '^'),
+		LINE_RETURN: ('', ''), # TODO
 	}
 
 	def dump(self, tree):

--- a/zim/formats/plain.py
+++ b/zim/formats/plain.py
@@ -81,6 +81,7 @@ class Dumper(DumperClass):
 		TAG: ('', ''),
 		SUBSCRIPT: ('', ''),
 		SUPERSCRIPT: ('', ''),
+		LINE_RETURN: ('', ''),
 	}
 
 	def dump_indent(self, tag, attrib, strings):

--- a/zim/formats/rst.py
+++ b/zim/formats/rst.py
@@ -40,6 +40,7 @@ class Dumper(TextDumper):
 		TAG: ('', ''), # No additional annotation (apart from the visible @)
 		SUBSCRIPT: ('\\ :sub:`', '`\\ '),
 		SUPERSCRIPT: ('\\ :sup:`', '`\\ '),
+		LINE_RETURN: ('', ''), # TODO
 	}
 	# TODO tags other than :sub: and :sup: may also need surrounding whitespace, deal with this in post process (join) action ?
 	# IDEM for blocks like images and objects, how to enforce empty lines and how to deal with inline images..

--- a/zim/formats/wiki.py
+++ b/zim/formats/wiki.py
@@ -670,6 +670,7 @@ class Dumper(TextDumper):
 		TAG: ('', ''), # No additional annotation (apart from the visible @)
 		SUBSCRIPT: ('_{', '}'),
 		SUPERSCRIPT: ('^{', '}'),
+		LINE_RETURN: ('', ''), # TODO
 	}
 
 	def dump(self, tree, file_output=False):

--- a/zim/plugins/tableeditor.py
+++ b/zim/plugins/tableeditor.py
@@ -45,7 +45,8 @@ SYNTAX_WIKI_PANGO2 = [
 	(r'<link href="\1">\1</link>', r'<span foreground="blue">\1<span size="0">\1</span></span>', r'[[\1]]'),
 	# Link url with link text  - Link url has always size = 0
 	(r'<link href="\1">\2</link>', r'<span foreground="blue">\2<span size="0">\1</span></span>', r'[[\2|\1]]'),
-	(r'<emphasis>\1</emphasis>', r'<i>\1</i>', r'//\1//')
+	(r'<emphasis>\1</emphasis>', r'<i>\1</i>', r'//\1//'),
+	(r'\\n', r'\n', r'\\n'),
 ]
 
 # Possible alignments in edit-table-dialog


### PR DESCRIPTION
Fix issue #953 : now, zim detects line return on table cell. `\n` is used in cell value to handle multiline