### PR TITLE
added option to PageIndex Plugin for setting the namespace to somethi…

### DIFF
--- a/zim/plugins/journal.py
+++ b/zim/plugins/journal.py
@@ -118,8 +118,9 @@ Also adds a calendar widget to access these pages.
 	)
 
 	plugin_notebook_properties = (
-		('namespace', 'namespace', _('Section'), Path(':Journal')), # T: input label
+		('namespace', 'namespace', _('Journal section'), Path(':Journal')), # T: input label
 		('granularity', 'choice', _('Use a page for each'), DAY, (DAY, WEEK, MONTH, YEAR)), # T: preferences option, values will be "Day", "Month", ...
+		('show_pages_from', 'namespace', _('Show pages from section'), Path(':Journal')), # T: input label
 	)
 
 	def path_from_date(self, notebook, date):
@@ -245,8 +246,14 @@ class JournalNotebookViewExtension(NotebookViewExtension):
 		self.disconnect_from(old_model)
 
 		index = self.notebook.index
+
 		namespace = properties['namespace']
-		new_model = PageTreeStore(index, root=namespace, reverse=True)
+		doReverse = True
+		if properties['show_pages_from'] is not None and properties['show_pages_from'].name != properties['namespace'].name:
+			namespace = properties['show_pages_from']
+			doReverse = False
+
+		new_model = PageTreeStore(index, root=namespace, reverse=doReverse)
 		self.calendar_widget.treeview.set_model(new_model)
 
 		self.connectto_all(new_model, ('row-inserted', 'row-deleted'), handler=self.on_pane_changed)

--- a/zim/plugins/pageindex/__init__.py
+++ b/zim/plugins/pageindex/__init__.py
@@ -58,6 +58,7 @@ This plugin adds the page index pane to the main window.
 
 	plugin_preferences = (
 		# key, type, label, default
+		('namespace', 'namespace', _('Namespace'), ''), # T: input label
 		('pane', 'choice', _('Position in the window'), LEFT_PANE, PANE_POSITIONS),
 			# T: preferences option
 		('use_drag_and_drop', 'bool', _('Use drag&drop to move pages in the notebook'), False),
@@ -77,10 +78,9 @@ class PageIndexNotebookViewExtension(NotebookViewExtension):
 
 	def __init__(self, plugin, pageview):
 		NotebookViewExtension.__init__(self, plugin, pageview)
-		index = pageview.notebook.index
-		model = PageTreeStore(index)
+
+		self.notebook = pageview.notebook
 		self.treeview = PageTreeView(pageview.notebook, self.navigation)
-		self.treeview.set_model(model)
 		self.widget = PageIndexWidget(self.treeview)
 
 		# Connect to ui signals
@@ -99,6 +99,15 @@ class PageIndexNotebookViewExtension(NotebookViewExtension):
 		self.plugin.preferences.connect('changed', self.on_preferences_changed)
 
 	def on_preferences_changed(self, preferences):
+		old_model = self.treeview.get_model()
+		self.disconnect_from(old_model)
+
+		logger.debug(preferences)
+		index = self.notebook.index
+		namespace = None if preferences['namespace'] is None or len(preferences['namespace'].strip()) == 0 else Path(preferences['namespace'])
+		new_model = PageTreeStore(index, root=namespace)
+		self.treeview.set_model(new_model)
+
 		self.treeview.set_use_drag_and_drop(preferences['use_drag_and_drop'])
 		self.treeview.set_use_tooltip(preferences['use_tooltip'])
 		self.treeview.set_use_ellipsize(not preferences['use_hscroll'])


### PR DESCRIPTION
added option to PageIndex Plugin for setting the namespace to something different than 'root' - allowing the user to separate PageIndex namespace from Journal namespace

this could also be a solution/alternative for/to https://github.com/zim-desktop-wiki/zim-desktop-wiki/pull/1750