### PR TITLE
LinkMap plugin: Add more dynamic navigation

### DIFF
--- a/zim/plugins/linkmap.py
+++ b/zim/plugins/linkmap.py
@@ -43,6 +43,8 @@ This is a core plugin shipping with zim.
 	plugin_preferences = (
 		# key, type, label, default
 		('button_in_headerbar', 'bool', _('Show linkmap button in headerbar'), True),
+		('refresh_on_move', 'bool', _('Fully refresh when moving (with double-click)'), False),
+		('depth', 'int', _('Link search depth'), 2, (1,16)),
 			# T: preferences option
 	)
 
@@ -61,7 +63,7 @@ class LinkMap(object):
 	def __init__(self, notebook, path, depth=2):
 		self.notebook = notebook
 		self.path = path
-		self.depth = depth
+		self.links = list(self._links(path, depth))
 
 	def _all_links(self):
 		for page in self.notebook.pages.walk():
@@ -102,7 +104,7 @@ class LinkMap(object):
 
 		seen = set()
 		seen.add(self.path.name)
-		for link in self._links(self.path, self.depth):
+		for link in self.links:
 			for name in (link.source.name, link.target.name):
 				if not name in seen:
 					dotcode.append('  "%s" [URL="%s"];' % (name, name))
@@ -128,25 +130,25 @@ class LinkMapPageViewExtension(PageViewExtension):
 
 	@action(_('Link Map'), icon='linkmap-symbolic', menuhints='view:headerbar') # T: menu item
 	def show_linkmap(self):
-		linkmap = LinkMap(self.pageview.notebook, self.pageview.page)
-		dialog = LinkMapDialog(self.pageview, linkmap, self.navigation)
+		dialog = LinkMapDialog(self.pageview, self.navigation, self.plugin.preferences['depth'], self.plugin.preferences['refresh_on_move'])
 		dialog.show_all()
 
 
 class LinkMapDialog(Dialog):
 
-	def __init__(self, parent, linkmap, navigation):
+	def __init__(self, parent, navigation, depth_pref, refresh_pref):
 		Dialog.__init__(self, parent, 'LinkMap',
 			defaultwindowsize=(400, 400), buttons=Gtk.ButtonsType.CLOSE)
-		self.linkmap = linkmap
+		self.pageview = parent
 		self.navigation = navigation
+		self.depth_preference = depth_pref
+		self.refresh_preference = refresh_pref
 
 		hbox = Gtk.HBox(spacing=5)
 		self.vbox.pack_start(hbox, True, True, 0)
 
 		self.xdotview = xdot.DotWidget()
 		self.xdotview.set_filter('fdp')
-		self.xdotview.set_dotcode(linkmap.get_dotcode().encode('UTF-8'))
 		self.xdotview.connect('clicked', self.on_node_clicked)
 		hbox.add(self.xdotview)
 
@@ -161,9 +163,17 @@ class LinkMapDialog(Dialog):
 			button = IconButton(stock)
 			button.connect('clicked', method)
 			vbox.pack_start(button, False, True, 0)
+		# Rebuild & refresh
+		self.rebuild_linkmap()
+
+	def rebuild_linkmap(self):
+		self.linkmap = LinkMap(self.pageview.notebook, self.pageview.page, self.depth_preference)
+		self.xdotview.set_dotcode(self.linkmap.get_dotcode().encode('UTF-8'))
 
 	def on_node_clicked(self, widget, name, event):
 		if re.match('b\'.*?\'$', name):
 			# Bug in dotcode ? URLS come in as strings containing byte representation
 			name = ast.literal_eval(name).decode('UTF-8')
 		self.navigation.open_page(Path(name))
+		if self.refresh_preference:
+			self.rebuild_linkmap()


### PR DESCRIPTION
Adds some configuration options for more dynamic navigation of the link map.
In particular, adds a `depth` option (to control link search depth) and a `refresh_on_move` option (to allow navigating the link map dynamically).
