### PR TITLE
Added mnemonics to collapse all entries in PageIndex

### DIFF
--- a/zim/plugins/pageindex/__init__.py
+++ b/zim/plugins/pageindex/__init__.py
@@ -1,6 +1,7 @@
 
 # Copyright 2008-2018 Jaap Karssenberg <jaap.karssenberg@gmail.com>
 
+from nturl2path import pathname2url
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -17,7 +18,7 @@ from zim.notebook.index.base import TreeModelMixinBase
 from zim.notebook.index.pages import PagesTreeModelMixin, PageIndexRecord, IndexNotFoundError, IS_PAGE
 
 from zim.plugins import PluginClass
-from zim.actions import PRIMARY_MODIFIER_MASK
+from zim.actions import PRIMARY_MODIFIER_MASK, action
 
 from zim.gui.notebookview import NotebookViewExtension
 from zim.gui.widgets import BrowserTreeView, ScrolledWindow, \
@@ -125,6 +126,10 @@ class PageIndexNotebookViewExtension(NotebookViewExtension):
 		self.treeview.disconnect_index()
 		model = PageTreeStore(self.pageview.notebook.index)
 		self.treeview.set_model(model)
+
+	@action(_('Collapse All'), accelerator='<Alt>K', menuhints='view') # T: menu item
+	def collapse(self):
+		self.treeview.collapse_all()
 
 
 class PageIndexWidget(Gtk.VBox, WindowSidePaneWidget):

--- a/zim/plugins/pageindex/__init__.py
+++ b/zim/plugins/pageindex/__init__.py
@@ -131,6 +131,17 @@ class PageIndexNotebookViewExtension(NotebookViewExtension):
 	def collapse(self):
 		self.treeview.collapse_all()
 
+	@action(_('Reveal current page in Page Index'), accelerator='<Alt>Y', menuhints='view') # T: menu item
+	def reveal(self):
+		model = self.treeview.get_model()
+		try:
+			treepaths = model.find_all(model.current_page)
+		except IndexNotFoundError:
+			return
+		else:
+			if len(treepaths) != 0:
+				self.treeview.select_treepath(treepaths[0])
+
 
 class PageIndexWidget(Gtk.VBox, WindowSidePaneWidget):
 

--- a/zim/plugins/pageindex/__init__.py
+++ b/zim/plugins/pageindex/__init__.py
@@ -1,7 +1,6 @@
 
 # Copyright 2008-2018 Jaap Karssenberg <jaap.karssenberg@gmail.com>
 
-from nturl2path import pathname2url
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -127,7 +126,7 @@ class PageIndexNotebookViewExtension(NotebookViewExtension):
 		model = PageTreeStore(self.pageview.notebook.index)
 		self.treeview.set_model(model)
 
-	@action(_('Collapse All'), accelerator='<Alt>K', menuhints='view') # T: menu item
+	@action(_('Collapse Page Index'), accelerator='<Alt>K', menuhints='view') # T: menu item
 	def collapse(self):
 		self.treeview.collapse_all()
 

--- a/zim/plugins/pageindex/__init__.py
+++ b/zim/plugins/pageindex/__init__.py
@@ -126,11 +126,11 @@ class PageIndexNotebookViewExtension(NotebookViewExtension):
 		model = PageTreeStore(self.pageview.notebook.index)
 		self.treeview.set_model(model)
 
-	@action(_('Collapse Page Index'), accelerator='<Alt>K', menuhints='view') # T: menu item
+	@action(_('Collapse Page Index'), accelerator=None, menuhints='view') # T: menu item
 	def collapse(self):
 		self.treeview.collapse_all()
 
-	@action(_('Reveal current page in Page Index'), accelerator='<Alt>Y', menuhints='view') # T: menu item
+	@action(_('Reveal current page in Page Index'), accelerator=None, menuhints='view') # T: menu item
 	def reveal(self):
 		model = self.treeview.get_model()
 		try:


### PR DESCRIPTION
Added mnemonic to collapse all entries in PageIndex (without the need to select PageIndex pane beforehand).

I am aware that you can press "\" in PageIndex pane, but for that to work, one first needs to select the PageIndex pane which I found is inconvenient in daily use.

Any feedback welcome!
