### PR TITLE
Fix KDE drag-n-drop bug

### DIFF
--- a/zim/plugins/pageindex/__init__.py
+++ b/zim/plugins/pageindex/__init__.py
@@ -539,7 +539,7 @@ class PageTreeView(BrowserTreeView):
 		assert selectiondata.get_target().name() == PAGELIST_TARGET_NAME
 		data = selectiondata.get_data()
 		logger.debug('Drag data recieved: %r', data)
-		if data is None:
+		if data is None or len(data)==0:
 			data = zim.gui.clipboard._internal_selection_data # HACK issue #390
 			zim.gui.clipboard._internal_selection_data = None
 			logger.debug('Got data via workaround: %s', data)


### PR DESCRIPTION
On KDE page drag and drop is broken because, like #390 data absent, but unlike it, it's an empty string, not a None