### PR TITLE
Disable automatic tests on Mac OS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        # disable macos until #1797 is fixed
+        #os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10"]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}


### PR DESCRIPTION
until #1797 is fixed. This makes the check-marks actually useful for catching failing tests in the meantime.