### PR TITLE
Make tests work in non-English locales

### DIFF
--- a/tests/plugins.py
+++ b/tests/plugins.py
@@ -3,6 +3,7 @@
 
 import tests
 
+import builtins
 import os
 
 from zim.plugins import *
@@ -33,7 +34,11 @@ class TestPluginClasses(tests.TestCase):
 		}
 		for name in plugins:
 			#~ print('>>', name)
+			# temporarily remove gettext.gettext definition from builtin namespace
+			old_underscore = builtins.__dict__['_']
+			builtins.__dict__['_'] = lambda x: x
 			klass = PluginManager.get_plugin_class(name)
+			builtins.__dict__['_'] = old_underscore
 
 			# test plugin info
 			for key in ('name', 'description', 'author'):

--- a/tests/uiactions.py
+++ b/tests/uiactions.py
@@ -928,7 +928,7 @@ class TestUIActionsRealFile(tests.TestCase):
 
 		self.assertIsNone(self.notebook.document_root)
 
-		with tests.LoggingFilter('zim', 'No document root defined'):
+		with tests.LoggingFilter('zim', _('No document root defined for this notebook')):
 			with tests.ApplicationContext():
 				with tests.DialogContext(ErrorDialog):
 					self.uiactions.open_document_root()


### PR DESCRIPTION
I had two failing tests when running `test.py` in my German locale due to comparing localized with non-localized texts. A straightforward workaround would be of course to use `LC_MESSAGES=en_US.utf8 ./test.py` but I felt it would be better to just fix the two tests.
#### TestUIActionsRealFile
```
testOpenDocumentRootNotDefined (tests.uiactions.TestUIActionsRealFile) ... ERROR: Für dieses Notizbuch ist kein Wurzelverzeichnis definiert
```
This is straightforward: just use the full localized message as expected message.

#### TestPluginClasses
```
FAIL: runTest (tests.plugins.TestPluginClasses)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/steffen/Dev/zim-desktop-wiki/tests/plugins.py", line 73, in runTest
    self.assertIn(label, manual, 'Preference "%s" for %s plugin not documented in manual page' % (label, name))
AssertionError: 'Version automatisch speichern, wenn das Notizbuch geschlossen wird' not found in '...If the option **Autosave version when the notebook is closed** is enabled ...' : Preference "Version automatisch speichern, wenn das Notizbuch geschlossen wird" for versioncontrol plugin not documented in manual page
```
This is just the other way round: as there are no localized versions of the manual to compare the localized plugin preference strings against we have to temporarily disable `gettext` when getting the plugin messages by setting `_` to a no-op and restoring its previous value afterwards.

