### PR TITLE
Fixes typo and adds example to Template manual

### DIFF
--- a/data/manual/Help/Templates.txt
+++ b/data/manual/Help/Templates.txt
@@ -323,7 +323,7 @@ The following options are supported:
 
 **HTML**
 * ''options.line_breaks'': value should be either "''default''" or "''remove''", controls line breaks (''<br>'' elements) in paragraphs
-* ''options.empty_lines'': value should be either "defualt" or "remove", controls whether empty lines in the source should be inserted as ''<br>'' elements in the HTML output between top level elements like paragraphs, headings etc.
+* ''options.empty_lines'': value should be either "default" or "remove", controls whether empty lines in the source should be inserted as ''<br>'' elements in the HTML output between top level elements like paragraphs, headings etc.
 
 **Latex**
 * ''options.document_type'': one of "''report''", "''article''" or "''book''". Controls the heading type used.

--- a/data/manual/Help/Templates.txt
+++ b/data/manual/Help/Templates.txt
@@ -329,7 +329,11 @@ The following options are supported:
 * ''options.document_type'': one of "''report''", "''article''" or "''book''". Controls the heading type used.
 
 ===== Template Resources =====
-To add additional files to the template, create a folder of the same name as the template. Any files in the folder (like style sheets, images, javascript files, etc.) will be copied along when this template is used to export data in zim. There is a function "''resource(filename)''" to refer to these files in the template.
+To add additional files to the template, create a folder of the same name as the template. Any files in the folder (like style sheets, images, javascript files, etc.) will be copied along when this template is used to export data in zim. There is a function "''resource(filename)''" to refer to these files in the template. For example:
+
+'''
+<link rel="stylesheet" href="[% resource('style.css') %]">
+'''
 
 Zim always includes some images when exporting for the checkboxes used in checkbox lists. To customize these there should be template resources named "''checked-box.png''", "''unchecked-box.png''" and "''xchecked-box.png''" in this folder.
 

--- a/data/manual/Help/Templates.txt
+++ b/data/manual/Help/Templates.txt
@@ -323,7 +323,7 @@ The following options are supported:
 
 **HTML**
 * ''options.line_breaks'': value should be either "''default''" or "''remove''", controls line breaks (''<br>'' elements) in paragraphs
-* ''options.empty_lines'': value should be either "default" or "remove", controls whether empty lines in the source should be inserted as ''<br>'' elements in the HTML output between top level elements like paragraphs, headings etc.
+* ''options.empty_lines'': value should be either "''default''" or "''remove''", controls whether empty lines in the source should be inserted as ''<br>'' elements in the HTML output between top level elements like paragraphs, headings etc.
 
 **Latex**
 * ''options.document_type'': one of "''report''", "''article''" or "''book''". Controls the heading type used.


### PR DESCRIPTION
Added an example showing how to reference a template resource using the `resource(filename)` function. It wasn't clear to me that the filename should be within quotes. Also fixed a typo and some formatting.