### PR TITLE
Standardize menu items to title case

### DIFF
--- a/data/manual/Help/Menu_Items.txt
+++ b/data/manual/Help/Menu_Items.txt
@@ -283,7 +283,7 @@ Open the folder with [[Help:Attachments|attachments]] for the current page in a 
 **Open Notebook Folder**
 Open the folder for the current notebook in a file browser.
 
-**View debug log**
+**View Debug Log**
 Open ''zim.log'' in the external editor (see [[Preferences]] to set the text editor).
 
 **Start Web Server**

--- a/data/manual/Help/Menu_Items.txt
+++ b/data/manual/Help/Menu_Items.txt
@@ -269,7 +269,7 @@ Open a list with recently changed pages and the time stamps of the last modifica
 **Word Count**
 Show number of lines, words, characters if current page, paragraph and selection.
 
-**Move selected text**
+**Move Selected Text**
 Opens a dialog which allows moving the current text selection to another page and optionally leave a link to the destination page. Similar to cut-and-paste but as a direct action.
 
 **Check Spelling <F7>**

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -7466,7 +7466,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 		else:
 			return buffer.select_word()
 
-	@action(_('Move selected text...')) # T: Menu item
+	@action(_('Move Selected Text...')) # T: Menu item
 	def move_text(self):
 		buffer = self.textview.get_buffer()
 		MoveTextDialog(self, self.notebook, self.page, buffer, self.navigation).run()

--- a/zim/gui/uiactions.py
+++ b/zim/gui/uiactions.py
@@ -365,7 +365,7 @@ class UIActions(object):
 		'''
 		ZIM_APPLICATION.run('--server', '--gui', self.notebook.uri)
 
-	@action(_('View debug log'), menuhints='tools') # T: menu item
+	@action(_('View Debug Log'), menuhints='tools') # T: menu item
 	def show_debug_log(self):
 		from zim.newfs import LocalFile
 		file = LocalFile(zim.debug_log_file)

--- a/zim/plugins/pageindex/__init__.py
+++ b/zim/plugins/pageindex/__init__.py
@@ -130,7 +130,7 @@ class PageIndexNotebookViewExtension(NotebookViewExtension):
 	def collapse(self):
 		self.treeview.collapse_all()
 
-	@action(_('Reveal current page in Page Index'), accelerator=None, menuhints='view') # T: menu item
+	@action(_('Reveal Current Page in Page Index'), accelerator=None, menuhints='view') # T: menu item
 	def reveal(self):
 		model = self.treeview.get_model()
 		try:


### PR DESCRIPTION
Most menu items are written in Title Case, except for a few. I changed these to Title Case for consistency. Example: `View debug log` to `View Debug Log`.