### PR TITLE
Fix double icon issue by adding StartupWMClass to desktop file

### DIFF
--- a/xdg/zim.desktop
+++ b/xdg/zim.desktop
@@ -4,6 +4,7 @@ Type=Application
 Exec=zim %f
 Icon=zim
 StartupNotify=true
+StartupWMClass=zim
 Terminal=false
 Categories=Utility;TextEditor;GTK;
 MimeType=application/x-zim-notebook;text/x-zim-wiki;


### PR DESCRIPTION
Reference:
https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html