### PR TITLE
Score editor: add check for convert-ly

### DIFF
--- a/data/manual/Plugins/Score_Editor.txt
+++ b/data/manual/Plugins/Score_Editor.txt
@@ -5,9 +5,9 @@ Wiki-Format: zim 0.4
 
 The score editor is a simple dialog that allows you to insert a score into a page using **GNU Lilypond**.
 
-In order to be able to use this plugin, you must have GNU Lilypond installed and the following command must be available on your system: "''lilypond"''. You can control the look of the scores using the special template "''_Score.ly"''.
+In order to be able to use this plugin, you must have GNU Lilypond installed and the following commands must be available on your system: "''lilypond"'' and "''convert-ly''" ([[#gnu-lilypond-version|why?]]). You can control the look of the scores using the special template "''_Score.ly"''.
 
-**Dependencies:** This plugin requires GNU Lilypond to be installed. In specific the "lilypond" command should be available in the system path.
+**Dependencies:** This plugin requires GNU Lilypond to be installed. Specifically, the "lilypond" and "convert-ly" commands should be available in the system path.
 
 ===== Syntax =====
 
@@ -129,7 +129,7 @@ Feel free to tailor the template file for your needs.
 
 Syntax of GNU Lilypond could change with new releases, and these changes need not be backward compatible. For this reason, the version of GNU Lilypond when the score was created is inserted into the score text by the plugin.
 
-When a different version of GNU Lilypond is installed, the plugin would use ''convert-ly'' (packaged with GNU Lilypond) to convert the score file to be compatible with installed version before rendering the score.
+When a different version of GNU Lilypond is installed, the plugin will use ''convert-ly'' (packaged with GNU Lilypond) to convert the score file to be compatible with installed version before rendering the score.
 
 ===== References =====
 

--- a/zim/plugins/scoreeditor.py
+++ b/zim/plugins/scoreeditor.py
@@ -59,7 +59,11 @@ This is a core plugin shipping with zim.
 	@classmethod
 	def check_dependencies(klass):
 		has_lilypond = Application(lilypond_cmd).tryexec()
-		return has_lilypond, [('GNU Lilypond', has_lilypond, True)]
+		has_convertly = Application(convertly_cmd).tryexec()
+		return has_lilypond and has_convertly, [
+				('GNU Lilypond', has_lilypond, True),
+				('convert-ly', has_convertly, True)
+			]
 
 
 class BackwardScoreImageObjectType(BackwardImageGeneratorObjectType):


### PR DESCRIPTION
On Windows, users may have the lilypond executable in their path
while lacking convert-ly. This adds a check for the availability
of the latter to prevent activating the plugin while lacking the
required dependencies.

Closes #1923