### PR TITLE
Use assertEqual instead of assertEquals

### DIFF
--- a/tests/imagegenerators.py
+++ b/tests/imagegenerators.py
@@ -47,7 +47,7 @@ class TestBackwardImageGeneratorNoPlugins(tests.TestCase):
 		pageview.textview.get_buffer().set_modified(True)
 		tree = pageview.page.get_parsetree()
 		text = WikiDumper().dump(tree)
-		self.assertEquals(text, ['{{./test.png?type=equation}}\n'])
+		self.assertEqual(text, ['{{./test.png?type=equation}}\n'])
 
 
 @tests.skipUnless(InsertEquationPlugin.check_dependencies_ok(), 'Missing dependencies')
@@ -75,7 +75,7 @@ class TestBackwardImageGeneratorWithPlugin(TestBackwardImageGeneratorNoPlugins):
 			attrib, data = otype.data_from_model(model)
 			self.assertTrue(attrib['src'])
 
-		self.assertEquals(attachment_dir.file('equation.tex').read(), r'c = \sqrt{ a^2 + b^2 }')
+		self.assertEqual(attachment_dir.file('equation.tex').read(), r'c = \sqrt{ a^2 + b^2 }')
 		assertIsPNG(attachment_dir.file('equation.png'))
 
 	def testEditObjectDialog(self):
@@ -96,7 +96,7 @@ class TestBackwardImageGeneratorWithPlugin(TestBackwardImageGeneratorNoPlugins):
 		with tests.DialogContext(edit_dialog):
 			pageview.edit_object()
 
-		self.assertEquals(attachment_dir.file('test.tex').read(), r'c = \sqrt{ a^2 + b^2 }')
+		self.assertEqual(attachment_dir.file('test.tex').read(), r'c = \sqrt{ a^2 + b^2 }')
 		assertIsPNG(attachment_dir.file('test.png'))
 
 	def testNewFile(self):
@@ -232,7 +232,7 @@ x_{1,2}=\frac{-b\pm\sqrt{\color{Red}b^2-4ac}}{2a}
 		tree = WikiParser().parse(wiki)
 		latex = LatexDumper(linker).dump(tree)
 
-		self.assertEquals(latex, wanted.splitlines(True))
+		self.assertEqual(latex, wanted.splitlines(True))
 
 
 @tests.skipUnless(InsertDiagramPlugin.check_dependencies_ok(), 'Missing dependencies')

--- a/tests/tableeditor.py
+++ b/tests/tableeditor.py
@@ -81,7 +81,7 @@ class TestWikiSyntaxNoPlugin(tests.TestCase):
 
 	def parseAndDump(self, text):
 		tree = WikiParser().parse(text)
-		self.assertEquals(list(tree.iter_tokens()), TABLE_TOKENS)
+		self.assertEqual(list(tree.iter_tokens()), TABLE_TOKENS)
 
 	def testWikiText(self):
 		self.parseAndDump(TABLE_WIKI_TEXT)
@@ -117,8 +117,8 @@ class TestTableObjectType(tests.TestCase):
 		builder.end('zim-tree')
 		tree = ParseTree(builder.close())
 
-		#self.assertEquals(list(tree.iter_tokens()), TABLE_TOKENS) -- XXX should work but doesn;t :(
-		self.assertEquals(''.join(WikiDumper().dump(tree)), TABLE_WIKI_TEXT[1:-1])
+		#self.assertEqual(list(tree.iter_tokens()), TABLE_TOKENS) -- XXX should work but doesn;t :(
+		self.assertEqual(''.join(WikiDumper().dump(tree)), TABLE_WIKI_TEXT[1:-1])
 
 	def testModelFromData(self):
 		notebook = self.setUpNotebook()
@@ -131,8 +131,8 @@ class TestTableObjectType(tests.TestCase):
 		builder.end('zim-tree')
 		tree = ParseTree(builder.close())
 
-		#self.assertEquals(list(tree.iter_tokens()), TABLE_TOKENS) -- XXX should work but doesn;t :(
-		self.assertEquals(''.join(WikiDumper().dump(tree)), TABLE_WIKI_TEXT[1:-1])
+		#self.assertEqual(list(tree.iter_tokens()), TABLE_TOKENS) -- XXX should work but doesn;t :(
+		self.assertEqual(''.join(WikiDumper().dump(tree)), TABLE_WIKI_TEXT[1:-1])
 
 
 class TestPageViewNoPlugin(tests.TestCase):
@@ -147,7 +147,7 @@ class TestPageViewNoPlugin(tests.TestCase):
 		)
 		pageview.textview.get_buffer().set_modified(True) # Force re-interpretation of the buffer
 		tree = pageview.page.get_parsetree()
-		self.assertEquals(list(tree.iter_tokens()), TABLE_TOKENS)
+		self.assertEqual(list(tree.iter_tokens()), TABLE_TOKENS)
 
 
 class TestPageViewWithPlugin(TestPageViewNoPlugin):


### PR DESCRIPTION
assertEquals is deprecated in Python 3.2 and removed in 3.11.