### PR TITLE
Add linking related UX to ToC pane

### DIFF
--- a/tests/tableofcontents.py
+++ b/tests/tableofcontents.py
@@ -7,6 +7,7 @@ import tests
 
 from tests.mainwindow import setUpMainWindow
 
+from zim.notebook import Path
 from zim.plugins import PluginManager
 from zim.plugins.tableofcontents import *
 from zim.gui.widgets import RIGHT_PANE, LEFT_PANE

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -1429,10 +1429,10 @@ class TextBuffer(Gtk.TextBuffer):
 			return None
 
 	def _get_implict_anchor_if_heading(self, iter):
-		text = self._get_heading_text(iter)
+		text = self.get_heading_text(iter)
 		return heading_to_anchor(text) if text else None
 
-	def _get_heading_text(self, iter):
+	def get_heading_text(self, iter):
 		line_start = iter.copy() if iter.starts_line() else self.get_iter_at_line(iter.get_line())
 		is_heading = any(filter(_is_heading_tag, line_start.get_tags()))
 		if not is_heading:
@@ -1440,7 +1440,7 @@ class TextBuffer(Gtk.TextBuffer):
 
 		line_end = line_start.copy()
 		line_end.forward_line()
-		return line_start.get_text(line_end)
+		return line_start.get_text(line_end).strip()
 
 	#endregion
 
@@ -6698,7 +6698,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		item = Gtk.MenuItem.new_with_mnemonic(_('Copy _link to this location')) # T: menu item to copy link to achor location in page
 		anchor = buffer.get_anchor_for_location(iter)
 		if anchor:
-			heading_text = buffer._get_heading_text(iter) # can be None if not a heading
+			heading_text = buffer.get_heading_text(iter) # can be None if not a heading
 			item.connect('activate', _copy_link_to_anchor, anchor, heading_text)
 		else:
 			item.set_sensitive(False)


### PR DESCRIPTION
Based on #1560, doesn't include the anchor stuff.

    Add linking related UX to ToC pane                                                                                                               
                                                                                                                                                     
    Extend ToC pane context menu with                                                                                                                
                                                                                                                                                     
    * "Copy link to heading"                                                                                                                         
    * "Open in New Window"                                                                                                                           
                                                                                                                                                     
    Also fixes #1730 and horizontal divider                                                                                                          
    context menu sensitivity issues.