### PR TITLE
Version control: fix fossil

### DIFF
--- a/zim/plugins/versioncontrol/__init__.py
+++ b/zim/plugins/versioncontrol/__init__.py
@@ -977,7 +977,7 @@ state. Or select multiple versions to see changes between those versions.
 		# TODO check for gannotated
 		file = self._get_file()
 		assert not file is None
-		annotated = self.vcs.annotated(file)
+		annotated = self.vcs.annotate(file)
 		TextDialog(self, _('Annotated Page Source'), annotated).run()
 			# T: dialog title
 

--- a/zim/plugins/versioncontrol/fossil.py
+++ b/zim/plugins/versioncontrol/fossil.py
@@ -140,7 +140,7 @@ class FOSSILApplicationBackend(VCSApplicationBase):
 
 		@returns: a boolean True if a repo is already setup, or False
 		"""
-		return self.root.file('.fslckout').exists() or self.root.file('_FOSSIL_').exists()
+		return self.root.file('.fslckout').exists() or self.root.file('notebook.fossil').exists()
 
 	def init(self):
 		"""
@@ -154,7 +154,7 @@ class FOSSILApplicationBackend(VCSApplicationBase):
 
 	def checkout(self, file):
 		# Create working folder
-		return self.run(['open', file])
+		return self.run(['open', '--keep', file])
 
 	def is_modified(self):
 		"""Returns true if the repo is not up-to-date, or False


### PR DESCRIPTION
- add '--keep' flag to fossil open, fixes #2005
- check for 'notebook.fossil', fixes #2006
- fix typo in function call, fixes #1248

I've confirmed that creating a new fossil repository and saving versions both work; `fossil timeline` lists all non-empty commits created from Zim, and the saving GUI correctly lists edited files.