### PR TITLE
Fix warning about not having called gi.require_version

### DIFF
--- a/zim/plugins/osx_menubar.py
+++ b/zim/plugins/osx_menubar.py
@@ -25,8 +25,10 @@ from zim.gui.mainwindow import MainWindowExtension
 from zim.plugins import PluginClass
 
 try:
+	import gi
+	gi.require_version('GtkosxApplication', '1.0')
 	from gi.repository import GtkosxApplication
-except ImportError:
+except (ValueError, ImportError) as error:
 	GtkosxApplication = None
 
 


### PR DESCRIPTION
This PR fixes the following warning:
> WARNING: Zim.app/Contents/Resources/lib/python3.8/site-packages/zim/plugins/osx_menubar.py:31: PyGIWarning: GtkosxApplication was imported without specifying a version first. Use gi.require_version('GtkosxApplication', '1.0') before import to ensure that the right version gets loaded.
> from gi.repository import GtkosxApplication