### PR TITLE
Add support for interpolating arguments in shell commands

### DIFF
--- a/tests/applications.py
+++ b/tests/applications.py
@@ -56,17 +56,21 @@ class TestApplications(tests.TestCase):
 		entry['Desktop Entry']['Name'] = 'Foo'
 		for app, args, wanted in (
 			# Test cases should be compliant with spec
-			('foo %f', (), ('foo',)),
-			('foo %f %i', (), ('foo',)), # no icon set
-			('foo %f %k', (), ('foo', '')), # no source set
+			('foo %f', (), ('foo',)),  # no file set
+			('foo %f %i', (), ('foo',)),  # no file and no icon set
+			('foo %f %k', (), ('foo',)),  # no file and no source set
 			('foo %f %c', (), ('foo', 'Foo')),
 			('foo', ('bar',), ('foo', 'bar')),
 			('foo', ('bar baz',), ('foo', 'bar baz')),
 			('foo "hmm ja"', ('bar',), ('foo', 'hmm ja', 'bar')),
 			('foo %f', ('bar baz',), ('foo', 'bar baz')),
 			('foo %F', ('bar baz',), ('foo', 'bar baz')),
-			('foo %u', ('bar baz',), ('foo', 'bar baz')),
+			# ('foo %u', ('bar baz',), ('foo', 'bar baz')),
+			('foo "%u"', ('bar baz',), ('foo', 'bar baz')),
+			("foo '%u'", ('bar baz',), ('foo', 'bar baz')),
 			('foo %U', ('bar baz',), ('foo', 'bar baz')),
+			('foo "%U"', ('bar baz',), ('foo', 'bar baz')),
+			("foo '%U'", ('bar baz',), ('foo', 'bar baz')),
 			('foo %F', ('bar', 'baz'), ('foo', 'bar', 'baz')),
 			('foo %F hmm', ('bar', 'baz'), ('foo', 'bar', 'baz', 'hmm')),
 			('foo %U', ('bar', 'baz'), ('foo', 'bar', 'baz')),

--- a/zim/gui/applications.py
+++ b/zim/gui/applications.py
@@ -920,56 +920,43 @@ class DesktopEntryDict(SectionedConfigDict, Application):
 					uris.append(str(arg))
 			return uris
 
-		cmd = split_quoted_strings(self['Desktop Entry']['Exec'])
+		cmd = self['Desktop Entry']['Exec']
 		if args is None or len(args) == 0:
 			if '%f' in cmd:
-				cmd.remove('%f')
+				cmd = cmd.replace('%f', '')
 			elif '%F' in cmd:
-				cmd.remove('%F')
+				cmd = cmd.replace('%F', '')
 			elif '%u' in cmd:
-				cmd.remove('%u')
+				cmd = cmd.replace('%u', '')
 			elif '%U' in cmd:
-				cmd.remove('%U')
+				cmd = cmd.replace('%U', '')
 		elif '%f' in cmd:
 			assert len(args) == 1, 'application takes one file name'
-			i = cmd.index('%f')
-			cmd[i] = str(args[0])
+			cmd = cmd.replace('%f', str(args[0]))
 		elif '%F' in cmd:
-			i = cmd.index('%F')
-			for arg in reversed(list(map(str, args))):
-				cmd.insert(i, str(arg))
-			cmd.remove('%F')
+			cmd = cmd.replace('%F', " ".join(list(map(str, args))))
 		elif '%u' in cmd:
 			assert len(args) == 1, 'application takes one url'
-			i = cmd.index('%u')
-			cmd[i] = uris(args)[0]
+			cmd = cmd.replace('%u', uris(args)[0])
 		elif '%U' in cmd:
-			i = cmd.index('%U')
-			for arg in reversed(uris(args)):
-				cmd.insert(i, str(arg))
-			cmd.remove('%U')
+			cmd = cmd.replace('%U', " ".join(uris(args)))
 		else:
-			cmd.extend(list(map(str, args)))
+			cmd += " " + " ".join(list(map(str, args)))
 
 		if '%i' in cmd:
 			if 'Icon' in self['Desktop Entry'] \
 			and self['Desktop Entry']['Icon']:
-				i = cmd.index('%i')
-				cmd[i] = self['Desktop Entry']['Icon']
-				cmd.insert(i, '--icon')
+				cmd = cmd.replace('%i', '--icon ' + self['Desktop Entry']['Icon'])
 			else:
-				cmd.remove('%i')
+				cmd = cmd.replace('%i', '')
 
 		if '%c' in cmd:
-			i = cmd.index('%c')
-			cmd[i] = self.name
+			cmd = cmd.replace('%c', self.name)
 
 		if '%k' in cmd:
-			i = cmd.index('%k')
-			if hasattr(self, 'file'):
-				cmd[i] = self.file.path
-			else:
-				cmd[i] = ''
+			cmd = cmd.replace('%k', self.file.path if hasattr(self, 'file') else '')
+
+		cmd = split_quoted_strings(cmd)
 
 		return tuple(cmd)
 

--- a/zim/gui/applications.py
+++ b/zim/gui/applications.py
@@ -920,6 +920,9 @@ class DesktopEntryDict(SectionedConfigDict, Application):
 					uris.append(str(arg))
 			return uris
 
+		def quote(arg):
+			return '"{}"'.format(arg.replace('"', '\"'))
+
 		cmd = self['Desktop Entry']['Exec']
 		if args is None or len(args) == 0:
 			if '%f' in cmd:
@@ -932,16 +935,16 @@ class DesktopEntryDict(SectionedConfigDict, Application):
 				cmd = cmd.replace('%U', '')
 		elif '%f' in cmd:
 			assert len(args) == 1, 'application takes one file name'
-			cmd = cmd.replace('%f', str(args[0]))
+			cmd = cmd.replace('%f', quote(args[0]))
 		elif '%F' in cmd:
-			cmd = cmd.replace('%F', " ".join(list(map(str, args))))
+			cmd = cmd.replace('%F', " ".join(list(map(quote, args))))
 		elif '%u' in cmd:
 			assert len(args) == 1, 'application takes one url'
 			cmd = cmd.replace('%u', uris(args)[0])
 		elif '%U' in cmd:
-			cmd = cmd.replace('%U', " ".join(uris(args)))
+			cmd = cmd.replace('%U', " ".join(map(quote, uris(args))))
 		else:
-			cmd += " " + " ".join(list(map(str, args)))
+			cmd += " " + " ".join(list(map(quote, args)))
 
 		if '%i' in cmd:
 			if 'Icon' in self['Desktop Entry'] \

--- a/zim/parsing.py
+++ b/zim/parsing.py
@@ -14,7 +14,7 @@ def split_quoted_strings(string, unescape=True, strict=True):
 	boundries.
 
 	( XDG Desktop Entry spec says full words must be quoted and
-	quotes in a word escaped, but doesn't specifify what to do with
+	quotes in a word escaped, but doesn't specify what to do with
 	loose quotes in a string. )
 
 	Also a comma "," is handled specially and is always considered a


### PR DESCRIPTION
This PR adds support for interpolating arguments in shell commands, e.g.:

```
[Desktop Entry]
Version=1.0
Name=Bowser Gnome Extension
GenericName=Bowser Web Browser Chooser
Comment=Set up rules to open specific URLs in specific web browsers
Exec=bash -c '$(which gjs) ~/.local/share/gnome-shell/extensions/bowser-gnome@kronosoul.xyz/bowser.js -o "%u"'
Icon=bowser
Terminal=false
Type=Application
Categories=Network;WebBrowser;
Keywords=web;browser;internet;Internet;WWW;Browser;Web;Explorer;
X-Desktop-File-Install-Version=0.24
MimeType=x-scheme-handler/unknown;x-scheme-handler/about;text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;application/xml;application/rss+xml;application/rdf+xml;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;
```

Without this PR, the work-around is to remove the `bash -c` part and hard-code the path to `gjs`:
```
Exec=/usr/bin/gjs ~/.local/share/gnome-shell/extensions/bowser-gnome@kronosoul.xyz/bowser.js -o "%u"
```

Resolves #828

TODO:
- [ ] add tests