### PR TITLE
symbol.list: add 8757 (because)

### DIFF
--- a/data/symbols.list
+++ b/data/symbols.list
@@ -254,6 +254,7 @@
 \cup	8746
 \int	8747
 \there4	8756
+\bec	8757
 \sim	8764
 \cong	8773
 \asymp	8776


### PR DESCRIPTION
Should probs look into what other symbols are missing - what's 8758 for
example?

Fixes #1153.