### PR TITLE
pageview: define os

### DIFF
--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -23,6 +23,7 @@ from gi.repository import Gdk
 from gi.repository import GdkPixbuf
 from gi.repository import Pango
 
+import os
 import re
 import string
 import weakref


### PR DESCRIPTION
Fixes #2224.

`os`(`.path.splittext`) is only ever used once, but importing the whole keeps the code more readable.