### PR TITLE
Add/restore mention of --index [OPTIONS] in usage

### DIFF
--- a/zim/main/__init__.py
+++ b/zim/main/__init__.py
@@ -48,7 +48,7 @@ usage: zim [OPTIONS] [NOTEBOOK [PAGE]]
    or: zim --server [OPTIONS] [NOTEBOOK]
    or: zim --export [OPTIONS] NOTEBOOK [PAGE]
    or: zim --search NOTEBOOK QUERY
-   or: zim --index  NOTEBOOK
+   or: zim --index  [OPTIONS] NOTEBOOK
    or: zim --plugin PLUGIN [ARGUMENTS]
    or: zim --manual [OPTIONS] [PAGE]
    or: zim --help


### PR DESCRIPTION
Present in `data/manual/Help/Commandline_Options.txt`

See also https://github.com/zim-desktop-wiki/zim-desktop-wiki/issues/2089#issuecomment-1190460461