### PR TITLE
_split_environ_dir_list: ignore empty directories

### DIFF
--- a/zim/config/basedirs.py
+++ b/zim/config/basedirs.py
@@ -20,7 +20,7 @@ def _split_environ_dir_list(value, default=()):
 		paths = value.split(os.pathsep)
 	else:
 		paths = default
-	return [LocalFolder(p) for p in paths]
+	return [LocalFolder(p) for p in paths if p]
 
 
 ## Initialize config paths


### PR DESCRIPTION
Fixes #2250. The faulty setting mentioned in the linked issue refers to a trailing `:` in an environment variable, resulting in an uncaught ValueError due to _joinabspath being called with an empty string.