### PR TITLE
Fix ControlledDict.pop on Python 3.11

### DIFF
--- a/zim/config/dicts.py
+++ b/zim/config/dicts.py
@@ -74,6 +74,13 @@ class ControlledDict(DefinitionOrderedDict, SignalEmitter, ConnectorMixin):
 			self.disconnect_from(v)
 		self.emit('changed')
 
+	def pop(self, key, default=None):
+		# Only emit changed once here
+		with self.block_signals('changed'):
+			v = DefinitionOrderedDict.pop(self, key, default)
+		self.emit('changed')
+		return v
+
 	def update(self, E=(), **F):
 		# Only emit changed once here
 		with self.block_signals('changed'):


### PR DESCRIPTION
The fix for Python Issue BPO-27275 changes `OrderedDict.pop()` behavior
so that it does not call `__delitem__` any more.
On the other hand, `ControlledDict` expects such call to happen
to emit the `changed`' event.
Fixed by overriding `pop()` in `ControlledDict`
so that it explictly emits `changed`.

Fixes #2087