### PR TITLE
Fix #2007 - sane Gtk-related defaults for Windows and macOS

### DIFF
--- a/data/manual/Plugins/ToolBar.txt
+++ b/data/manual/Plugins/ToolBar.txt
@@ -7,6 +7,8 @@ This plugin adds a "tool bar" to the main window. It can be a "classic" toolbar 
 
 The toolbar will show a few default tools as well as tools defined in plugins and [[Help:Custom_Tools|custom tools]].
 
+**Note:** Due to an upstream bug, this plugin should be kept enabled on Windows and macOS with the "Show controls in the window decoration" option disabled in order for the windows to behave correctly.
+
 
 ===== Options =====
 

--- a/windows/src/environ-portable.ini
+++ b/windows/src/environ-portable.ini
@@ -11,5 +11,8 @@ XDG_DATA_HOME=../data
 XDG_DATA_DIRS=
 XDG_CACHE_HOME=../cache
 
+# see issue #2007
+GTK_CSD=0
+
 #LANG=NL_nl
 

--- a/zim/plugins/toolbar.py
+++ b/zim/plugins/toolbar.py
@@ -36,6 +36,8 @@ from zim.gui.customtools import CustomToolManager
 
 import zim.errors
 
+import os  # see issue #2007 - Gtk bug on other platforms
+DEFAULT_DECOR = os.uname().sysname == 'Linux'
 
 STYLES = (
 	('ICONS', _('Icons')), # T: toolbar style
@@ -73,7 +75,7 @@ configuring the window decoration.
 
 	plugin_preferences = (
 		# key, type, label, default
-		('show_headerbar', 'bool', _('Show controls in the window decoration') + '\n' + _('This option requires restart of the application'), True),
+		('show_headerbar', 'bool', _('Show controls in the window decoration') + '\n' + _('This option requires restart of the application'), DEFAULT_DECOR),
 			# T: option for plugin preferences
 		('show_toolbar', 'bool', _('Show toolbar'), True),
 			# T: option for plugin preferences

--- a/zim/plugins/toolbar.py
+++ b/zim/plugins/toolbar.py
@@ -36,8 +36,10 @@ from zim.gui.customtools import CustomToolManager
 
 import zim.errors
 
-import os  # see issue #2007 - Gtk bug on other platforms
-DEFAULT_DECOR = os.uname().sysname == 'Linux'
+import os  # see issue #2007 - Gtk bug on Windows and macOS
+DEFAULT_DECOR = not (os.name == 'nt' or \
+	(hasattr(os, 'uname') and os.uname().sysname == 'Darwin')
+)
 
 STYLES = (
 	('ICONS', _('Icons')), # T: toolbar style
@@ -63,11 +65,16 @@ class ToolBarPlugin(PluginClass):
 
 	plugin_info = {
 		'name': _('Tool Bar'), # T: plugin name
-		'description': _('''\
+		'description': _(f'''\
 This plugin adds a "tool bar" to the main window.
 It can be a "classic" toolbar at the top of the window
-or running along the side of the window. It also allows
-configuring the window decoration.
+or running along the side of the window.
+
+It also allows configuring the window decoration,
+thought changing the defaults can have unintended
+consequences on Windows and macOS; please consult
+the manual before disabling the plugin or modifying
+the window decoration related settings.
 '''), # T: plugin description
 		'author': 'Jaap Karssenberg',
 		'help': 'Plugins:ToolBar',
@@ -75,7 +82,7 @@ configuring the window decoration.
 
 	plugin_preferences = (
 		# key, type, label, default
-		('show_headerbar', 'bool', _('Show controls in the window decoration') + '\n' + _('This option requires restart of the application'), DEFAULT_DECOR),
+		('show_headerbar', 'bool', _('Show controls in the window decoration') + '\n' + _('This option requires restart of the application'), DEFAULT_DECOR),  # OS spesific
 			# T: option for plugin preferences
 		('show_toolbar', 'bool', _('Show toolbar'), True),
 			# T: option for plugin preferences


### PR DESCRIPTION
See commit messages.

Draft - doesn't address `GTK_CSD` being 1 by default on non-portable Windows installs.

One way would be to just override it here, but that does prevent people from enjoying the beauty of the broken decorations:

https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/1b9d3c14b2a2c7184a28ec5cb93fccac2f321b95/zim/__init__.py#L185-L187