### PR TITLE
Path.absname, absolute paths for insert date

### DIFF
--- a/zim/export/template.py
+++ b/zim/export/template.py
@@ -310,7 +310,7 @@ class ExportTemplateContext(dict):
 			else:
 				# links to other pages
 				builder.append(LINK,
-					{'type': 'page', 'href': ':' + path.name},
+					{'type': 'page', 'href': path.absname},
 					path.basename)
 			builder.end(LISTITEM)
 

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -7654,7 +7654,7 @@ class InsertDateDialog(Dialog):
 			text = model[0][self.DATE_COL]
 
 		if self.link and self.linkbutton.get_active():
-			self.buffer.insert_link_at_cursor(text, self.link.name)
+			self.buffer.insert_link_at_cursor(text, self.link.absname)
 		else:
 			self.buffer.insert_at_cursor(text)
 

--- a/zim/gui/widgets.py
+++ b/zim/gui/widgets.py
@@ -1773,7 +1773,7 @@ class PageEntry(InputEntry):
 		elif path.isroot:
 			self.set_text('')
 		else:
-			self.set_text(':' + path.name)
+			self.set_text(path.absname)
 
 	def get_path(self):
 		'''Get the path shown in the widget.

--- a/zim/notebook/page.py
+++ b/zim/notebook/page.py
@@ -227,6 +227,12 @@ class Path(object):
 		return self.name[i:]
 
 	@property
+	def absname(self):
+		'''Get the full, absolute path.
+		Returns ':' for the top level namespace.'''
+		return ':' + self.name
+
+	@property
 	def namespace(self):
 		'''Gives the name for the parent page.
 		Returns an empty string for the top level namespace.
@@ -342,8 +348,8 @@ class HRef(object):
 		@raises ValueError: when the string could not be parsed
 		(see L{Path.makeValidPageName()})
 
-		@note: This method HRef class assumes the logic of our wiki links
-		for other formats, a separate constructor may be needed
+		@note: This method HRef class assumes the logic of our wiki links.
+		For other formats, a separate constructor may be needed.
 		'''
 		if href.startswith(':'):
 			rel = HREF_REL_ABSOLUTE


### PR DESCRIPTION
Complements Path.relname and Path.basename. In addition, replaced
instances of "':' + link.name" with this new property and changed
links created by the "Insert Date and Time" dialog absolute.