### PR TITLE
Upgrade Python version requirement to >= 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ First, you should verify you have the dependencies zim needs. To list all depend
 You will at least need the following:
 
 * Gtk+ >= 3.18
-* python3 >= 3.2
+* python3 >= 3.6
 * python3-gi (also known as pygobject, but make sure to have the "gi" based version)
 * python3-xdg (optional, but recommended)
 * xdg-utils (optional, but recommended on linux)

--- a/debian/control
+++ b/debian/control
@@ -3,13 +3,13 @@ Section: utils
 Priority: optional
 Maintainer: Jaap Karssenberg <jaap.karssenberg@gmail.com>
 Standards-Version: 4.4.0
-Build-Depends: debhelper (>= 7.4.12), dh-python, xdg-utils, python3 (>= 3.2), python3-setuptools, gir1.2-gtk-3.0, python3-gi, python3-xdg
-X-Python3-Version: >=3.2
+Build-Depends: debhelper (>= 7.4.12), dh-python, xdg-utils, python3 (>= 3.6), python3-setuptools, gir1.2-gtk-3.0, python3-gi, python3-xdg
+X-Python3-Version: >=3.6
 
 Package: zim
 Architecture: all
 Homepage: https://zim-wiki.org/
-Depends: ${python3:Depends}, ${misc:Depends}, python3 (>= 3.2), libgtk-3-0 (>= 3.18), gir1.2-gtk-3.0, python3-gi, python3-xdg
+Depends: ${python3:Depends}, ${misc:Depends}, python3 (>= 3.6), libgtk-3-0 (>= 3.18), gir1.2-gtk-3.0, python3-gi, python3-xdg
 # python-gtkspell required for the spell checker plugin
 # Recommends: python-gtkspellcheck
 # graphviz required for the link map/diagram plugins

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ import msgfmt # also distributed with zim
 import makeman # helper script
 
 try:
-	assert sys.version_info >= (3, 2)
+	assert sys.version_info >= (3, 6)
 except:
-	print('zim needs python >= 3.2', file=sys.stderr)
+	print('zim needs python >= 3.6', file=sys.stderr)
 	sys.exit(1)
 
 

--- a/zim.py
+++ b/zim.py
@@ -10,9 +10,9 @@ import re
 
 # Check if we run the correct python version
 try:
-	assert sys.version_info >= (3, 2)
+	assert sys.version_info >= (3, 6)
 except:
-	print('zim needs python >= 3.2', file=sys.stderr)
+	print('zim needs python >= 3.6', file=sys.stderr)
 	sys.exit(1)
 
 

--- a/zim/config/dicts.py
+++ b/zim/config/dicts.py
@@ -30,11 +30,7 @@ import types
 import ast
 import json
 
-try:
-	import collections.abc as abc
-except ImportError:
-	# python < version 3.3
-	import collections as abc
+import collections.abc as abc
 
 from zim.signals import SignalEmitter, ConnectorMixin, SIGNAL_NORMAL, init_signals_for_new_object
 from zim.utils import DefinitionOrderedDict

--- a/zim/plugins/__init__.py
+++ b/zim/plugins/__init__.py
@@ -38,11 +38,7 @@ import logging
 import inspect
 import weakref
 
-try:
-	import collections.abc as abc
-except ImportError:
-	# python < version 3.3
-	import collections as abc
+import collections.abc as abc
 
 from zim.newfs import LocalFolder, LocalFile
 

--- a/zim/templates/expression.py
+++ b/zim/templates/expression.py
@@ -35,12 +35,7 @@ These restrictions hsould help to minimize risk of arbitrary code
 execution in expressions.
 '''
 
-try:
-	import collections.abc as abc
-except ImportError:
-	# python < version 3.3
-	import collections as abc
-
+import collections.abc as abc
 
 import inspect
 import logging

--- a/zim/templates/processor.py
+++ b/zim/templates/processor.py
@@ -10,11 +10,7 @@ expressions in the template.
 '''
 
 
-try:
-	import collections.abc as abc
-except ImportError:
-	# python < version 3.3
-	import collections as abc
+import collections.abc as abc
 
 from zim.newfs import FileNotFoundError
 from zim.utils import MovingWindowIter


### PR DESCRIPTION
Needed for type hints etc; 3.5 has been EOL for over a year, [the oldest Ubuntu LTS is on 3.6](https://packages.ubuntu.com/search?keywords=python3).

Previously discussed at #1776.

Includes the slightest bit of cleanup of old code, didn't touch eg. the regex patterns that have been held back by Python 2.5 (not a typo!).

Let's start a happy new year with a new(er) Python version! :)