### PR TITLE
Source View plugin: Don't show hidden languages

### DIFF
--- a/zim/plugins/sourceview.py
+++ b/zim/plugins/sourceview.py
@@ -44,7 +44,7 @@ if GtkSource:
 	lang_ids = lm.get_language_ids()
 	lang_names = [lm.get_language(i).get_name() for i in lang_ids]
 
-	LANGUAGES = dict((lm.get_language(i).get_name(), i) for i in lang_ids)
+	LANGUAGES = dict((lm.get_language(i).get_name(), i) for i in lang_ids if not lm.get_language(i).get_hidden())
 
 	ssm = GtkSource.StyleSchemeManager()
 


### PR DESCRIPTION
Fixes #1921

Ref: https://lazka.github.io/pgi-docs/GtkSource-3.0/classes/Language.html#GtkSource.Language.get_hidden