### PR TITLE
Add missing backarrow code

### DIFF
--- a/data/menubar.xml
+++ b/data/menubar.xml
@@ -39,6 +39,7 @@
 				<menuitem action='toggle_checkbox'/>
 				<menuitem action='xtoggle_checkbox'/>
 				<menuitem action='migrate_checkbox'/>
+				<menuitem action='transmigrate_checkbox'/>
 			</menu>
 			<menuitem action='edit_object'/>
 			<menuitem action='remove_link'/>

--- a/data/style.conf
+++ b/data/style.conf
@@ -89,4 +89,7 @@ foreground=#4e9a06
 [Tag migrated-checkbox]
 #foreground = grey
 
+[Tag transmigrated-checkbox]
+#foreground = grey
+
 # vim: syntax=desktop

--- a/tests/data/formats/export.html
+++ b/tests/data/formats/export.html
@@ -155,6 +155,7 @@ TODO list:<br>
 <p>
 <ul>
 <li class="migrated-box">Migrated checkbox</li>
+<li class="transmigrated-box">Transmigrated checkbox</li>
 </ul>
 </p>
 

--- a/tests/data/formats/export.markdown
+++ b/tests/data/formats/export.markdown
@@ -95,6 +95,7 @@ TODO list:
 
 
 * ▷ Migrated checkbox
+* ◁ Transmigrated checkbox
 
 
 A numbered list:

--- a/tests/data/formats/export.rst
+++ b/tests/data/formats/export.rst
@@ -113,6 +113,7 @@ TODO list:
 - ☒ baz
 
 - ▷ Migrated checkbox
+- ◁ Transmigrated checkbox
 
 A numbered list:
 1. foo

--- a/tests/data/formats/export.tex
+++ b/tests/data/formats/export.tex
@@ -170,6 +170,7 @@ TODO list:
 
 \begin{itemize}
 \item[\RIGHTarrow] Migrated checkbox
+\item[\LEFTarrow] Transmigrated checkbox
 \end{itemize}
 
 

--- a/tests/data/formats/parsetree.xml
+++ b/tests/data/formats/parsetree.xml
@@ -68,7 +68,7 @@ and also <strike>strike through</strike>
 
 <p>TODO list:
 <ul><li bullet="unchecked-box">foo</li><li bullet="checked-box">bar</li><ul><li bullet="checked-box">sub item 1</li><ul><li bullet="*">Some normal bullet</li></ul><li bullet="checked-box">sub item 2</li></ul><li bullet="xchecked-box">baz</li></ul></p>
-<p><ul><li bullet="migrated-box">Migrated checkbox</li></ul></p>
+<p><ul><li bullet="migrated-box">Migrated checkbox</li><li bullet="transmigrated-box">Transmigrated checkbox</li></ul></p>
 <p>A numbered list:
 <ol start="1"><li>foo</li><li>bar</li><ol start="a"><li>sub list</li><li>here</li></ol><li>hmmm</li></ol></p>
 

--- a/tests/data/formats/plain.txt
+++ b/tests/data/formats/plain.txt
@@ -86,6 +86,7 @@ TODO list:
 [x] baz
 
 [>] Migrated checkbox
+[<] Transmigrated checkbox
 
 A numbered list:
 1. foo

--- a/tests/data/formats/wiki.txt
+++ b/tests/data/formats/wiki.txt
@@ -86,6 +86,7 @@ TODO list:
 [x] baz
 
 [>] Migrated checkbox
+[<] Transmigrated checkbox
 
 A numbered list:
 1. foo

--- a/tests/pageview.py
+++ b/tests/pageview.py
@@ -2930,6 +2930,11 @@ class TestPageViewActions(tests.TestCase):
 		pageview.migrate_checkbox()
 		self.assertEqual(pageview.page.dump('wiki'), ['[>] my task\n'])
 
+	def testTransmigrateCheckBox(self):
+		pageview = setUpPageView(self.setUpNotebook(), '[*] my task\n')
+		pageview.transmigrate_checkbox()
+		self.assertEqual(pageview.page.dump('wiki'), ['[<] my task\n'])
+
 	def testEditObjectForLink(self):
 		pageview = setUpPageView(self.setUpNotebook(), '[[link]]\n')
 

--- a/zim/formats/markdown.py
+++ b/zim/formats/markdown.py
@@ -40,6 +40,7 @@ class Dumper(TextDumper):
 		XCHECKED_BOX: '* \u2612',
 		CHECKED_BOX: '* \u2611',
 		MIGRATED_BOX: '* \u25B7',
