### PR TITLE
Windows build: fix missing icon in font chooser dialog

### DIFF
--- a/windows/src/zim.spec
+++ b/windows/src/zim.spec
@@ -71,6 +71,7 @@ icon_names.update({
     'image-missing',
     'index',
     'list-add',
+    'list-remove',
     'system-help',
     'text-x-generic',
     'view-fullscreen',

--- a/windows/src/zim.spec
+++ b/windows/src/zim.spec
@@ -85,6 +85,9 @@ icon_names.update({
     'pan-end-symbolic',
     'pan-down-symbolic',
     'pan-up-symbolic',
+    'process-working-symbolic',
+    'folder-new',
+    'drive-harddisk',
 })
 
 a = Analysis( # noqa


### PR DESCRIPTION
This fixes #1482.