### PR TITLE
Prevent autoformatting of bullets during verbatim

### DIFF
--- a/tests/pageview.py
+++ b/tests/pageview.py
@@ -2106,6 +2106,23 @@ foo
 		#~ tree = buffer.get_parsetree(raw=True)
 		#~ self.assertEqual(tree.tostring(), wanted)
 
+		# Test autoformatting of bullets when verbatim format is selected (#1957)
+		press(view, '\n')
+		buffer.toggle_format_tag_by_name('code')
+		press(view, '* test')
+		wanted = '''\
+<?xml version='1.0' encoding='utf-8'?>
+<zim-tree raw="True">aaa
+<li bullet="*" indent="0"> foo
+</li><div indent="0">
+</div><code>* test</code>
+<li bullet="*" indent="1"> duss
+</li><li bullet="*" indent="1"> <link href="">CamelCase</link>
+</li>
+</zim-tree>'''
+		tree = buffer.get_parsetree(raw=True)
+		self.assertEqual(tree.tostring(), wanted)
+
 		# TODO more unindenting ?
 		# TODO checkboxes
 		# TODO Auto formatting of various link types

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -4807,11 +4807,12 @@ class TextView(Gtk.TextView):
 	def do_end_of_word(self, start, end, word, char, editmode):
 		# Default handler with built-in auto-formatting options
 		buffer = self.get_buffer()
+		non_nesting_tags = buffer.range_has_tags(_is_non_nesting_tag, start, end)
 		handled = False
 		#print('WORD >>%s<< CHAR >>%s<<' % (word, char))
 		def apply_anchor(match):
 			#print("ANCHOR >>%s<<" % word)
-			if buffer.range_has_tags(_is_non_nesting_tag, start, end):
+			if non_nesting_tags:
 				return False
 			name = match[2:]
 			buffer.delete(start, end)
@@ -4823,7 +4824,7 @@ class TextView(Gtk.TextView):
 			start = end.copy()
 			if not start.backward_chars(len(match)):
 				return False
-			elif buffer.range_has_tags(_is_non_nesting_tag, start, end):
+			elif non_nesting_tags:
 				return False
 			else:
 				tag = buffer._create_tag_tag(match)
@@ -4857,6 +4858,7 @@ class TextView(Gtk.TextView):
 				return False
 		word_is_numbered_bullet = is_numbered_bullet_re.match(word)
 		if (char == ' ' or char == '\t') \
+		and not non_nesting_tags \
 		and allow_bullet(start, word_is_numbered_bullet) \
 		and (word in autoformat_bullets or word_is_numbered_bullet):
 			if buffer.range_has_tags(_is_heading_tag, start, end):


### PR DESCRIPTION
`/^* /` would produce a bullet while the verbatim format was active.

Source text produced before this PR after selecting the verbatim formatting and typing `* test`:
`* test` (the bullet gets autoformatted and the verbatim format gets ditched)

New behavior:
`''* test''` (text typed in verbatim is displayed verbatim)