### PR TITLE
Remove trailing **** from first paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ stored in a folder structure, like in an outliner, and can have attachments.
 Creating a new page is as easy as linking to a nonexistent page. All data is
 stored in plain text files with wiki formatting. Various plugins provide
 additional functionality, like a task list manager, an equation editor, a tray
-icon, and support for version control.****
+icon, and support for version control.
 
 ![Screenshot](./website/files/screenshots/zim-normal.png)
 


### PR DESCRIPTION
- added in 13d8c46b (I thought it might be a footnote or similar, but there isn't one)
- not present in the develop branch where 13d8c46b isn't merged

Two questions for maintainers:
- For the record, are this kind of small fixes worthy of PRs or should I gather up a few? I consider this one to be due to its visibility.
- As I skimmed the README for other stray markup, I noticed data/{urls,symbols}.list aren't listed under files included from other sources. Should they be?