### PR TITLE
BackLinks_Pane: Options to show count, full paths

### DIFF
--- a/data/manual/Help/Links.txt
+++ b/data/manual/Help/Links.txt
@@ -1,5 +1,5 @@
 Content-Type: text/x-zim-wiki
-Wiki-Format: zim 0.6
+Wiki-Format: zim 0.4
 Creation-Date: 2021-01-19T20:44:59+01:00
 
 ====== Links ======
@@ -10,6 +10,7 @@ You can either link pages or urls. Urls are recognized because they start with e
 * Links that start with a ':' are resolved from the top level of the notebook
 * Links that start with a '+' are resolved as sub-pages below the current page
 * Links that contain a '?' are interwiki links, see below.
+You
 * All other links are resolved within the path from the root to the current page
 
 You can make any text into a link, thus the link you see and what it links to do not have to be the same. You can use the "//Edit//->//Link//" menu item to modify a link.
@@ -52,4 +53,4 @@ The zim notebooks you added in the "Open notebook" dialog are automatically reco
 ===== Back links =====
 "Back links" are the reverse of normal links. For example when page //A// links to page //B// then page //B// will have "back link" to page //A//. The list with back links is the answer the question "What links here".
 
-In the status bar at the bottom of the window you can see how many back links there are for the current page. To view which pages link here you can open the "Search Back links" menu item (//Search//->//Search Back links//) or click the area in the status bar that gives info about back links. 
+To view which pages link here you can open the "Search Back links" menu item (//Search//->//Search Back links//) or use the [[Plugins:BackLinks Pane|BackLinks Pane]] plugin.

--- a/data/manual/Plugins/BackLinks_Pane.txt
+++ b/data/manual/Plugins/BackLinks_Pane.txt
@@ -8,10 +8,9 @@ This plugin adds an extra widget showing a list of pages linking to the current 
 
 **Dependencies:** This plugin has no additional dependencies.
 
-
 ===== Options =====
 The option **Position in the window** determines in which side pane the browser is shown.
 
 The option **Show BackLink count in title** determines whether the number of pages linking to the current page is shown in the widget's pane title.
 
-The option **Show full Page Names** determines which are shown: the pages' full names or just their basenames.
+The option **Show full Page Names** determines which are shown: the pages' full names or their shorter relative names. A page's full name includes its full hierarchy path. See [[Help:Pages|Pages]] for more details.

--- a/data/manual/Plugins/BackLinks_Pane.txt
+++ b/data/manual/Plugins/BackLinks_Pane.txt
@@ -11,3 +11,7 @@ This plugin adds an extra widget showing a list of pages linking to the current 
 
 ===== Options =====
 The option **Position in the window** determines in which side pane the browser is shown.
+
+The option **Show BackLink count in title** determines whether the number of pages linking to the current page is shown in the widget's pane title.
+
+The option **Show full Page Names** determines which are shown: the pages' full names or just their basenames.

--- a/data/manual/Plugins/BackLinks_Pane.txt
+++ b/data/manual/Plugins/BackLinks_Pane.txt
@@ -11,6 +11,6 @@ This plugin adds an extra widget showing a list of pages linking to the current 
 ===== Options =====
 The option **Position in the window** determines in which side pane the browser is shown.
 
-The option **Show BackLink count in title** determines whether the number of pages linking to the current page is shown in the widget's pane title.
+The option **Show BackLink count in title** determines whether the number of pages linking to the current page is shown in the widget's pane title. See [[Help:Links|Links]] for more details.
 
 The option **Show full Page Names** determines which are shown: the pages' full names or their shorter relative names. A page's full name includes its full hierarchy path. See [[Help:Pages|Pages]] for more details.

--- a/zim/plugins/backlinkpane.py
+++ b/zim/plugins/backlinkpane.py
@@ -90,9 +90,16 @@ class BackLinksWidget(Gtk.ScrolledWindow, WindowSidePaneWidget):
 			#~ model.append(None, (link.source, text))
 			model.append((link.source, text))
 
+		self.update_title(model)
+
 		## TODO make hierarchy by link type ?
 		## use link.type attribute
 		#self.treeview.expand_all()
+
+	def update_title(self, treeview_model):
+		n = len(treeview_model)
+		self.set_title(ngettext('%i BackLink', '%i BackLinks', n) % n)
+		# T: Label for the statusbar, %i is the number of BackLinks to the current page
 
 	def on_link_activated(self, treeview, path, column):
 		model = treeview.get_model()


### PR DESCRIPTION
1. **Show BackLink count in title** determines whether the number of pages linking to the current page is shown in the widget's pane title. (heavily inspired by attachmentbrowser)
2. **Show full Page Names** determines which are shown: the pages' full names or just their basenames. (naming convention matches BookmarkBar)

Both are gloriously updated on preference changes.