### PR TITLE
Fix #1560: add linking related UX in ToC pane

### DIFF
--- a/tests/main.py
+++ b/tests/main.py
@@ -90,7 +90,7 @@ class TestNotebookCommand(tests.TestCase):
 
 		myinfo = NotebookInfo(pwd + '/Notes')
 		os.chdir('/')
-		notebookinfo, page = cmd.get_notebook_argument()
+		notebookinfo, page, _ = cmd.get_notebook_argument()
 
 		self.assertEqual(notebookinfo, myinfo)
 		os.chdir(pwd)

--- a/tests/notebook.py
+++ b/tests/notebook.py
@@ -272,7 +272,6 @@ mount=%s %s
 		self.assertRaises(FileNotFoundError, build_notebook, info)
 
 
-
 class TestNotebook(tests.TestCase):
 
 	def setUp(self):
@@ -432,7 +431,6 @@ class TestNotebook(tests.TestCase):
 			':AnotherNewPage:Foo:bar\n'
 			'**bold** :AnotherNewPage\n')
 
-
 		#~ print('\n==== DB ====')
 		#~ self.notebook.index.update()
 		#~ cursor = self.notebook.index.db.cursor()
@@ -551,7 +549,7 @@ class TestEndOfLine(tests.TestCase):
 		config['Notebook']['endofline'] = eol
 		config.write()
 
-		notebook, x = build_notebook(dir)
+		notebook, _ = build_notebook(dir)
 		page = notebook.get_page(Path('Test'))
 		page.parse('wiki', 'test 123\n456\n')
 		notebook.store_page(page)

--- a/tests/tableofcontents.py
+++ b/tests/tableofcontents.py
@@ -10,6 +10,7 @@ from tests.mainwindow import setUpMainWindow
 from zim.plugins import PluginManager
 from zim.plugins.tableofcontents import *
 from zim.gui.widgets import RIGHT_PANE, LEFT_PANE
+from zim.notebook import Path
 
 
 @tests.slowTest

--- a/tests/tokenparser.py
+++ b/tests/tokenparser.py
@@ -49,25 +49,44 @@ class TestTokenParser(tests.TestCase):
 class TestFunctions(tests.TestCase):
 
 	def testCollectTokens(self):
