### PR TITLE
Allow using GtkSourceView 4.x if 3.x not found

### DIFF
--- a/zim/gui/widgets.py
+++ b/zim/gui/widgets.py
@@ -40,7 +40,14 @@ import locale
 
 try:
 	import gi
-	gi.require_version('GtkSource', '3.0')
+
+	# Allow using GtkSourceView 4.x (requires Gtk 3.24) for systems that no
+	# longer provide 3.x.
+	try:
+		gi.require_version('GtkSource', '3.0')
+	except:
+		gi.require_version('GtkSource', '4')
+
 	from gi.repository import GtkSource
 except:
 	GtkSource = None

--- a/zim/plugins/sourceview.py
+++ b/zim/plugins/sourceview.py
@@ -18,7 +18,14 @@ except:
 
 try:
 	import gi
-	gi.require_version('GtkSource', '3.0')
+
+	# Allow using GtkSourceView 4.x (requires Gtk 3.24) for systems that no
+	# longer provide 3.x.
+	try:
+		gi.require_version('GtkSource', '3.0')
+	except:
+		gi.require_version('GtkSource', '4')
+
 	from gi.repository import GtkSource
 except:
 	GtkSource = None


### PR DESCRIPTION
If GtkSourceView 3.x cannot be loaded, try to load GtkSourceView 4.x. This is intended for the stand-alone macOS application where a massive update to all its dependencies has happened and GtkSourceView has been upgraded to the last version supporting Gtk 3, which is 4.x.

Nothing will change for other platforms that still provide GtkSourceView 3.x, as it is still the preferred version.

GtkSourceView 4.x requires at least Gtk 3.24, so it may not be desireable to drop 3.x entirely as that might break support for older Linux distributions.