### PR TITLE
Manual/Help: Document valid tag characters

### DIFF
--- a/data/manual/Help/Tags.txt
+++ b/data/manual/Help/Tags.txt
@@ -8,6 +8,8 @@ Zim supports the use of tags to organize pages. Tags are keywords or labels that
 
 Tags can be used anywhere in a page using the "@" prefix. Like this: @example @tags
 
+Tag names are case insensitive. In addition to letters, they can also contain numbers and undescores.
+
 To find context based on tags you can use the [[Searching|Search]] dialog. For example to find all pages tagged with "@example" you can search for "''Tag: example''" or just for "''@example''". Since tags are cached in the index, this search is much quicker than a full text search for random words.
 
 There is also a plugin that will add a tag cloud and a page index organized by tag in the side page, see also [[Plugins:Tags]]


### PR DESCRIPTION
Basically \w in non-coder speak. Closes #1535.