### PR TITLE
Construct the Window.uistate property

### DIFF
--- a/zim/gui/widgets.py
+++ b/zim/gui/widgets.py
@@ -2407,6 +2407,11 @@ class Window(Gtk.Window):
 	def __init__(self):
 		GObject.GObject.__init__(self)
 		self._uistate_initialized = False
+		if hasattr(self, 'uistate'):
+			assert isinstance(self.uistate, zim.config.ConfigDict) # just to be sure
+		else:
+			self.uistate = zim.config.ConfigDict()
+
 		self._last_sidepane_focus = None
 
 		# Construct all the components


### PR DESCRIPTION
Initialize `Window.uistate` in [`Window.__init__`](https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/4d38bb8f5f693e50a4a5f83e4c95eb049f6e9786/zim/gui/widgets.py#L2407-L2409) similar to how it is done in [`Dialog._init__`](https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/4d38bb8f5f693e50a4a5f83e4c95eb049f6e9786/zim/gui/widgets.py#L2866-L2871).

This is needed to avoid a crash when `Window.uistate` is accessed in [`Window.init_uistate`](https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/4d38bb8f5f693e50a4a5f83e4c95eb049f6e9786/zim/gui/widgets.py#L2567) upon calling [`zim.gui.widgets.Window.show_all()`](https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/4d38bb8f5f693e50a4a5f83e4c95eb049f6e9786/zim/gui/widgets.py#L2757-L2758) from the [Tag Autocomplete plugin](https://github.com/shivams/zim-tag-autocompletion/blob/65c1a67770f254110295ae68ad3bc12522023265/__init__.py#L211).