### PR TITLE
Fix NameError in _update_new_file_submenu

### DIFF
--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -7200,7 +7200,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 			def handler(menuitem, file):
 				self.insert_new_file(file)
 
-			for name in folder.list_files():
+			for file in folder.list_files():
 				name = file.basename
 				if '.' in name:
 					name, x = name.rsplit('.', 1)


### PR DESCRIPTION
Came across this in the logs while testing:

```
DEBUG: Store page in background: Home:Page name with spaces
DEBUG: Index file: /home/introt/Notebooks/Notes/Home/Page_name_with_spaces.txt
Traceback (most recent call last):
  File "/home/introt/repos/zim-desktop-wiki/zim/gui/pageview/__init__.py", line 7204, in _update_new_file_submenu
    name = file.basename
NameError: name 'file' is not defined
```