### PR TITLE
Path existance is made agnostic of whether path is directory or file

### DIFF
--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -6763,7 +6763,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 			item = Gtk.MenuItem.new_with_mnemonic(_('Open With...'))
 				# T: menu item for sub menu with applications
 			menu.prepend(item)
-			if file.exists():
+			if FilePath.exists(file):
 				submenu = OpenWithMenu(self, file)
 				item.set_submenu(submenu)
 			else:
@@ -6793,7 +6793,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 
 		item = Gtk.MenuItem.new_with_mnemonic(_('_Open'))
 			# T: menu item to open a link or file
-		if file and not file.exists():
+		if file and not FilePath.exists(file):
 			item.set_sensitive(False)
 		else:
 			item.connect_object(


### PR DESCRIPTION
The context menu for an anchor in the page view will use `zim.fs.File` which is derived from `zim.fs.FilePath` to represent the target no matter if the target is a file or a directory. Since `file.exists()` is used to populate the context menu no `Open with...` or even `Open` will be available for anchors to local directories (for instance, another zim).
By using the `zim.fs.FilePath.exists()` function instead these options are available both for files and directories.

Another solution could be to use the `FilePath` type for all paths that has not yet been determined whether they are directories or not in the application logic.