### PR TITLE
Fix shared config option (fixes #1049)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ ENV/
 # debian pybuild
 .pybuild/
 debian/python-module-stampdir/
+
+# PyCharm
+.idea

--- a/zim/notebook/notebook.py
+++ b/zim/notebook/notebook.py
@@ -88,7 +88,7 @@ def _iswritable(dir):
 		f = dir.file('.zim.tmp')
 		try:
 			f.write('Test')
-			f.remove(cleanup=False)
+			f.remove()
 		except:
 			return False
 		else:
@@ -242,6 +242,9 @@ class Notebook(ConnectorMixin, SignalEmitter):
 		shared = config['Notebook']['shared']
 
 		subdir = dir.subdir('.zim')
+		if not shared:
+			subdir.touch()
+
 		if not shared and subdir.exists() and _iswritable(subdir):
 			cache_dir = subdir
 		else:


### PR DESCRIPTION
This makes the "shared" config option describe in [https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/master/data/manual/Help/Config_Files.txt](https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/master/data/manual/Help/Config_Files.txt) work again when shared is set to false.

The `_iswritable` function always returned false since the call to `f.remove(cleanup=False)` failed because the function doesn't take any parameters. I also added code to create the .zim folder which the state and index file should be located in when shared is set to false.

I added an entry to the gitignore file for files associated with the PyCharm IDE which I use for development. I think it makes since to include it since it's a popular Python IDE.

Fixes #1049.