### PR TITLE
Fix html:// to https:// in Link manual page

### DIFF
--- a/data/manual/Help/Links.txt
+++ b/data/manual/Help/Links.txt
@@ -4,7 +4,7 @@ Creation-Date: 2021-01-19T20:44:59+01:00
 
 ====== Links ======
 
-You can either link pages or URLs. URLs are recognized because they start with e.g. "''html://''" or "''mailto:''". Page names can contain ':' characters to separate the page name from parent pages.
+You can either link pages or URLs. URLs are recognized because they start with e.g. "''https://''" or "''mailto:''". Page names can contain ':' characters to separate the page name from parent pages.
 
 * Links containing a '/' are considered links to external files
 * Links that start with a ':' are resolved from the top level of the notebook


### PR DESCRIPTION
Currently, the docs refer to a html:// page, probably http:// or https:// was ment.