### PR TITLE
Use LC_TIME locale to determine first day of week

### DIFF
--- a/zim/datetimetz.py
+++ b/zim/datetimetz.py
@@ -15,6 +15,7 @@ with weeknumbers correctly.
 
 import re
 import locale
+locale.setlocale(locale.LC_ALL, '')
 
 from datetime import *
 
@@ -83,7 +84,7 @@ def init_first_day_of_week():
 	global FIRST_DAY_OF_WEEK
 	try:
 		import babel
-		mylocale = babel.Locale(locale.getdefaultlocale()[0])
+		mylocale = babel.Locale(locale.getlocale(locale.LC_TIME)[0])
 		if mylocale.first_week_day == 0:
 			FIRST_DAY_OF_WEEK = MONDAY
 		else:


### PR DESCRIPTION
As per https://docs.python.org/3/library/locale.html `setlocale` needs to be called to initialize getlocale() from the user environment. Then we can lookup the right locale setting. `LC_TIME` is the proper one here, not the default locale (`LANG` or `LC_ALL`)

:warning: not tested, submitted directly from github edit form

See also https://stackoverflow.com/questions/48270191/python-does-not-use-locale-from-environment.