### PR TITLE
Make test suite run in Fedora build environment

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -118,7 +118,8 @@ def _setUpEnvironment():
 		'TEST_XDG_DATA_DIRS': os.path.join(TMPDIR, 'data_dir'),
 		'XDG_CONFIG_HOME': os.path.join(TMPDIR, 'config_home'),
 		'XDG_CONFIG_DIRS': os.path.join(TMPDIR, 'config_dir'),
-		'XDG_CACHE_HOME': os.path.join(TMPDIR, 'cache_home')
+		'XDG_CACHE_HOME': os.path.join(TMPDIR, 'cache_home'),
+		'XDG_RUNTIME_DIR': os.path.join(TMPDIR, 'runtime')
 	})
 
 	if os.path.isdir(TMPDIR):

--- a/tests/newfs.py
+++ b/tests/newfs.py
@@ -104,7 +104,8 @@ class TestFilePath(tests.TestCase):
 
 		# Test home folder fallback
 		f = FilePath('~non-existing-user/foo')
-		self.assertEqual(f.path, P('/'.join((HOME.dirname, 'non-existing-user', 'foo'))))
+		homedirname = HOME.dirname or '' # Build environments may have HOME set as e.g. '/builddir'
+		self.assertEqual(f.path, P('/'.join((homedirname, 'non-existing-user', 'foo'))))
 
 
 	def testShareDrivePath(self):
@@ -179,7 +180,9 @@ class TestFilePath(tests.TestCase):
 			self.assertEqual(f.get_abspath(p).path, want)
 
 	def testUserpath(self):
-		self.assertTrue(len(HOME.pathnames) >= 2)
+		# Not always true, e.g. a build environment may have home set to
+		# /builddir.
+		#self.assertTrue(len(HOME.pathnames) >= 2)
 
 		f = FilePath('~/foo')
 		self.assertEqual(f.path, HOME.get_childpath('foo').path)

--- a/tests/uiactions.py
+++ b/tests/uiactions.py
@@ -22,6 +22,10 @@ import zim.gui
 
 from zim.gui.uiactions import UIActions, PAGE_EDIT_ACTIONS
 
+def strip_file_url_prefix(str):
+	if str.startswith('file://'): return str[7:]
+	return str
+
 
 class EmptyWindowObject(object):
 	# Any other method than get_toplevel() should raise to prevent
@@ -853,7 +857,7 @@ class TestUIActionsRealFile(tests.TestCase):
 		folder.touch()
 
 		def open_folder(cmd):
-			self.assertEqual(cmd[-1], folder.path)
+			self.assertEqual(strip_file_url_prefix(cmd[-1]), folder.path)
 
 		with tests.ApplicationContext(open_folder):
 			with tests.DialogContext():
@@ -867,7 +871,7 @@ class TestUIActionsRealFile(tests.TestCase):
 			dialog.answer_yes()
 
 		def open_folder(cmd):
-			self.assertEqual(cmd[-1], folder.path)
+			self.assertEqual(strip_file_url_prefix(cmd[-1]), folder.path)
 
 		with tests.ApplicationContext(open_folder):
 			with tests.DialogContext(create_folder):
@@ -875,7 +879,7 @@ class TestUIActionsRealFile(tests.TestCase):
 
 	def testOpenNotebookFolder(self):
 		def open_folder(cmd):
-			self.assertEqual(cmd[-1], self.notebook.folder.path)
+			self.assertEqual(strip_file_url_prefix(cmd[-1]), self.notebook.folder.path)
 
 		with tests.ApplicationContext(open_folder):
 			self.uiactions.open_notebook_folder()
@@ -886,7 +890,7 @@ class TestUIActionsRealFile(tests.TestCase):
 		self.notebook.document_root.touch()
 
 		def open_folder(cmd):
-			self.assertEqual(cmd[-1], self.notebook.document_root.path)
+			self.assertEqual(strip_file_url_prefix(cmd[-1]), self.notebook.document_root.path)
 
 		with tests.ApplicationContext(open_folder):
 			with tests.DialogContext():


### PR DESCRIPTION
Changes to the test suite that make it run successfully in Fedora build environment. The changes are not specific to Fedora, they may help getting the tests run in other build environments as well.

Issues fixed:
1. Do not expect home directory to be of format `/home/user` - it can also be a single path directory like `/builddir`.
2. Specify `XDG_RUNTIME_DIR` environment variable during test initialization. It is not always set in headless environments.
3. Allow addition of `file://`prefix to filenames in some `uiactions` tests, because Zim does this when the files are opened with the embedded WebBrowser application. This happens in Fedora build environment, presumably because no applications for opening files have been defined there. (I admit I do not understand the prefix adding part here - I had to simply assume it is correct behaviour and not a bug that only became visible in Fedora build environment.)

Fixes #814 - I have successfully done a scratch build in Koji using these fixes.