### PR TITLE
Support closing an open 'find bar' by pressing ESC

### DIFF
--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -6069,6 +6069,15 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		self._insertedobject_manager = InsertedObjectPageviewManager(self)
 		self.__zim_extension_objects__.append(self._insertedobject_manager) # HACK to make actions discoverable
 
+	def do_key_press_event(self, event: Gdk.EventKey) -> bool:
+		keyval = strip_boolean_result(event.get_keyval())
+		if keyval == KEYVAL_ESC:
+			# hide the find_bar if it is currently visible
+			if self.find_bar.get_visible():
+				self.hide_find()
+				return True
+		return Gtk.VBox.do_key_press_event(self, event)
+
 	def grab_focus(self):
 		self.textview.grab_focus()
 
@@ -8427,14 +8436,6 @@ class FindBar(FindWidget, Gtk.ActionBar):
 	def on_find_entry_activate(self):
 		self.on_find_entry_changed()
 		self.find_next()
-
-	def do_key_press_event(self, event):
-		keyval = strip_boolean_result(event.get_keyval())
-		if keyval == KEYVAL_ESC:
-			self.hide()
-			return True
-		else:
-			return Gtk.HBox.do_key_press_event(self, event)
 
 
 class FindAndReplaceDialog(FindWidget, Dialog):


### PR DESCRIPTION
I found no way to close the "find bar" opened by a search operation using the keyboard, so I added a small keypress handler a while ago that allows one to close the "find bar" via pressing the ESC key.
So far I've only tested this on Linux.