### PR TITLE
Keybinding for cutting the current line(s)

### DIFF
--- a/data/manual/Help/Menu_Items.txt
+++ b/data/manual/Help/Menu_Items.txt
@@ -110,7 +110,10 @@ Prompt a dialog to edit the properties of a link or other object. This also show
 Remove a link at the cursor.
 
 **Copy Line <Shift><Ctrl><C>**
-Copy the whole line an put it on the clipboard.
+Copy the whole line and put it on the clipboard.
+
+**Cut Line <Shift><Ctrl><X>**
+Cut the whole line and put it on the clipboard. If there is a selection that spans multiple lines, the entire contents of the lines will be cut and added to the clipboard.
 
 **Copy Location <Shift><Ctrl><L>**
 Copy the page name for the current page on the clipboard.

--- a/data/menubar.xml
+++ b/data/menubar.xml
@@ -47,6 +47,7 @@
 			<placeholder name='plugin_items'/>
 			<separator/>
 			<menuitem action='copy_current_line'/>
+			<menuitem action='cut_current_line'/>
 			<menuitem action='copy_location'/>
 			<separator/>
 			<menuitem action='show_templateeditor'/>

--- a/tests/pageview.py
+++ b/tests/pageview.py
@@ -3794,6 +3794,23 @@ class TestPageViewActions(tests.TestCase):
 		with tests.LoggingFilter('zim.gui.clipboard'):
 			self.assertIsNone(Clipboard.get_parsetree())
 
+	def testCutCurrentLine(self):
+		# Check that the current line, where the cursor is located, is cut and
+		# can be copied from one page to another via the cut current line feature.
+		pageView1Text = 'test 123\ntest 456\ntest 789\n'
+		pageview1 = setUpPageView(self.setUpNotebook(), pageView1Text)
+		pageview2 = setUpPageView(self.setUpNotebook())
+
+		buffer1 = pageview1.textview.get_buffer()
+		buffer2 = pageview2.textview.get_buffer()
+		self.assertEqual(get_text(buffer2), '')
+
+		buffer1.place_cursor(buffer1.get_iter_at_offset(12))
+		pageview1.cut_current_line()
+		pageview2.paste()
+
+		self.assertEqual(get_text(buffer1), 'test 123\ntest 789\n')
+		self.assertEqual(get_text(buffer2), 'test 456\n')
 
 class TestPageviewDialogs(tests.TestCase):
 

--- a/tests/pageview.py
+++ b/tests/pageview.py
@@ -3812,6 +3812,24 @@ class TestPageViewActions(tests.TestCase):
 		self.assertEqual(get_text(buffer1), 'test 123\ntest 789\n')
 		self.assertEqual(get_text(buffer2), 'test 456\n')
 
+	def testCutCurrentLines(self):
+		# Check that the multiple lines within the selection bounds are cut and
+		# can be copied from one page to another via the cut current line feature.
+		pageView1Text = 'test 123\ntest 456\ntest 789\n'
+		pageview1 = setUpPageView(self.setUpNotebook(), pageView1Text)
+		pageview2 = setUpPageView(self.setUpNotebook())
+
+		buffer1 = pageview1.textview.get_buffer()
+		buffer2 = pageview2.textview.get_buffer()
+		self.assertEqual(get_text(buffer2), '')
+
+		buffer1.select_range(buffer1.get_iter_at_offset(3), buffer1.get_iter_at_offset(12))
+		pageview1.cut_current_line()
+		pageview2.paste()
+
+		self.assertEqual(get_text(buffer1), 'test 789\n')
+		self.assertEqual(get_text(buffer2), 'test 123\ntest 456\n')
+
 class TestPageviewDialogs(tests.TestCase):
 
 	def testVarious(self):

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -7088,6 +7088,19 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 
 		buffer.delete_mark(mark)
 
+	@action(_('Cut Line'), accelerator='<Primary><Shift>X', menuhints='edit') # T: menu item to cut current line to clipboard
+	def cut_current_line(self):
+		'''Menu action to cut the current line to the clipboard'''
+		buffer = self.textview.get_buffer()
+		buffer.select_line()
+		bounds = buffer.get_selection_bounds()
+		tree = buffer.get_parsetree(bounds)
+		Clipboard.set_parsetree(self.notebook, self.page, tree)
+		start, end = bounds
+		buffer.delete(start, end)
+		buffer.set_modified(True)
+		buffer.update_editmode()
+
 	@action(_('Date and Time...'), accelerator='<Primary>D', menuhints='insert') # T: Menu item
 	def insert_date(self):
 		'''Menu action to insert a date, shows the L{InsertDateDialog}'''

--- a/zim/gui/pageview/__init__.py
+++ b/zim/gui/pageview/__init__.py
@@ -7092,7 +7092,7 @@ class PageView(GSignalEmitterMixin, Gtk.VBox):
 	def cut_current_line(self):
 		'''Menu action to cut the current line to the clipboard'''
 		buffer = self.textview.get_buffer()
-		buffer.select_line()
+		buffer.select_lines_for_selection()
 		bounds = buffer.get_selection_bounds()
 		tree = buffer.get_parsetree(bounds)
 		Clipboard.set_parsetree(self.notebook, self.page, tree)


### PR DESCRIPTION
I implemented the `Cut Line (Shift+Ctrl+X)` shortcut as described in #1911. It also works for cutting multiple lines when there's a selection that spans multiple lines. All related tests passed. Cheers!

[Screencast from 2023-01-29 16-48-35.webm](https://user-images.githubusercontent.com/361179/215338910-2004f6b3-285f-423d-ad23-9da22a5183a1.webm)