+		TRANSMIGRATED_BOX: '* \u25C1',
 		BULLET: '*',
 	}
 

--- a/zim/formats/rst.py
+++ b/zim/formats/rst.py
@@ -28,6 +28,7 @@ class Dumper(TextDumper):
 		XCHECKED_BOX: '- \u2612',
 		CHECKED_BOX: '- \u2611',
 		MIGRATED_BOX: '- \u25B7',
+		TRANSMIGRATED_BOX: '- \u25C1',
 		BULLET: '-',
 	}
 

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -2411,6 +2411,7 @@ class TextBuffer(Gtk.TextBuffer):
 				CHECKED_BOX
 				XCHECKED_BOX
 				MIGRATED_BOX
+				TRANSMIGRATED_BOX
 		or a numbered list bullet (test with L{is_numbered_bullet_re})
 		'''
 		iter = self.get_iter_at_line(line)
@@ -2926,7 +2927,8 @@ class TextBuffer(Gtk.TextBuffer):
 
 		@param line: the line number
 		@param checkbox_type: the checkbox type that we want to toggle:
-		one of C{CHECKED_BOX}, C{XCHECKED_BOX}, C{MIGRATED_BOX}.
+		one of C{CHECKED_BOX}, C{XCHECKED_BOX}, C{MIGRATED_BOX},
+		C{TRANSMIGRATED_BOX}.
 		If C{checkbox_type} is given, it toggles between this type and
 		unchecked. Otherwise it rotates through unchecked, checked
 		and xchecked.
@@ -3400,6 +3402,7 @@ class TextBufferList(list):
 			UNCHECKED_BOX
 			XCHECKED_BOX
 			MIGRATED_BOX
+			TRANSMIGRATED_BOX
 		'''
 		assert bullet in BULLETS
 		with self.buffer.user_action:
@@ -3408,7 +3411,7 @@ class TextBufferList(list):
 				pass
 			elif bullet == UNCHECKED_BOX:
 				self._checkbox_unchecked(row)
-			else: # CHECKED_BOX, XCHECKED_BOX, MIGRATED_BOX
+			else: # CHECKED_BOX, XCHECKED_BOX, MIGRATED_BOX, TRANSMIGRATED_BOX
 				self._checkbox_checked(row, bullet)
 
 	def _checkbox_unchecked(self, row):
@@ -6162,11 +6165,13 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 			self.actiongroup.get_action('toggle_checkbox').set_sensitive(True)
 			self.actiongroup.get_action('xtoggle_checkbox').set_sensitive(True)
 			self.actiongroup.get_action('migrate_checkbox').set_sensitive(True)
+			self.actiongroup.get_action('transmigrate_checkbox').set_sensitive(True)
 		else:
 			self.actiongroup.get_action('uncheck_checkbox').set_sensitive(False)
 			self.actiongroup.get_action('toggle_checkbox').set_sensitive(False)
 			self.actiongroup.get_action('xtoggle_checkbox').set_sensitive(False)
 			self.actiongroup.get_action('migrate_checkbox').set_sensitive(False)
+			self.actiongroup.get_action('transmigrate_checkbox').set_sensitive(False)
 
 		if buffer.get_link_tag(iter):
 			self.actiongroup.get_action('remove_link').set_sensitive(True)
@@ -6476,8 +6481,8 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		menu.prepend(Gtk.SeparatorMenuItem())
 
 		for bullet, label in (
-			(MIGRATED_BOX, _('Check Checkbox \'>\'')), # T: popup menu menuitem
 			(TRANSMIGRATED_BOX, _('Check Checkbox \'<\'')), # T: popup menu menuitem
+			(MIGRATED_BOX, _('Check Checkbox \'>\'')), # T: popup menu menuitem
 			(XCHECKED_BOX, _('Check Checkbox \'X\'')), # T: popup menu menuitem
 			(CHECKED_BOX, _('Check Checkbox \'V\'')), # T: popup menu menuitem
 			(UNCHECKED_BOX, _('Un-check Checkbox')), # T: popup menu menuitem


### PR DESCRIPTION
See commit messages.

I left tests/data/notebook-wiki.xml alone as changing it didn't seem to impact the tests and I wasn't sure how to handle < being interpreted as a start of an XML tag - should it be html.escape()d or is there another way?