### PR TITLE
Fix NameError raised by self.notebook.info

### DIFF
--- a/zim/notebook/notebook.py
+++ b/zim/notebook/notebook.py
@@ -352,7 +352,7 @@ class Notebook(ConnectorMixin, SignalEmitter):
 			uri = self.uri
 		except AssertionError:
 			uri = None
-
+		from . import NotebookInfo
 		return NotebookInfo(uri, **self.config['Notebook'])
 
 	def on_properties_changed(self, properties):


### PR DESCRIPTION
`NotebookInfo` was not defined in `notebook.py`. It's imported here to avoid circular imports and also because this property doesn't seem to be used by any existing code - I bumped into this while trying to port the patch from #64 to the latest version.

Let me know if you want a test for this - imo this should be covered by a test of a feature which requires this property