### PR TITLE
Allow cancelling ImageGeneratorDialog via esc

### DIFF
--- a/zim/plugins/base/imagegenerator.py
+++ b/zim/plugins/base/imagegenerator.py
@@ -315,7 +315,7 @@ class ImageGeneratorDialog(Dialog):
 			model.get_text(),
 			syntax
 		).run()
-		if result is not None:
+		if result is not None and result[0] is not None:
 			text, image_file = result
 			model.set_from_generator(text, image_file)
 		model.generator.cleanup()


### PR DESCRIPTION
Add check to make closing the window via other means act
identically to pressing the "Cancel" button. Fixes #2081.