### PR TITLE
fixing backlinks plugin: open backlink in new window

### DIFF
--- a/zim/plugins/backlinkpane.py
+++ b/zim/plugins/backlinkpane.py
@@ -131,6 +131,7 @@ class BackLinksWidget(Gtk.ScrolledWindow, WindowSidePaneWidget):
 		menu.append(item)
 
 		# Other per page menu items do not really apply here...
+		menu.show_all()
 
 	def on_open_new_window(self, o, treeview):
 		model, iter = treeview.get_selection().get_selected()


### PR DESCRIPTION
backlinks plugin: fixed "Open in new page" popup entry that is currently not shown when trying to open the context menu