### PR TITLE
Insert Symbol: allow "custom autocorrect"

### DIFF
--- a/data/manual/Plugins/Insert_Symbol.txt
+++ b/data/manual/Plugins/Insert_Symbol.txt
@@ -4,12 +4,14 @@ Creation-Date: 2010-05-25T16:06:18.373201
 
 ====== Insert Symbol ======
 
-This plugin adds a dialog to insert special symbols and characters. It also enables autoformatting for these symbols and characters.
+This plugin adds a dialog to insert special symbols and characters. It also enables autoformatting for these symbols and characters as well predefined phrases.
 
 Shortcut codes for autoformatting are shown in the tooltip in the dialog. So for example the typing shortcut "\alpha" as a single word in the editor will replace this shortcut by the unicode character for the Greek letter alpha. Similar typing "-->" as a single word will be replaced with a unicode symbol for a right arrow.
 
 In some cases you want to be able to type a character without the trailing whitespace, e.g. when you want to type a formula with several greek letters. In this case the ";" can be used to close the sequence, so typing "\alpha;" will result in the greek letter alpha without any trailing whitespace.
 
-The list with shortcuts can be edited using the button in the dialog or by opening the config file "''symbols.list''" in a text editor. You may need to restart zim in order  load the edited file.
+The list with shortcuts can be edited using the button in the dialog or by opening the config file "''symbols.list''" in a text editor. You may need to restart zim in order to load the edited file.
+
+Phrases won't show up in the dialog, but will be replaced while typing all the same. Use "\n" to break lines, "\\n" for a literal "\n",  "\#" for "#" and "\\#" for "\#".
 
 **Dependencies:** This plugin has no additional dependencies.


### PR DESCRIPTION
Phrases don't show up in the dialog, since they aren't added to the
symbol order list. Lines can be broken using \n, and escapes are
provided to allow literal \n as well as non-comment #.

In my opinion, text replacements should be a core feature, and I see
no point in needlessly duplicating the end_of_word check between
multiple plugins. This solution is quite clean, and could be made
user-friendlier by having a separate dialog and config file for the
phrases while keeping the shared replacement logic.

Closes zim-desktop-wiki/zim-desktop-wiki#846