### PR TITLE
Use flatpak locale directory in flatpak

### DIFF
--- a/zim/__init__.py
+++ b/zim/__init__.py
@@ -160,7 +160,10 @@ if os.name == "nt" and not os.environ.get('LANG') and _lang not in (None, 'C'):
 	os.environ['LANG'] = _lang + '.' + _enc if _enc else _lang
 
 
-_localedir = os.path.join(os.path.dirname(ZIM_EXECUTABLE), 'locale')
+if os.path.isfile('/.flatpak-info'):
+	_localedir = os.path.join('/app/share/locale/')
+else:
+	_localedir = os.path.join(os.path.dirname(ZIM_EXECUTABLE), 'locale')
 
 try:
 	if os.path.isdir(_localedir):


### PR DESCRIPTION
Check whether Zim is running inside flatpak and use the flatpak locale directory if so.

Inside flatpak locale is at `/app/share/locale`, but the standard locale directory of Python's `gettext` module is `/usr/share/locale`, hence zim fails to load translations in flatpak.

See https://github.com/flathub/org.zim_wiki.Zim/issues/19
