### PR TITLE
Token parsing: fix typo, add filter_token

### DIFF
--- a/tests/tokenparser.py
+++ b/tests/tokenparser.py
@@ -59,25 +59,44 @@ class TestTokenParser(tests.TestCase):
 class TestFunctions(tests.TestCase):
 
 	def testCollectTokens(self):
-		self.assertEqual(	# simple
-			collect_untill_end_token(
+		# simple
+		self.assertEqual(
+			collect_until_end_token(
 				[('B', {}), ('T', ''), (END, 'B'), (END, 'A'), ('T', '')],
 				'A'
 			),
 				[('B', {}), ('T', ''), (END, 'B')]
 		)
-		self.assertEqual(	# nested
-			collect_untill_end_token(
+		# nested
+		self.assertEqual(
+			collect_until_end_token(
 				[('A', {}), ('T', ''), (END, 'A'), (END, 'A'), ('T', '')],
 				'A'
 			),
 				[('A', {}), ('T', ''), (END, 'A')]
 		)
+		# error case: no closing tag found
 		with self.assertRaises(EndOfTokenListError):
-			collect_untill_end_token(
+			collect_until_end_token(
 				[('B', {}), ('T', ''), (END, 'B'), ('T', '')],
 				'A'
 			)
+
+	def testFilterTokens(self):
+		self.assertEqual(
+			list(filter_token(
+				[('T', 'pre'), ('A', {}), ('T', 'inner'), (END, 'A'), ('T', 'post')],
+				'A'
+			)),
+			[('T', 'pre'), ('T', 'post')]
+		)
+		self.assertEqual(
+			list(filter_token(
+				[('T', 'pre'), ('A', {}), ('A', {}), ('T', 'inner'), (END, 'A'), (END, 'A'), ('T', 'post')],
+				'A'
+			)),
+			[('T', 'pre'), ('T', 'post')]
+		)
 
 	def testTokensToText(self):
 		self.assertEqual(

--- a/zim/formats/__init__.py
+++ b/zim/formats/__init__.py
@@ -628,12 +628,12 @@ class ParseTree(object):
 
 	def iter_elements(self, tag):
 		'''Helper function to find all occurences of C{tag}, yields L{TokenListElement}s'''
-		from zim.tokenparser import collect_untill_end_token
+		from zim.tokenparser import collect_until_end_token
 
 		token_iter = self.iter_tokens()
 		for t in token_iter:
 			if t[0] == tag:
-				content = collect_untill_end_token(token_iter, tag)
+				content = collect_until_end_token(token_iter, tag)
 				yield TokenListElement(t[0], t[1], content)
 
 	def substitute_elements(self, tags, func):
@@ -646,13 +646,13 @@ class ParseTree(object):
 		C{tags}. The return value of C{func} can be C{None} to remove the element,
 		the same or a modified L{TokenListElement} or a list of tokens.
 		'''
-		from zim.tokenparser import collect_untill_end_token
+		from zim.tokenparser import collect_until_end_token
 
 		tokens = []
 		token_iter = self.iter_tokens()
 		for t in token_iter:
 			if t[0] in tags:
-				content = collect_untill_end_token(token_iter, t[0])
+				content = collect_until_end_token(token_iter, t[0])
 				replacement = func(TokenListElement(t[0], t[1], content))
 				if replacement is None:
 					pass # remove these tokens

--- a/zim/plugins/tableofcontents.py
+++ b/zim/plugins/tableofcontents.py
@@ -16,7 +16,7 @@ logger = logging.getLogger('zim.plugins.tableofcontents')
 from zim.plugins import PluginClass
 from zim.signals import ConnectorMixin, DelayedCallback
 from zim.notebook import Path
-from zim.tokenparser import collect_untill_end_token, tokens_to_text
+from zim.tokenparser import collect_until_end_token, tokens_to_text
 from zim.formats import HEADING, LINE
 
 from zim.gui.pageview import PageViewExtension
@@ -76,7 +76,7 @@ def get_headings(parsetree, include_hr):
 		if t[0] == HEADING:
 			level = int(t[1]['level'])
 			text = tokens_to_text(
-						collect_untill_end_token(tokens, HEADING) ).strip()
+						collect_until_end_token(tokens, HEADING) ).strip()
 			assert level > 0 # just to be sure
 			while stack[-1][0] >= level:
 				stack.pop()

--- a/zim/plugins/tasklist/indexer.py
+++ b/zim/plugins/tasklist/indexer.py
@@ -16,7 +16,7 @@ from zim.formats import get_format, \
 	UNCHECKED_BOX, CHECKED_BOX, XCHECKED_BOX, MIGRATED_BOX, TRANSMIGRATED_BOX, BULLET, TAG, ANCHOR, \
 	HEADING, PARAGRAPH, BLOCK, NUMBEREDLIST, BULLETLIST, LISTITEM, STRIKE
 from zim.tokenparser import TEXT, END, \
-	skip_to_end_token, tokens_to_text, tokens_by_line, collect_untill_end_token
+	skip_to_end_token, tokens_to_text, tokens_by_line, collect_until_end_token
 
 from zim.plugins.journal import daterange_from_path
 	# TODO instead of just importing this function we should define
@@ -583,7 +583,7 @@ class TaskParser(object):
 			return False
 
 	def _parse_heading(self, token_iter, daterange):
-		head = collect_untill_end_token(token_iter, HEADING)
+		head = collect_until_end_token(token_iter, HEADING)
 
 		if daterange:
 			day = self._parse_heading_day(head, daterange)
@@ -628,7 +628,7 @@ class TaskParser(object):
 
 	def _parse_paragraph(self, token_iter, defaults):
 		# Look for lines that define tasks
-		paragraph = collect_untill_end_token(token_iter, PARAGRAPH)
+		paragraph = collect_until_end_token(token_iter, PARAGRAPH)
 		tasks = []
 
 		for line in tokens_by_line(paragraph):

--- a/zim/tokenparser.py
+++ b/zim/tokenparser.py
@@ -44,7 +44,7 @@ class EndOfTokenListError(AssertionError):
 	pass
 
 
-def collect_untill_end_token(token_iter, tag):
+def collect_until_end_token(token_iter, tag):
 	nesting = 0
 	tokens = []
 	end_token = (END, tag)
@@ -61,6 +61,23 @@ def collect_untill_end_token(token_iter, tag):
 		raise EndOfTokenListError('Did not find "%s" closing tag' % tag)
 
 	return tokens
+
+
+def filter_token(token_iter, token):
+	"""
+	Iterator removing all tokens enclosed by an opening/closing tag 'token'.
+	Nested occurrence of 'token' is taken into account.
+	"""
+	nesting = 0
+	for t in token_iter:
+		if t[0] == token:
+			nesting += 1
+		elif t == (END, token):
+			nesting -= 1
+		elif nesting == 0:
+			yield t
+	if nesting != 0:
+		raise EndOfTokenListError('Mismatch in opening/closing tags for "%s"' % token)
 
 
 def tokens_to_text(tokens):


### PR DESCRIPTION
Taken from zim-desktop-wiki/zim-desktop-wiki#1560 by @roland-ruedenauer 

* s/collect_untill_end_token_iter/collect_until_end_token_iter/g

* filter_token:

        Iterator returning all tokens occurring before detecting
        a closing tag for 'end_token'.
        Nested occurrence of 'end_token' is taken into account.