### PR TITLE
Fix images becoming one pixel wide after fixing path

### DIFF
--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -7570,8 +7570,8 @@ class EditImageDialog(Dialog):
 
 		reset_button.connect_object('clicked',
 			self.__class__.reset_dimensions, self)
-		#~ self.form.widgets['file'].connect_object('activate',
-			#~ self.__class__.reset_dimensions, self)
+		self.form.widgets['file'].connect_object('changed',
+			self.__class__.do_file_changed, self)
 		self.form.widgets['width'].connect_object('value-changed',
 			self.__class__.do_width_changed, self)
 		self.form.widgets['height'].connect_object('value-changed',
@@ -7610,6 +7610,11 @@ class EditImageDialog(Dialog):
 			height.set_value(h)
 			self._block = False
 			self._ratio = float(w) / h
+
+	def do_file_changed(self):
+		# Prevent images becoming one pixel wide
+		if self._image_data['width'] is 1:
+			self.reset_dimensions()
 
 	def do_width_changed(self):
 		if hasattr(self, '_block') and self._block:


### PR DESCRIPTION
This fixes that by resetting the dimensions after path changes if the width of the image is 1.

Steps to reproduce:
1. Edit image properties, set a custom width and press OK; the width changes
2. Edit image properties, change Location to a nonexistent one and press OK;  the image is replaced with a placeholder
3. Edit image properties and correct the Location; notice that the width is set to 1
4. Press OK; the image is now 1 pixel wide

A better alternative would be restoring the previously set dimensions, but let's not make perfect the enemy of good.

