### PR TITLE
TableEditor: hotfix for link visibility, documentation improvements

### DIFF
--- a/data/manual/Plugins/Table_Editor/Superior_Table_Operations.txt
+++ b/data/manual/Plugins/Table_Editor/Superior_Table_Operations.txt
@@ -23,12 +23,12 @@ After formatting: 	{{./cell_after_text_formatting.png}}
 ==== Links in a  cell ====
 '''
 [[http://www.python.org]]
+[[http://www.python.org\|Python homepage]]
 [[foo@bar.org]]
 [[foo]]		Internal Link
 '''
 
-Note:	Only **one link per cell** can be opened. The first one is taken.
-		You can not use a special link text. The link text must be a URL, a mail-address or the title of a linked page.
+Note: Only **one link per cell** can be opened. The first one is taken.
 A link can be accessed with:
 * ''RIGHT MOUSE-BUTTON-CLICK'' on cell with the link  and selection of the menu item //Open cell in content link//
 * ''CTRL + LEFT MOUSE-BUTTON-CLICK'' on a cell

--- a/tests/tableeditor.py
+++ b/tests/tableeditor.py
@@ -237,5 +237,5 @@ class TestTableFunctions(tests.TestCase):
 		self.assertEqual(CellFormatReplacer.cell_to_input('<span background="yellow">highlight</span>', with_pango=True),
 						 '__highlight__')
 		self.assertEqual(CellFormatReplacer.zim_to_cell('<link href="./alink">hello</link>'),
-						 '<span foreground="blue">hello<span size="0">./alink</span></span>')
+						 '<span foreground="blue">hello<span size="1">./alink</span></span>')
 		self.assertEqual(CellFormatReplacer.cell_to_zim('<tt>code-block</tt>'), '<code>code-block</code>')

--- a/zim/plugins/tableeditor.py
+++ b/zim/plugins/tableeditor.py
@@ -42,10 +42,10 @@ SYNTAX_WIKI_PANGO2 = [
 	(r'<mark>\1</mark>', r'<span background="yellow">\1</span>', r'__\1__'),
 	(r'<code>\1</code>', r'<tt>\1</tt>', r"''\1''"),
 	(r'<strike>\1</strike>', r'<s>\1</s>', r'~~\1~~'),
-	# Link url without link text  - Link url has always size = 0
-	(r'<link href="\1">\1</link>', r'<span foreground="blue">\1<span size="0">\1</span></span>', r'[[\1]]'),
-	# Link url with link text  - Link url has always size = 0
-	(r'<link href="\1">\2</link>', r'<span foreground="blue">\2<span size="0">\1</span></span>', r'[[\2|\1]]'),
+	# Link url without link text  - Link url has always size = 1 to stay hidden FIXME: hacky
+	(r'<link href="\1">\1</link>', r'<span foreground="blue">\1<span size="1">\1</span></span>', r'[[\1]]'),
+	# Link url with link text  - Link url has always size = 1 to stay hidden FIXME: hacky
+	(r'<link href="\1">\2</link>', r'<span foreground="blue">\2<span size="1">\1</span></span>', r'[[\2|\1]]'),
 	(r'<emphasis>\1</emphasis>', r'<i>\1</i>', r'//\1//')
 ]
 


### PR DESCRIPTION
* Fixes #2146 and improves documentation.
  * Spans now require a non-zero font size; one "[1024ths of a point](https://docs.gtk.org/Pango/pango_markup.html)" is small enough not to be visible even with longer links.
* Fixes #1413: updates manual to reflect how links inside tables actually work