### PR TITLE
Improve man page to correctly display Zim use cases.

### DIFF
--- a/makeman.py
+++ b/makeman.py
@@ -24,6 +24,9 @@ def get_about():
 			break # next header
 		elif line.startswith('====') or line.startswith('!['):
 			pass # skip images and header underline
+		elif line.startswith('* '):
+			lines.append('.IP \[bu]\n')
+			lines.append(line[2:]) # add list element
 		else:
 			lines.append(line)
 


### PR DESCRIPTION
The description section of the man page is extracted from the README.md file.
This extraction does not handle markdown lists properly. As a result the list
of use cases is not displayed aesthetically.

       Zim can be used to:

       * Keep an archive of notes * Keep a daily or weekly journal * Take  notes
       during  meetings  or  lectures * Organize task lists * Draft blog entries
       and emails * Do brainstorming

This change update the formatting of this list like:

       Zim can be used to:

       •      Keep an archive of notes

       •      Keep a daily or weekly journal

       •      Take notes during meetings or lectures

       •      Organize task lists

       •      Draft blog entries and emails

       •      Do brainstorming