### PR TITLE
Add support to take screenshots on macOS

### DIFF
--- a/data/manual/Plugins/Insert_Screenshot.txt
+++ b/data/manual/Plugins/Insert_Screenshot.txt
@@ -9,7 +9,7 @@ This plugin adds a dialog that allows you to take a screenshot of the desktop or
 
 Supported tools:
 
-Linux / unix:
+Linux / unix (X11 only):
 * import (ImageMagick)
 * scrot
 

--- a/data/manual/Plugins/Insert_Screenshot.txt
+++ b/data/manual/Plugins/Insert_Screenshot.txt
@@ -16,6 +16,9 @@ Linux / unix:
 Windows:
 * boxcutter
 
+macOS:
+* screencapture
+
 ===== Preferences =====
 
 The preference **Screenshot Command** allows you to select the tool to use.

--- a/zim/plugins/screenshot.py
+++ b/zim/plugins/screenshot.py
@@ -4,7 +4,7 @@
 
 
 import time
-from platform import os
+import platform
 
 from gi.repository import Gtk
 
@@ -17,7 +17,7 @@ from zim.gui.pageview import PageViewExtension
 from zim.gui.widgets import Dialog, ErrorDialog
 
 
-PLATFORM = os.name
+PLATFORM = platform.system()
 
 """
 TESTED:
@@ -28,8 +28,9 @@ UNTESTED:
 """
 COMMAND = 'import'
 SUPPORTED_COMMANDS_BY_PLATFORM = dict([
-	('posix', ('import', 'scrot', 'gnome-screenshot')),
-	('nt', ('boxcutter',)),
+	('Linux', ('import', 'scrot', 'gnome-screenshot')),
+	('Windows', ('boxcutter',)),
+	('Darwin', ('screencapture',)),
 ])
 SUPPORTED_COMMANDS = SUPPORTED_COMMANDS_BY_PLATFORM[PLATFORM]
 if len(SUPPORTED_COMMANDS):
@@ -61,6 +62,12 @@ class ScreenshotPicker(object):
 			'full': ('--window',),
 			'delay': '--delay',
 			'file': '-f',
+		}),
+		('screencapture', {
+			'select': ('-i',),
+			'full': ('-T0',),
+			'delay': '-T',
+			'file': None,
 		}),
 	])
 	cmd_default = COMMAND


### PR DESCRIPTION
This is a follow-up to https://github.com/zim-desktop-wiki/zim-desktop-wiki/issues/2424

- Introduce `screencapture` to support screen captures on macOS.
  - Using `-T0` for `full` is actually a workaround (it says "delay 0 seconds") as this parameter cannot be set to `None`.
- Use `platform.system()` instead of `os.name` as we need a way to detect macOS ("Darwin").