-		self.assertEqual(	# simple
-			collect_untill_end_token(
+		# simple
+		self.assertEqual(
+			collect_until_end_token(
 				[('B', {}), ('T', ''), (END, 'B'), (END, 'A'), ('T', '')],
 				'A'
 			),
-				[('B', {}), ('T', ''), (END, 'B')]
+			[('B', {}), ('T', ''), (END, 'B')]
 		)
-		self.assertEqual(	# nested
-			collect_untill_end_token(
+		# nested
+		self.assertEqual(
+			collect_until_end_token(
 				[('A', {}), ('T', ''), (END, 'A'), (END, 'A'), ('T', '')],
 				'A'
 			),
-				[('A', {}), ('T', ''), (END, 'A')]
+			[('A', {}), ('T', ''), (END, 'A')]
 		)
+		# error case: no closing tag found
 		with self.assertRaises(EndOfTokenListError):
-			collect_untill_end_token(
+			collect_until_end_token(
 				[('B', {}), ('T', ''), (END, 'B'), ('T', '')],
 				'A'
 			)
+
+	def testFilterTokens(self):
+		self.assertEqual(
+			list(filter_token(
+				[('T', 'pre'), ('A', {}), ('T', 'inner'), (END, 'A'), ('T', 'post')],
+				'A'
+			)),
+			[('T', 'pre'), ('T', 'post')]
+		)
+		self.assertEqual(
+			list(filter_token(
+				[('T', 'pre'), ('A', {}), ('A', {}), ('T', 'inner'), (END, 'A'), (END, 'A'), ('T', 'post')],
+				'A'
+			)),
+			[('T', 'pre'), ('T', 'post')]
+		)
 
 	def testTokensToText(self):
 		self.assertEqual(

--- a/zim/formats/__init__.py
+++ b/zim/formats/__init__.py
@@ -297,6 +297,9 @@ class ParseTree(object):
 		self._object_cache = {}
 		self.meta = DefinitionOrderedDict()
 
+	def __str__(self):
+		return "<%s: content=\"%s\">" % (self.__class__.__name__, self.tostring().replace('"', '\\"').replace('\n', '\\n'))
+
 	@property
 	def hascontent(self):
 		'''Returns True if the tree contains any content at all.'''

--- a/zim/gui/clipboard.py
+++ b/zim/gui/clipboard.py
@@ -327,9 +327,7 @@ def _link_tree(links, notebook, path):
 				href.anchor = anchor
 				link = href.to_wiki_link()
 				if notebook.config['Notebook']['short_links']:
-					name = href.parts()[-1]
-					if anchor:
-						name += '#' + anchor
+					name = href.short_name()
 			elif type == 'file':
 				try:
 					file = LocalFile(link) # Assume links are always URIs
@@ -509,9 +507,7 @@ class PageLinkData(ClipboardData):
 				text = self.text
 			elif self.notebook.config['Notebook']['short_links']:
 				href = HRef.new_from_wiki_link(link)
-				text = href.parts()[-1]
-				if self.anchor:
-					text += '#' + self.anchor
+				text = href.short_name()
 			else:
 				text = link
 

--- a/zim/gui/mainwindow.py
+++ b/zim/gui/mainwindow.py
@@ -312,7 +312,7 @@ class MainWindow(WindowBaseMixin, Window):
 		'close': (GObject.SignalFlags.RUN_LAST, None, ()),
 	}
 
-	def __init__(self, notebook, page=None, fullscreen=False, geometry=None):
+	def __init__(self, notebook, page=None, anchor=None, fullscreen=False, geometry=None):
 		'''Constructor
 		@param notebook: the L{Notebook} to show in this window
 		@param page: a C{Path} object to open
@@ -464,7 +464,7 @@ class MainWindow(WindowBaseMixin, Window):
 		page = page or self.history.get_current()
 		if page:
 			page = notebook.get_page(page)
-			self.open_page(page)
+			self.open_page(page, anchor)
 		else:
 			self.open_page_home()
 

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -6526,7 +6526,6 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 
 	def _do_activate_link(self, link, hints):
 		type = link_type(link)
-
 		if type == 'page':
 			href = HRef.new_from_wiki_link(link)
 			path = self.notebook.pages.resolve_link(self.page, href)
@@ -6536,17 +6535,20 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 			open_file(self, path)
 		elif type == 'notebook':
 			from zim.main import ZIM_APPLICATION
-
 			if link.startswith('zim+'):
-				uri, pagename = link[4:], None
+				uri, pagename, anchor = link[4:], None, None
 				if '?' in uri:
 					uri, pagename = uri.split('?', 1)
-
-				ZIM_APPLICATION.run('--gui', uri, pagename)
-
+				args = [uri]
+				if pagename and '#' in pagename:
+					pagename, anchor = pagename.split('#', 1)
+				if pagename:
+					args.append(pagename)
+				if anchor:
+					args.append(anchor)
 			else:
-				ZIM_APPLICATION.run('--gui', FilePath(link).uri)
-
+				args = [FilePath(link).uri]
+			ZIM_APPLICATION.run('--gui', *args)
 		else:
 			if type == 'mailto' and not link.startswith('mailto:'):
 				link = 'mailto:' + link  # Enforce proper URI form

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -1387,10 +1387,10 @@ class TextBuffer(Gtk.TextBuffer):
 			return None
 
 	def _get_implict_anchor_if_heading(self, iter):
-		text = self._get_heading_text(iter)
+		text = self.get_heading_text(iter)
 		return heading_to_anchor(text) if text else None
 
-	def _get_heading_text(self, iter):
+	def get_heading_text(self, iter):
 		line_start = iter.copy() if iter.starts_line() else self.get_iter_at_line(iter.get_line())
 		is_heading = any(filter(_is_heading_tag, line_start.get_tags()))
 		if not is_heading:
@@ -1398,7 +1398,7 @@ class TextBuffer(Gtk.TextBuffer):
 
 		line_end = line_start.copy()
 		line_end.forward_line()
-		return line_start.get_text(line_end)
+		return line_start.get_text(line_end).strip()
 
 	#endregion
 
@@ -6665,7 +6665,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		item = Gtk.MenuItem.new_with_mnemonic(_('Copy _link to this location')) # T: menu item to copy link to achor location in page
 		anchor = buffer.get_anchor_for_location(iter)
 		if anchor:
-			heading_text = buffer._get_heading_text(iter) # can be None if not a heading
+			heading_text = buffer.get_heading_text(iter) # can be None if not a heading
 			item.connect('activate', _copy_link_to_anchor, anchor, heading_text)
 		else:
 			item.set_sensitive(False)

--- a/zim/gui/server.py
+++ b/zim/gui/server.py
@@ -132,7 +132,7 @@ class ServerWindow(Gtk.Window):
 		try:
 			uri = self.notebookcombobox.get_notebook()
 			if uri:
-				notebook, x = build_notebook(NotebookInfo(uri))
+				notebook, _ = build_notebook(NotebookInfo(uri))
 				if not notebook:
 					return
 			else:

--- a/zim/gui/uiactions.py
+++ b/zim/gui/uiactions.py
@@ -125,7 +125,7 @@ class UIActions(object):
 		from zim.gui.notebookdialog import NotebookDialog
 		NotebookDialog.unique(self, self.widget, callback=self.open_notebook).present()
 
-	def open_notebook(self, location, pagename=None):
+	def open_notebook(self, location, pagename=None, anchor=None):
 		'''Open another notebook.
 		@param location: notebook location as uri or object with "uri" attribute
 		@param pagename: optional page name
@@ -134,10 +134,12 @@ class UIActions(object):
 		assert pagename is None or isinstance(pagename, str)
 
 		uri = location.uri if hasattr(location, 'uri') else location
+		args = [uri]
 		if pagename:
-			ZIM_APPLICATION.run('--gui', uri, pagename)
-		else:
-			ZIM_APPLICATION.run('--gui', uri)
+			args.append(pagename)
+		if anchor:
+			args.append(anchor)
+		ZIM_APPLICATION.run('--gui', *args)
 
 	@action(_('_Import Page...'), menuhints='notebook:edit') # T: Menu item
 	def import_page(self):

--- a/zim/notebook/notebook.py
+++ b/zim/notebook/notebook.py
@@ -1,11 +1,7 @@
 
 # Copyright 2008-2020 Jaap Karssenberg <jaap.karssenberg@gmail.com>
 
-
-
-
 import os
-import re
 import weakref
 import logging
 import threading
@@ -23,7 +19,6 @@ from zim.config import INIConfigFile, String, ConfigDefinitionByClass, Boolean, 
 from zim.errors import Error
 from zim.utils import natural_sort_key
 from zim.newfs.helpers import TrashNotSupportedError
-from zim.config import HierarchicDict
 from zim.parsing import link_type, is_win32_path_re, valid_interwiki_key
 from zim.signals import ConnectorMixin, SignalEmitter, SIGNAL_NORMAL
 
@@ -794,14 +789,11 @@ class Notebook(ConnectorMixin, SignalEmitter):
 
 		if elt.gettext() == elt.get('href'):
 			elt[:] = [link]
-		elif elt.gettext() == oldhref.parts()[-1] and len(elt) == 1:
+		elif elt.gettext() == oldhref.short_name() and len(elt) == 1:
 			# We are using short links and the link text was short link
 			# and there were no sub-node (like bold text) that would be cancelled.
 			# Related to 'short_links' but not checking the property here.
-			short = newhref.parts()[-1]
-			if newhref.anchor:
-				short += '#' + newhref.anchor
-			elt[:] = [short]  # 'Journal:2020:01:20' -> '20'
+			elt[:] = [newhref.short_name()]  # 'Journal:2020:01:20' -> '20'
 
 		elt.set('href', link)
 

--- a/zim/notebook/notebook.py
+++ b/zim/notebook/notebook.py
@@ -266,7 +266,7 @@ class Notebook(ConnectorMixin, SignalEmitter):
 		_NOTEBOOK_CACHE[dir.uri] = nb
 		return nb
 
-	def __init__(self, cache_dir, config, folder, layout, index):
+	def __init__(self, cache_dir, config: NotebookConfig, folder, layout, index):
 		'''Constructor
 		@param cache_dir: a L{Folder} object used for caching the notebook state
 		@param config: a L{NotebookConfig} object

--- a/zim/notebook/page.py
+++ b/zim/notebook/page.py
@@ -372,6 +372,10 @@ class HRef(object):
 	def parts(self):
 		return self.names.split(':') if self.names else []
 
+	def short_name(self):
+		name = self.parts()[-1] if self.names else ""
+		return name + "#" + self.anchor if self.anchor else name
+
 	def to_wiki_link(self):
 		'''Returns href as text for wiki link'''
 		if self.rel == HREF_REL_ABSOLUTE:

--- a/zim/plugins/quicknote.py
+++ b/zim/plugins/quicknote.py
@@ -332,7 +332,7 @@ class QuickNoteDialog(Dialog):
 			try:
 				if isinstance(notebook, str):
 					notebook = NotebookInfo(notebook)
-				obj, x = build_notebook(notebook)
+				obj, _ = build_notebook(notebook)
 				self.form.widgets['namespace'].notebook = obj
 				self.form.widgets['page'].notebook = obj
 				logger.debug('Notebook for autocomplete: %s (%s)', obj, notebook)
@@ -445,7 +445,7 @@ class QuickNoteDialog(Dialog):
 
 	def _get_notebook(self):
 		uri = self.notebookcombobox.get_notebook()
-		notebook, p = build_notebook(LocalFolder(uri))
+		notebook, _ = build_notebook(LocalFolder(uri))
 		return notebook
 
 	def create_new_page(self, notebook, path, text):

--- a/zim/plugins/tableofcontents.py
+++ b/zim/plugins/tableofcontents.py
@@ -1,13 +1,12 @@
-
 # Copyright 2012-2018 Jaap Karssenberg <jaap.karssenberg@gmail.com>
 
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject
 from gi.repository import Pango
+from typing import List, Optional, Tuple
 
-import re
-import datetime
+
 import logging
 
 logger = logging.getLogger('zim.plugins.tableofcontents')
@@ -15,14 +14,14 @@ logger = logging.getLogger('zim.plugins.tableofcontents')
 
 from zim.plugins import PluginClass
 from zim.signals import ConnectorMixin, DelayedCallback
-from zim.notebook import Path
-from zim.tokenparser import collect_untill_end_token, tokens_to_text
-from zim.formats import HEADING, LINE
+from zim.tokenparser import collect_until_end_token_iter, filter_token, tokens_to_text
+from zim.formats import ANCHOR, HEADING, LINE
 
+from zim.gui.clipboard import Clipboard, SelectionClipboard
 from zim.gui.pageview import PageViewExtension
 from zim.gui.widgets import LEFT_PANE, PANE_POSITIONS, BrowserTreeView, populate_popup_add_separator, \
 	WindowSidePaneWidget, widget_set_css
-from zim.gui.pageview import FIND_REGEX, SCROLL_TO_MARK_MARGIN, _is_heading_tag, LineSeparatorAnchor
+from zim.gui.pageview import SCROLL_TO_MARK_MARGIN, _is_heading_tag, LineSeparatorAnchor
 
 LINE_LEVEL = 2  # assume level 1 is page heading, level 2 is topic break within page
 
@@ -76,7 +75,10 @@ def get_headings(parsetree, include_hr):
 		if t[0] == HEADING:
 			level = int(t[1]['level'])
 			text = tokens_to_text(
-						collect_untill_end_token(tokens, HEADING) ).strip()
+				filter_token(
+					collect_until_end_token_iter(tokens, HEADING),
+					ANCHOR
+				)).strip()
 			assert level > 0 # just to be sure
 			while stack[-1][0] >= level:
 				stack.pop()
@@ -325,7 +327,8 @@ class ToCWidget(ConnectorMixin, Gtk.ScrolledWindow):
 			model.clear()
 		else:
 			if model is not None:
-				model.update(get_headings(tree, self.include_hr), self.show_h1)
+				headings = get_headings(tree, self.include_hr)
+				model.update(headings, self.show_h1)
 		self.emit('changed')
 
 	def on_heading_activated(self, treeview, path, column):
@@ -373,7 +376,31 @@ class ToCWidget(ConnectorMixin, Gtk.ScrolledWindow):
 
 		buffer.select_range(start, end)
 
+	def on_copy_link_to_anchor(self, obj, anchor: str, heading_text: str):
+		Clipboard.set_pagelink(self.pageview.notebook, self.pageview.page, anchor, heading_text)
+		SelectionClipboard.set_pagelink(self.pageview.notebook, self.pageview.page, anchor, heading_text)
+		return True
+
+	def can_copy_link_to_anchor(self, paths: List[str]) -> Optional[Tuple[str,str]]:
+		if not paths or len(paths) != 1:
+			return None
+		model = self.treeview.get_model()
+		n = model.get_nth_heading(paths[0])
+		textview = self.pageview.textview
+		buffer = textview.get_buffer()
+		hd_iter = find_heading(buffer, n, self.include_hr)
+		if not hd_iter:
+			return None
+		anchor = buffer.get_anchor_for_location(hd_iter)
+		if not anchor:
+			return None
+		heading_text = buffer.get_heading_text(hd_iter)
+		if not heading_text:
+			return None
+		return anchor, heading_text
+
 	def on_populate_popup(self, treeview, menu):
+
 		model, paths = treeview.get_selection().get_selected_rows()
 		if not paths:
 			can_promote = False
@@ -383,6 +410,7 @@ class ToCWidget(ConnectorMixin, Gtk.ScrolledWindow):
 			can_demote = self.can_demote(paths)
 
 		populate_popup_add_separator(menu, prepend=True)
+
 		for text, sensitive, handler in (
 			(_('Demote'), can_demote, self.on_demote),
 				# T: action to lower level of heading in the text
@@ -396,7 +424,29 @@ class ToCWidget(ConnectorMixin, Gtk.ScrolledWindow):
 			else:
 				item.set_sensitive(False)
 
+		sep = Gtk.SeparatorMenuItem()
+		menu.append(sep)
+
+		item = Gtk.MenuItem.new_with_mnemonic(_("Copy _link to this location"))
+		menu.append(item)
+		link_details = self.can_copy_link_to_anchor(paths)
+		if link_details:
+			item.connect('activate', self.on_copy_link_to_anchor, *link_details)
+		else:
+			item.set_sensitive(False)
+
+		# open in new window
+		item = Gtk.MenuItem.new_with_mnemonic(_('Open in New _Window'))
+		menu.append(item)
+		if link_details:
+			item.connect('activate', self.on_open_in_new_window, *link_details)
+		else:
+			item.set_sensitive(False)
+
 		menu.show_all()
+
+	def on_open_in_new_window(self, obj, anchor: str, heading_text: str):
+		self.pageview.navigation.open_page(self.pageview.page, anchor, new_window=True)
 
 	def can_promote(self, paths):
 		# All headings have level larger than 1
@@ -414,7 +464,7 @@ class ToCWidget(ConnectorMixin, Gtk.ScrolledWindow):
 			for i in model.walk(iter):
 				p = model.get_path(i)
 				key = tuple(p)
-				if not key in seen:
+				if key not in seen:
 					if self.show_h1:
 						newlevel = len(p) - 1
 					else:

--- a/zim/plugins/tasklist/indexer.py
+++ b/zim/plugins/tasklist/indexer.py
@@ -626,7 +626,7 @@ class TaskParser(object):
 
 	def _parse_paragraph(self, token_iter, defaults):
 		# Look for lines that define tasks
-		paragraph = collect_untill_end_token(token_iter, PARAGRAPH)
+		paragraph = collect_until_end_token(token_iter, PARAGRAPH)
 		tasks = []
 
 		for line in tokens_by_line(paragraph):

--- a/zim/plugins/tasklist/indexer.py
+++ b/zim/plugins/tasklist/indexer.py
@@ -1,7 +1,4 @@
-
 # Copyright 2009-2020 Jaap Karssenberg <jaap.karssenberg@gmail.com>
-
-
 
 import logging
 import re
@@ -17,7 +14,7 @@ from zim.formats import get_format, \
 	HEADING, PARAGRAPH, BLOCK, NUMBEREDLIST, BULLETLIST, LISTITEM, STRIKE, \
 	Visitor, VisitorSkip
 from zim.tokenparser import TEXT, END, \
-	skip_to_end_token, tokens_to_text, tokens_by_line, collect_untill_end_token
+	skip_to_end_token, tokens_to_text, tokens_by_line, collect_until_end_token
 
 from zim.plugins.journal import daterange_from_path
 	# TODO instead of just importing this function we should define
@@ -584,7 +581,7 @@ class TaskParser(object):
 			return False
 
 	def _parse_heading(self, token_iter, daterange):
-		head = collect_untill_end_token(token_iter, HEADING)
+		head = collect_until_end_token(token_iter, HEADING)
 
 		if daterange:
 			day = self._parse_heading_day(head, daterange)


### PR DESCRIPTION
The context menu for ToC entries gets extended by offering now in addition
- "Copy link to heading"
- "Open in New Window"

The PR also fixes the wrong displaying of headings with an explicit anchor in the ToC pane (filtering for a tag was added bc of this).