### PR TITLE
HRef short_name & anchor link fixes for #1769 & #1929

### DIFF
--- a/tests/clipboard.py
+++ b/tests/clipboard.py
@@ -302,7 +302,7 @@ some <b>bold</b> text
 
 	def testCopyPasteParseTreeWithLinkInDifferentPage(self):
 		page = self.notebook.get_page(Path('Test'))
-		page.parse('wiki', '[[+Foo]]\n[[+Foo|Foo]]\n[[+Foo|my foo link]]\n[[+Foo#anchor]]')
+		page.parse('wiki', '[[+Foo]]\n[[+Foo|Foo]]\n[[+Foo|my foo link]]\n[[+Foo#anchor]]\n[[#anchor]]')
 		parsetree = page.get_parsetree()
 		Clipboard.set_parsetree(self.notebook, page, parsetree)
 
@@ -313,13 +313,14 @@ some <b>bold</b> text
 			'<link href="Test:Foo">Test:Foo</link>\n'
 			'<link href="Test:Foo">Foo</link>\n'
 			'<link href="Test:Foo">my foo link</link>\n'
-			'<link href="Test:Foo#anchor">Test:Foo#anchor</link>'
+			'<link href="Test:Foo#anchor">Test:Foo#anchor</link>\n'
+			'<link href="Test#anchor">Test#anchor</link>'
 			'</p></zim-tree>'
 		) # Link updated to point to same target from new location
 
 	def testCopyPasteParseTreeWithLinkInDifferentNotebook(self):
 		page = self.notebook.get_page(Path('Test'))
-		page.parse('wiki', '[[+Foo]]\n[[+Foo|my foo link]]\n[[+Foo#anchor]]')
+		page.parse('wiki', '[[+Foo]]\n[[+Foo|my foo link]]\n[[+Foo#anchor]]\n[[#anchor]]')
 		parsetree = page.get_parsetree()
 		Clipboard.set_parsetree(self.notebook, page, parsetree)
 
@@ -330,7 +331,8 @@ some <b>bold</b> text
 			'<zim-tree><p>'
 			'<link href="first_notebook?Test:Foo">first_notebook?Test:Foo</link>\n'
 			'<link href="first_notebook?Test:Foo">my foo link</link>\n'
-			'<link href="first_notebook?Test:Foo#anchor">first_notebook?Test:Foo#anchor</link>'
+			'<link href="first_notebook?Test:Foo#anchor">first_notebook?Test:Foo#anchor</link>\n'
+			'<link href="first_notebook?Test#anchor">first_notebook?Test#anchor</link>'
 			'</p></zim-tree>'
 		) # Link updated to point to same target from new location
 

--- a/tests/uiactions.py
+++ b/tests/uiactions.py
@@ -459,7 +459,7 @@ class TestUIActions(tests.TestCase):
 
 	def testMovePageUpdateLinks(self):
 		referrer = self.notebook.get_page(Path('Referrer'))
-		referrer.parse('wiki', 'Test [[Test]]\n')
+		referrer.parse('wiki', 'Test [[Test]]\n[[#anchor]]\n')
 		self.notebook.store_page(referrer)
 
 		def movepage(dialog):
@@ -471,7 +471,7 @@ class TestUIActions(tests.TestCase):
 		with tests.DialogContext(movepage):
 			self.uiactions.move_page()
 
-		self.assertEqual(referrer.dump('wiki'), ['Test [[NewParent:Test]]\n'])
+		self.assertEqual(referrer.dump('wiki'), ['Test [[NewParent:Test]]\n', '[[#anchor]]\n'])
 
 	def testMovePageNoUpdateLinks(self):
 		referrer = self.notebook.get_page(Path('Referrer'))

--- a/zim/gui/clipboard.py
+++ b/zim/gui/clipboard.py
@@ -326,9 +326,7 @@ def _link_tree(links, notebook, path):
 				href.anchor = anchor
 				link = href.to_wiki_link()
 				if notebook.config['Notebook']['short_links']:
-					name = href.parts()[-1]
-					if anchor:
-						name += '#' + anchor
+					name = href.short_name()
 			elif type == 'file':
 				try:
 					file = LocalFile(link) # Assume links are always URIs
@@ -508,9 +506,7 @@ class PageLinkData(ClipboardData):
 				text = self.text
 			elif self.notebook.config['Notebook']['short_links']:
 				href = HRef.new_from_wiki_link(link)
-				text = href.parts()[-1]
-				if self.anchor:
-					text += '#' + self.anchor
+				text = href.short_name()
 			else:
 				text = link
 

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -8191,14 +8191,11 @@ class InsertLinkDialog(Dialog):
 		elif self.form['short_links'] and link_type(link) == 'page':
 				# Similar to 'short_links' notebook property but using uistate instead
 				try:
