### PR TITLE
Fix zoom-in accelerator label

### DIFF
--- a/data/manual/Help/Menu_Items.txt
+++ b/data/manual/Help/Menu_Items.txt
@@ -155,7 +155,7 @@ Show the calendar dialog.
 
 Only available if the [[Plugins:Journal|Journal plugin]] is enabled.
 
-**Zoom In <Ctrl><><>**
+**Zoom In <Ctrl><+>**
 Increase the font size by 1 point.
 
 **Zoom Out <Ctrl><->**

--- a/tests/mainwindow.py
+++ b/tests/mainwindow.py
@@ -280,7 +280,10 @@ class TestMenuDocs(tests.TestCase):
 				Gtk.AccelMap().lookup_entry(accel_path).key.accel_key,
 				Gtk.AccelMap().lookup_entry(accel_path).key.accel_mods)
 			if accel_label:
-				label += ' <' + accel_label.replace('+', '><') + '>'
+				if '++' in accel_label:
+					label += ' <' + accel_label.replace('++', '><+') + '>'
+				else:
+					label += ' <' + accel_label.replace('+', '><') + '>'
 			if level:
 				label = '**' + label + '**'
 			else:


### PR DESCRIPTION
Fix wrong accel key label introduced in menu items help page in commit 9dfd96afc.
I'm very sorry but I overlooked this mistake in #1502.