### PR TITLE
Corrected variable name.

### DIFF
--- a/zim/search.py
+++ b/zim/search.py
@@ -557,7 +557,7 @@ class SearchSelection(PageSelection):
 				try:
 					yield self.notebook.get_page(path)
 				except:
-					logger.exception('Exception opening: %s', page)
+					logger.exception('Exception opening: %s', path)
 					continue
 
 		if scope:


### PR DESCRIPTION
The logging message invocation in the exception handler referenced a non-existing variable and hence made exception handling itself crash.

This replaces PR https://github.com/zim-desktop-wiki/zim-desktop-wiki/pull/2037.