### PR TITLE
Update insert_line documentation

### DIFF
--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -6934,10 +6934,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 
 	@action(_('Horizontal _Line'), menuhints='insert') # T: Menu item for Insert menu
 	def insert_line(self):
-		'''
-                This function is called from menu action.
-                Insert a line at the cursor position.
-		'''
+		'''Menu action to insert a line at the cursor position'''
 		buffer = self.textview.get_buffer()
 		with buffer.user_action:
 			buffer.insert_objectanchor_at_cursor(LineSeparatorAnchor())


### PR DESCRIPTION
The new docstring follows the style of the other menu actions' docstrings (and doesn't confuse my tab-native docstring parser by indenting with spaces).

@jaap-karssenberg a few questions about a possible tool related to #155 :

1. `"""` vs. `'''`? PEP 257 says to use the former, while zim-desktop-wiki has a few thousand `'''`s with a couple hundred `"""`s mixed in.
    - Should one be standardized?
2. Line width; PEP 257 says 72, while Zim's docstrings max out at well over a hundred chars. I've prototyped a solution using TextWrapper that errs on the side of caution to not break code blocks etc, but judging whether the first line should stand alone is next to impossible due to incorrect formatting.
    - Should all docstrings be rewrapped and to what width?
3. Indentation inside docstrings; sphinx doesn't care about the amount or type of indentation as long as it's constant; thus a single space would suffice to fix field lists and would sidestep number 2.
    - What indentation should be used inside docstrings? A tab, a single space, or multiple spaces?
4. Since such a tool would modify all source files anyway, would you consider changing from tabs to four spaces? ;)

Thanks for your time!