### PR TITLE
set initial date for the journal widget if opening journal page from CLI

### DIFF
--- a/zim/plugins/journal.py
+++ b/zim/plugins/journal.py
@@ -233,6 +233,8 @@ class JournalNotebookViewExtension(NotebookViewExtension):
 		self.notebook = pageview.notebook
 		self.calendar_widget = CalendarWidget(plugin, self.notebook, self.navigation)
 		self.connectto(pageview, 'page-changed', lambda o, p: self.calendar_widget.set_page(p))
+		if pageview.page is not None:
+			self.calendar_widget.set_page(pageview.page)
 
 		properties = self.plugin.notebook_properties(self.notebook)
 		self.connectto(properties, 'changed', self.on_properties_changed)


### PR DESCRIPTION
If I open the journal entry from the command line (e.g. `zim notes Journal:2021:11:07`) the date shown in the journal selector is always today, regardless of the actual date opened. This patch attempts to rectify the issue by setting the page in the calendar widget right after initialization.