### PR TITLE
Update README for XDG paths when using Python virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Zim can be installed from source using:
 
     ./setup.py install
 
+If you are installing Zim from source in a Python virtual environment,
+you need to tell Zim where to load necessary data files by
+`export XDG_DATA_DIRS=<where-your-virtual-environment-root-folder-is>/share:$XDG_DATA_DIRS`.
+Please refer to the `Install Paths` section for more details about the XDG paths.
+
 Most plugins have additional requirements. These are listed in the plugin descriptions.
 
 ### Ubuntu


### PR DESCRIPTION
By explicitly elaborating the XDG path setup for people launching their
zim in a Python virtual environment, we will help them to launch their
zim easier without confusion.

Closes #1381