### PR TITLE
Fix workflows: bump and lower versions on Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.6", "3.10"]
-
-    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        include:
+          - name: Python 3.6 on Ubuntu 20.04
+            os: ubuntu-20.04
+            python-version: "3.6"
+          - name: Python 3.11 on ${{ matrix.os }}
+            os: ubuntu-latest
+            python-version: "3.11"
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Python 3.6 is EOL and not supported on ubuntu-latest: https://github.com/actions/setup-python/issues/544#issuecomment-1332535877

Bumps upper Python version to 3.11 as we are compatible thanks to #1821 and #2117.