-					parts = HRef.new_from_wiki_link(link).parts()
+					href = HRef.new_from_wiki_link(link)
 				except ValueError:
 					return ''
 				else:
-					if len(parts) > 0:
-						return parts[-1]
-					else:
-						return link
+					return href.short_name()
 		else:
 			return link
 

--- a/zim/notebook/index/links.py
+++ b/zim/notebook/index/links.py
@@ -97,7 +97,7 @@ class LinksIndexer(IndexerBase):
 			(row['id'],)
 		)
 		for href in doc.iter_href(include_anchors=False):
-			assert href.parts()	# links cannot be only anchor
+			assert href.parts()  # links cannot be only anchor
 			anchorkey = natural_sort_key(href.parts()[0])
 			try:
 				#print("INSERT INTO links(%d, %d, %d, %s,...)" % (row['id'], ROOT_ID, href.rel, href.names))

--- a/zim/notebook/notebook.py
+++ b/zim/notebook/notebook.py
@@ -793,12 +793,9 @@ class Notebook(ConnectorMixin, SignalEmitter):
 		from zim.formats import TEXT
 		if elt.content == [(TEXT, elt.attrib['href'])]:
 			elt.content[:] = [(TEXT, link)]
-		elif elt.content == [(TEXT, oldhref.parts()[-1])]:
+		elif elt.content == [(TEXT, oldhref.short_name())]:
 			# Related to 'short_links' but not checking the property here.
-			short = newhref.parts()[-1]
-			if newhref.anchor:
-				short += '#' + newhref.anchor
-			elt.content[:] = [(TEXT, short)]  # 'Journal:2020:01:20' -> '20'
+			elt.content[:] = [(TEXT, newhref.short_name())]  # 'Journal:2020:01:20' -> '20'
 
 		elt.attrib['href'] = link
 

--- a/zim/notebook/notebook.py
+++ b/zim/notebook/notebook.py
@@ -686,7 +686,7 @@ class Notebook(ConnectorMixin, SignalEmitter):
 
 				if oldtarget == oldroot:
 					return self._update_link_tag(elt, page, newroot, href)
-				elif oldtarget.ischild(oldroot):
+				elif oldtarget.ischild(oldroot) and href.names:  # make sure href has parts
 					oldanchor = self.pages.resolve_link(oldpath, HRef(HREF_REL_FLOATING, href.parts()[0]))
 					if oldanchor.ischild(oldroot):
 						pass # oldtarget cannot be trusted
@@ -753,7 +753,7 @@ class Notebook(ConnectorMixin, SignalEmitter):
 				newtarget = newroot.child(target.relname(oldroot))
 				return self._update_link_tag(elt, page, newtarget, href)
 
-			elif href.rel == HREF_REL_FLOATING \
+			elif href.rel == HREF_REL_FLOATING and href.names \
 			and natural_sort_key(href.parts()[0]) == natural_sort_key(oldroot.basename) \
 			and page.ischild(oldroot.parent):
 				try:

--- a/zim/notebook/page.py
+++ b/zim/notebook/page.py
@@ -383,6 +383,11 @@ class HRef():
 	def parts(self) -> List[str]:
 		return self.names.split(':') if self.names else []
 
+	def short_name(self) -> str:
+		" Returns the last name part and/or anchor if any. "
+		name = self.parts()[-1] if self.names else ""
+		return name + "#" + self.anchor if self.anchor else name
+
 	def to_wiki_link(self) -> str:
 		'''Returns href as text for wiki link'''
 		if self.rel == HREF_REL_ABSOLUTE:

--- a/zim/notebook/page.py
+++ b/zim/notebook/page.py
@@ -380,7 +380,7 @@ class HRef():
 		rel = {HREF_REL_ABSOLUTE: 'abs', HREF_REL_FLOATING: 'float', HREF_REL_RELATIVE: 'rel'}[self.rel]
 		return '<%s: %s %s %s>' % (self.__class__.__name__, rel, self.names, self.anchor)
 
-	def parts(self) -> List[str]:
+	def parts(self) -> Union[List, List[str]]:
 		return self.names.split(':') if self.names else []
 
 	def short_name(self) -> str:


### PR DESCRIPTION
* Add HRef.short_name method, which returns the last name part and/or anchor if any (by @roland-ruedenauer) Fixes #1769.
* Add sanity checks for usage of HRef.parts(). Fixes #1929.
* Adds tests to prevent the above from regressing