### PR TITLE
Add some more symbols

### DIFF
--- a/data/symbols.list
+++ b/data/symbols.list
@@ -78,6 +78,7 @@
 
 # Additional ISO-8859/1 entities listed in rfc1866 (section 14)
 \iexcl	161
+\iquest	191
 \cent	162
 \pound	163
 \curren	164
@@ -87,6 +88,7 @@
 \uml	168
 \ordf	170
 \laquo	171
+\raquo	187
 \not	172
 \shy	173
 \macr	175
@@ -101,11 +103,21 @@
 \middot	183
 \cedil	184
 \ordm	186
-\raquo	187
-\frac14	188
 \frac12	189
+\frac13	8531
+\frac14	188
+\frac15	8533
+\frac16	8537
+\frac18	8539
+\frac23	8532
+\frac25	8534
 \frac34	190
-\iquest	191
+\frac35	8535
+\frac38	8540
+\frac45	8536
+\frac56	8538
+\frac58	8541
+\frac78	8542
 \times	215
 \divide	247
 
@@ -178,6 +190,7 @@
 \rlm	8207
 \ndash	8211
 \mdash	8212
+\horbar 8213
 \lsquo	8216
 \rsquo	8217
 \sbquo	8218
@@ -205,6 +218,12 @@
 \uarr	8593
 \rarr	8594
 \darr	8595
+\nearr	8599
+\searr	8600
+\nwarr	8598
+\swarr	8601
+\curarr	8631
+\cularr	8630
 \harr	8596
 \crarr	8629
 \lArr	8656
@@ -228,6 +247,7 @@
 \prop	8733
 \infin	8734
 \ang	8736
+\angsph	8738
 \and	8743
 \or	8744
 \cap	8745
@@ -239,8 +259,11 @@
 \asymp	8776
 \ne	8800
 \equiv	8801
+\wedgeq	8793
 \le	8804
+\les	10877
 \ge	8805
+\ges	10878
 \sub	8834
 \sup	8835
 \nsub	8836
@@ -328,5 +351,8 @@
 \phone	9990 # Telephone Sign
 \flag	9873 # Black Flag
 
-## Suggestions for more shortcuts are welcome - please file in bug tracker ##
+\numero	8470 # numero sign
+\female	9792
+\male	9794
 
+## Suggestions for more shortcuts are welcome - please file in bug tracker ##


### PR DESCRIPTION
Add some of the more commonly used HTML5 symbols. See https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references for complete list, but I don't think it makes sense to add all symbols from this list.  

Further I re-arranged some symbols to make them appear in more logical order. There are, however, quite a few repeating symbols with different shortcuts (e.g. `\pm`, `+-` and `+_` for the `±` sign). To my mind, they should be put in a row and not be scattered around, or even better, these symbols should appear only once in the icon view while preserving all possible shortcuts (right now I have no idea how to achieve this).

