### PR TITLE
fixup quicknote

### DIFF
--- a/zim/plugins/quicknote.py
+++ b/zim/plugins/quicknote.py
@@ -458,8 +458,8 @@ class QuickNoteDialog(Dialog):
 		page.parse('wiki', text, append=True) # FIXME format hard coded
 		notebook.store_page(page)
 
-	def import_attachments(self, notebook, path, dir):
-		dir = adapt_from_oldfs(fir)
+	def import_attachments(self, notebook, path, from_dir):
+		from_dir = adapt_from_oldfs(from_dir)
 		attachments = notebook.get_attachments_dir(path)
-		for name in dir.list_files():
+		for file in from_dir.list_files():
 			file.copyto(attachments)


### PR DESCRIPTION
Fixes typos in import_attachments and renames dir argument to be more descriptive.

Test coverage for the plugin should be expanded to catch similar regressions.

Thanks to @MaxTyutyunnikov for [discovering the issue and its fix](https://github.com/MaxTyutyunnikov/zim-desktop-wiki/commit/1190f6d7e37c400019472d67cd7761347265de76).