### PR TITLE
Fix formatting issues with pre-formatted text

### DIFF
--- a/tests/insertsymbol.py
+++ b/tests/insertsymbol.py
@@ -63,6 +63,14 @@ class TestInsertSymbolPlugin(tests.TestCase):
 		text = start.get_text(end)
 		self.assertEqual(text, r'\alpha ') # no replace
 
+		# no insert in code or pre section at end-of-line
+		buffer.clear()
+		pageview.toggle_format(VERBATIM)
+		press(textview, '\\alpha\n')
+		start, end = buffer.get_bounds()
+		text = start.get_text(end)
+		self.assertEqual(text, '\\alpha\n') # no replace
+
 		# test dialog
 		def check_dialog(dialog):
 			self.assertIsInstance(dialog, InsertSymbolDialog)

--- a/tests/pageview.py
+++ b/tests/pageview.py
@@ -2179,6 +2179,11 @@ class TestDoEndOfLine(tests.TestCase, TextBufferTestCaseMixin):
 		self.assertInsertNewLine('=== Foo', '<h level="2">Foo</h>\n')
 		self.assertInsertNewLine('=== Foo ===', '<h level="2">Foo</h>\n')
 
+	def testNoFormattingInsideCode(self):
+		# Make sure text inside code is not being formatted
+		self.assertInsertNewLine('<code>== Foo ==</code>', '<code>== Foo ==</code>\n')
+		self.assertInsertNewLine('<code>---</code>', '<code>---</code>\n')
+
 	def testFormatLine(self):
 		self.assertInsertNewLine('aaa\n-----', 'aaa\n<line>--------------------</line>\n')
 

--- a/zim/gui/pageview.py
+++ b/zim/gui/pageview.py
@@ -4076,10 +4076,7 @@ class TextView(Gtk.TextView):
 			start = iter.copy()
 			if buffer.iter_backward_word_start(start):
 				word = start.get_text(iter)
-				editmode = [t.zim_tag
-					for t in buffer._editmode_tags
-					if hasattr(t, 'zim_tag')
-				]
+				editmode = [t.zim_tag for t in buffer.iter_get_zim_tags(iter)]
 				self.emit('end-of-word', start, iter, word, char, editmode)
 
 			if keyval in KEYVALS_ENTER:
@@ -4488,11 +4485,17 @@ class TextView(Gtk.TextView):
 	def do_end_of_line(self, end):
 		# Default handler, takes care of cutting of formatting on the
 		# line end, set indenting and bullet items on the new line etc.
-		buffer = self.get_buffer()
 
 		if end.starts_line():
 			return # empty line
+
+		buffer = self.get_buffer()
+
 		start = buffer.get_iter_at_line(end.get_line())
+		if any(_is_pre_or_code_tag(t) for t in start.get_tags()):
+			logger.debug('pre-formatted code')
+			return # pre-formatted
+
 		line = start.get_text(end)
 		#~ print('LINE >>%s<<' % line)
 


### PR DESCRIPTION
This pull-request fixes issues where zim does modify pre-formatted text on end-of-line event processing.
This happens e.g. when having `== text ==` or `=/=` in a line with text style 'preformatted' and pressing enter key.
In both cases a unwanted conversion took place.