### PR TITLE
Fix macOS tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           eval "$(echo $WRK_DIR/jhb-*/usr/bin/jhb run python3 $(pwd)/test.py)"
         env:
           # disable an internal test within the dependencies
-          SYS_IGNORE_USR_LOCAL: true
+          SYS_USRLOCAL_IGNORE: true
 
 
   test_windows:


### PR DESCRIPTION
Due to updates in the underlying build system for macOS, the name of the variable to ignore errors related to files in /usr/local has changed. This commit updates the workflow accordingly.