### PR TITLE
Make zeitgeist plugin work again

### DIFF
--- a/data/manual/Plugins/Log_events_with_Zeitgeist.txt
+++ b/data/manual/Plugins/Log_events_with_Zeitgeist.txt
@@ -6,6 +6,6 @@ Creation-Date: 2012-06-05T20:52:03+02:00
 
 When this plugin is activated, information about accessing, creating and modifying Zim Wiki pages is logged using the Zeitgeist framework. This allows applications like the Unity Dash to display recently used pages or the Activity Journal to give a timeline overview of your activities.
 
-**Dependencies:** This plugin requires the Python bindings for Zeitgeist. For Debian and Ubuntu, these bindings are available in the ''python-zeitgeist'' package.
+**Dependencies:** This plugin requires the Python bindings for Zeitgeist. For Debian and Ubuntu, these bindings are available in the ''python3-zeitgeist'' package.
 
 For more information about the Zeitgeist project see: http://zeitgeist-project.com

--- a/zim/plugins/zeitgeist-logger.py
+++ b/zim/plugins/zeitgeist-logger.py
@@ -59,14 +59,14 @@ class ZeitgeistPlugin(PluginClass):
 			return
 
 		uri = page.source.uri
-		origin = Gio.File(uri).get_parent().get_uri()
+		origin = page.source_file.dirname
 		text = _('Wiki page: %s') % page.name
 			# T: label for how zim pages show up in the recent files menu, %s is the page name
 
 		subject = Subject.new_for_values(mimetype='text/x-zim-wiki',
 		                                 uri=uri,
 		                                 origin=origin,
-		                                 interpretation=Interpretation.TEXT_DOCUMENT,
+		                                 interpretation=Interpretation.PLAIN_TEXT_DOCUMENT,
 		                                 manifestation=Manifestation.FILE_DATA_OBJECT,
 		                                 text=text)
 		event = Event.new_for_values(actor='application://zim.desktop',
@@ -84,7 +84,7 @@ class ZeitGeistMainWindowExtension(MainWindowExtension):
 		self.connectto(window, 'page-changed')
 		self.page = None
 
-	def on_page_changed(self, page):
+	def on_page_changed(self, pageview, page):
 		if self.page is not None:
 			self.plugin.create_and_send_event(self.page, Interpretation.LEAVE_EVENT)
 


### PR DESCRIPTION
Some minimal changes to make the zeitgeist plugin work again. Note that this now requires the `python3-zeitgeist` package on Debian/Ubuntu.

Fixes #787