### PR TITLE
Zeitgeist plugin fixes

### DIFF
--- a/zim/plugins/zeitgeist-logger.py
+++ b/zim/plugins/zeitgeist-logger.py
@@ -82,7 +82,11 @@ class ZeitGeistMainWindowExtension(MainWindowExtension):
 	def __init__(self, plugin, window):
 		MainWindowExtension.__init__(self, plugin, window)
 		self.connectto(window, 'page-changed')
-		self.page = None
+		if window.page is not None:
+			self.plugin.create_and_send_event(window.page, Interpretation.ACCESS_EVENT)
+			self.page = window.page
+		else:
+			self.page = None
 
 	def on_page_changed(self, pageview, page):
 		if self.page is not None:

--- a/zim/plugins/zeitgeist-logger.py
+++ b/zim/plugins/zeitgeist-logger.py
@@ -104,10 +104,10 @@ class ZeitgeistNotebookExtension(NotebookExtension):
 		self.connectto_all(notebook,
 			('deleted-page', 'stored-page'), order=SIGNAL_AFTER)
 
-	def on_deleted_page(self, page, path):
+	def on_deleted_page(self, notebook, page):
 		logger.debug("Deleted page: %s", page.name)
 		self.plugin.create_and_send_event(page, Interpretation.DELETE_EVENT)
 
-	def on_stored_page(self, page, path):
+	def on_stored_page(self, notebook, page):
 		logger.debug("Modified page: %s", page.name)
 		self.plugin.create_and_send_event(page, Interpretation.MODIFY_EVENT)


### PR DESCRIPTION
Apologies for proposing another PR for the zeitgeist plugin after #1625, but as @Nick222 reported in #1640, its current state is quite broken... This PR should fix the following two problems in the zeitgeist plugin:
* modify and delete events for not sent correctly at all (not sure whether this was always broken or resulted from changes in zim)
* send an access event for the page that is open when starting zim (the plugin is loaded after its page-opened event).

Fixes #1640 