### PR TITLE
Use lowercase desktop name when looking up desktop specific mimeapps.list file

### DIFF
--- a/tests/applications.py
+++ b/tests/applications.py
@@ -279,7 +279,7 @@ class TestApplicationManager(tests.TestCase):
 		self.addCleanup(restore_desktop)
 
 		os.environ['XDG_CURRENT_DESKTOP'] = 'Test'
-		desktopfile = XDG_CONFIG_HOME.file('Test-mimeapps.list')
+		desktopfile = XDG_CONFIG_HOME.file('test-mimeapps.list')
 		defaultfile = XDG_CONFIG_HOME.file('mimeapps.list')
 
 		dir = XDG_DATA_HOME.subdir('applications')

--- a/zim/gui/applications.py
+++ b/zim/gui/applications.py
@@ -305,7 +305,7 @@ class ApplicationManager(object):
 
 		for folder in folders:
 			for desktop in desktops:
-				file = folder.file('%s-mimeapps.list' % desktop)
+				file = folder.file('%s-mimeapps.list' % desktop.lower())
 				if file.exists():
 					yield file
 


### PR DESCRIPTION
The [specification](https://specifications.freedesktop.org/mime-apps-spec/latest/ar01s02.html) states the desktop name should looked up in lowercase form.
This is related to issue #1531.