### PR TITLE
foreach_line_in_selection: ignore empty lines

### DIFF
--- a/tests/pageview.py
+++ b/tests/pageview.py
@@ -3284,6 +3284,15 @@ class TestPageViewActions(tests.TestCase):
 		pageview.apply_format_bullet_list()
 		self.assertEqual(pageview.page.dump('wiki'), ['* test 123\n'])
 
+	def testApplyBulletSkipsEmptyLines(self):
+		pageview = setUpPageView(self.setUpNotebook(), 'test 123\n\nabc\n')
+		buffer = pageview.textview.get_buffer()
+		begin = buffer.get_iter_at_offset(0)
+		end = buffer.get_iter_at_offset(14)
+		buffer.select_range(begin, end)
+		pageview.apply_format_bullet_list()
+		self.assertEqual(pageview.page.dump('wiki'), ['* test 123\n', '\n', '* abc\n'])
+
 	def testApplyNumberedList(self):
 		pageview = setUpPageView(self.setUpNotebook(), 'test 123\n')
 		buffer = pageview.textview.get_buffer()

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -2343,7 +2343,9 @@ class TextBuffer(Gtk.TextBuffer):
 				# because line is not visually part of selection
 				end.backward_char()
 			for line in range(start.get_line(), end.get_line() + 1):
-				func(line, *args, **kwarg)
+				# don't call function on empty lines
+				if not self.get_line_is_empty(line):
+					func(line, *args, **kwarg)
 			return True
 		else:
 			return False

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -2344,11 +2344,18 @@ class TextBuffer(Gtk.TextBuffer):
 				# exclude last line if selection ends at newline
 				# because line is not visually part of selection
 				end.backward_char()
-			for line in range(start.get_line(), end.get_line() + 1):
-				# don't call function on empty lines
-				if skip_empty_lines and self.get_line_is_empty(line):
-					continue
-				func(line, *args, **kwarg)
+			if skip_empty_lines:
+				all_lines_are_empty = True
+				for line in range(start.get_line(), end.get_line() + 1):
+					if not self.get_line_is_empty(line):
+						all_lines_are_empty = False
+						func(line, *args, **kwarg)
+				if all_lines_are_empty:
+					# the user wanted to do something to these empty lines, so we do
+					self.foreach_line_in_selection(func, *args, skip_empty_lines=False, **kwarg)
+			else:
+				for line in range(start.get_line(), end.get_line() + 1):
+					func(line, *args, **kwarg)
 			return True
 		else:
 			return False

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -4528,14 +4528,14 @@ class TextView(Gtk.TextView):
 			elif keyval in KEYVALS_ASTERISK + (KEYVAL_POUND,):
 				def toggle_bullet(line, newbullet):
 					bullet = buffer.get_bullet(line)
-					if not bullet and not buffer.get_line_is_empty(line):
+					if not bullet:
 						buffer.set_bullet(line, newbullet)
 					elif bullet == newbullet: # FIXME broken for numbered list
 						buffer.set_bullet(line, None)
 				if keyval == KEYVAL_POUND:
-					buffer.foreach_line_in_selection(toggle_bullet, NUMBER_BULLET)
+					buffer.foreach_line_in_selection(toggle_bullet, NUMBER_BULLET, skip_empty_lines=True)
 				else:
-					buffer.foreach_line_in_selection(toggle_bullet, BULLET)
+					buffer.foreach_line_in_selection(toggle_bullet, BULLET, skip_empty_lines=True)
 			elif keyval in KEYVALS_GT \
 			and multi_line_indent(start, end):
 				def email_quote(line):

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -2321,7 +2321,7 @@ class TextBuffer(Gtk.TextBuffer):
 		level = self.get_indent(line)
 		return self.set_indent(line, level - 1, interactive)
 
-	def foreach_line_in_selection(self, func, *args, **kwarg):
+	def foreach_line_in_selection(self, func, *args, skip_empty_lines=False, **kwarg):
 		'''Convenience function to call a function for each line that
 		is currently selected
 
@@ -2330,6 +2330,8 @@ class TextBuffer(Gtk.TextBuffer):
 			func(line, *args, **kwargs)
 
 		where C{line} is the line number
+		@param skip_empty_lines: if C{True}, C{func} won't be called
+		for empty lines
 		@param args: additional argument for C{func}
 		@param kwarg: additional keyword argument for C{func}
 
@@ -2344,8 +2346,9 @@ class TextBuffer(Gtk.TextBuffer):
 				end.backward_char()
 			for line in range(start.get_line(), end.get_line() + 1):
 				# don't call function on empty lines
-				if not self.get_line_is_empty(line):
-					func(line, *args, **kwarg)
+				if skip_empty_lines and self.get_line_is_empty(line):
+					continue
+				func(line, *args, **kwarg)
 			return True
 		else:
 			return False
@@ -7052,7 +7055,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 			start_mark = buffer.create_mark(None, bounds[0], left_gravity=True)
 			end_mark = buffer.create_mark(None, bounds[1], left_gravity=False)
 			try:
-				buffer.foreach_line_in_selection(buffer.set_bullet, bullet_type)
+				buffer.foreach_line_in_selection(buffer.set_bullet, bullet_type, skip_empty_lines=True)
 			except:
 				raise
 			else:


### PR DESCRIPTION
Status: https://github.com/zim-desktop-wiki/zim-desktop-wiki/pull/1534#issuecomment-986004627

---

Usually I don't want my empty lines to become empty list members, eg.

```
this is a list where items are separated by an empty line

let's make it into a checklist!
```

would turn into

```
[ ] this is a list where items are separated by an empty line
[ ] 
[ ] let's make it into a checklist!
```

instead of (imo) the more sane

```
[ ] this is a list where items are separated by an empty line

[ ] let's make it into a checklist!
```

Thus, this change. Q&A:

* Does it break some other functionality?
  * Maybe. It didn't break any tests though could do with some of its own.
* Shouldn't the empty lines be removed?
  * No, some people might be into that sort of stuff and it's not up to us to judge them.
* Does it fix my use case?
  * Yes.