### PR TITLE
Add buttons to traverse through the Journal forwards and backwards

### DIFF
--- a/tests/applications.py
+++ b/tests/applications.py
@@ -272,7 +272,10 @@ class TestApplicationManager(tests.TestCase):
 	def testSupportDesktopMimeappsList(self):
 		orig_desktop = os.environ.get('XDG_CURRENT_DESKTOP')
 		def restore_desktop():
-			os.environ['XDG_CURRENT_DESKTOP'] = orig_desktop
+			if orig_desktop:
+				os.environ['XDG_CURRENT_DESKTOP'] = orig_desktop
+			else:
+				del os.environ['XDG_CURRENT_DESKTOP']
 		self.addCleanup(restore_desktop)
 
 		os.environ['XDG_CURRENT_DESKTOP'] = 'Test'

--- a/zim/plugins/journal.py
+++ b/zim/plugins/journal.py
@@ -27,6 +27,7 @@ from zim.gui.widgets import ScrolledWindow, \
 
 from zim.plugins.pageindex import PageTreeStore, PageTreeView
 
+from datetime import timedelta
 
 logger = logging.getLogger('zim.plugins.journal')
 
@@ -346,7 +347,16 @@ class CalendarWidget(Gtk.VBox, WindowSidePaneWidget):
 		button.add(self.label)
 		button.set_relief(Gtk.ReliefStyle.NONE)
 		button.connect('clicked', lambda b: self.go_today())
+
+		button1 = Gtk.Button()
+		self.label_box.add(button1)
+		button1.connect('clicked', lambda b: self.sub_day())
+
 		self.label_box.add(button)
+
+		button2 = Gtk.Button()
+		self.label_box.add(button2)
+		button2.connect('clicked', lambda b: self.add_day())
 
 		self._close_button = None
 
@@ -376,6 +386,18 @@ class CalendarWidget(Gtk.VBox, WindowSidePaneWidget):
 
 	def go_today(self):
 		self.calendar.select_date(datetime.date.today())
+		self.calendar.emit('activate')
+
+	def add_day(self):
+		day = self.calendar.get_date()
+		d = timedelta(days=1)
+		self.calendar.select_date(day+d)
+		self.calendar.emit('activate')
+
+	def sub_day(self):
+		day = self.calendar.get_date()
+		d = timedelta(days=-1)
+		self.calendar.select_date(day+d)
 		self.calendar.emit('activate')
 
 	def set_embeded_closebutton(self, button):

--- a/zim/plugins/journal.py
+++ b/zim/plugins/journal.py
@@ -348,15 +348,20 @@ class CalendarWidget(Gtk.VBox, WindowSidePaneWidget):
 		button.set_relief(Gtk.ReliefStyle.NONE)
 		button.connect('clicked', lambda b: self.go_today())
 
-		button1 = Gtk.Button()
-		self.label_box.add(button1)
-		button1.connect('clicked', lambda b: self.sub_day())
+		button_substract = Gtk.Button()
+		button_substract.set_label('<')
+		button_substract.set_relief(Gtk.ReliefStyle.NONE)
+		button_substract.connect('clicked', lambda b: self.substract_day())
 
+		button_add = Gtk.Button()
+		button_add.set_label('>')
+		button_add.set_relief(Gtk.ReliefStyle.NONE)
+		button_add.connect('clicked', lambda b: self.add_day())
+
+		self.label_box.add(button_substract)
 		self.label_box.add(button)
+		self.label_box.add(button_add)
 
-		button2 = Gtk.Button()
-		self.label_box.add(button2)
-		button2.connect('clicked', lambda b: self.add_day())
 
 		self._close_button = None
 
@@ -394,7 +399,7 @@ class CalendarWidget(Gtk.VBox, WindowSidePaneWidget):
 		self.calendar.select_date(day+d)
 		self.calendar.emit('activate')
 
-	def sub_day(self):
+	def substract_day(self):
 		day = self.calendar.get_date()
 		d = timedelta(days=-1)
 		self.calendar.select_date(day+d)


### PR DESCRIPTION
Hi, here is a small enhancement to add little buttons to traverse through the Journal forwards and backwards easily.
I hope you like it:
![image](https://user-images.githubusercontent.com/14337589/111043328-44af9e00-8442-11eb-96d0-e742ed0638c7.png)

BTW I see some failing tests, but they don't seem to be related...