### PR TITLE
Pop from history when leaving the unmodified page quickly

### DIFF
--- a/zim/gui/mainwindow.py
+++ b/zim/gui/mainwindow.py
@@ -262,6 +262,7 @@ class MainWindow(WindowBaseMixin, Window):
 		"C{WxH+X+Y}", if C{None} the previous state is restored
 		'''
 		Window.__init__(self)
+		self.last_change = 0
 		self.notebook = notebook
 		self.page = None # will be set later by open_page
 		self.navigation = NavigationModel(self)
@@ -691,9 +692,16 @@ class MainWindow(WindowBaseMixin, Window):
 			if self.page.modified:
 				return False # Assume SavePageErrorDialog was shown and cancelled
 
-			old_cursor = self.pageview.get_cursor_pos()
-			old_scroll = self.pageview.get_scroll_pos()
-			self.history.set_state(self.page, old_cursor, old_scroll)
+			from time import time
+			if time() - self.last_change < 1:
+				# pop out from history since we have left the unmodified page too quickly
+				self.history._history.pop()
+				self.history._current = len(self.history._history) - 1
+			else:
+				old_cursor = self.pageview.get_cursor_pos()
+				old_scroll = self.pageview.get_scroll_pos()
+				self.history.set_state(self.page, old_cursor, old_scroll)
+			self.last_change = time()
 
 			self.save_uistate()
 


### PR DESCRIPTION
I often navigate through the notebook using <kbd>Ctrl</kbd>+<kbd>PgUp/Down</kbd>. The pages change according to the position in the contents sidebar. However, when I need to navigate further than a page, all the pages end up in the history. Which is not intented, I wanted just switch from `A` to `D`, opening `B` and `C` was just a side effect. When I want to go back in history by <kbd>Alt</kbd>+<kbd>Left</kbd>, I'd prefer to end up directly back on `A`, not to cycle through `C`, `B`, `A` respectively.

The proposed solution waits 1 s. If page is being left within 1 s, the page that ended up at the top of the history stack gets deleted. Would you please give me few advices? This is just proof of concept, I understand it has to be expanded. Is the solution good or did I take a wrong way? Should I create a method `history.py/History.pop_last`?
