### PR TITLE
Enables distinct shortcuts for en and em dashes

### DIFF
--- a/data/symbols.list
+++ b/data/symbols.list
@@ -337,7 +337,8 @@
 <=>	8660
 <==>	8660
 <==	8656
---	8212  # em dash aka &mdash; in HTML
+--	8211  # en dash aka &ndash; in HTML
+---	8212  # em dash aka &mdash; in HTML
 =/=	8800  # not equal to sign (may also use \neq)
 +-	177   # +- sign
 +_	177   # +- sign


### PR DESCRIPTION
Currently, the `Insert Symbol` plugin autoformats `--` to `—` (em dash). This is counter-intuitive since `--` usually represents `–` (en dashes) and `---` represents `—` (em dashes) in other markups such as LaTeX.

This pull request changes the default behavior as discussed in #1419.