### PR TITLE
Improve screenshot on Wayland

### DIFF
--- a/data/manual/Plugins/Insert_Screenshot.txt
+++ b/data/manual/Plugins/Insert_Screenshot.txt
@@ -9,7 +9,7 @@ This plugin adds a dialog that allows you to take a screenshot of the desktop or
 
 Supported tools:
 
-Linux / unix:
+Linux / unix (X11 only):
 * import (ImageMagick)
 * scrot
 

--- a/data/manual/Plugins/Insert_Screenshot.txt
+++ b/data/manual/Plugins/Insert_Screenshot.txt
@@ -16,6 +16,9 @@ Linux / unix:
 Windows:
 * boxcutter
 
+macOS:
+* screencapture
+
 ===== Preferences =====
 
 The preference **Screenshot Command** allows you to select the tool to use.

--- a/zim/plugins/screenshot.py
+++ b/zim/plugins/screenshot.py
@@ -71,7 +71,7 @@ class ScreenshotPicker(object):
 		}),
 		('gnome-screenshot', {
 			'select': ('--area',),
-			'full': ('--window',),
+			'full': (),
 			'delay': '--delay',
 			'file': '-f',
 		}),

--- a/zim/plugins/screenshot.py
+++ b/zim/plugins/screenshot.py
@@ -4,7 +4,7 @@
 
 
 import time
-from platform import os
+import platform
 
 from gi.repository import Gtk
 
@@ -17,7 +17,7 @@ from zim.gui.pageview import PageViewExtension
 from zim.gui.widgets import Dialog, ErrorDialog
 
 
-PLATFORM = os.name
+PLATFORM = platform.system()
 
 """
 TESTED:
@@ -28,8 +28,9 @@ UNTESTED:
 """
 COMMAND = 'import'
 SUPPORTED_COMMANDS_BY_PLATFORM = dict([
-	('posix', ('import', 'scrot', 'gnome-screenshot')),
-	('nt', ('boxcutter',)),
+	('Linux', ('import', 'scrot', 'gnome-screenshot')),
+	('Windows', ('boxcutter',)),
+	('Darwin', ('screencapture',)),
 ])
 SUPPORTED_COMMANDS = SUPPORTED_COMMANDS_BY_PLATFORM[PLATFORM]
 if len(SUPPORTED_COMMANDS):
@@ -61,6 +62,12 @@ class ScreenshotPicker(object):
 			'full': ('--window',),
 			'delay': '--delay',
 			'file': '-f',
+		}),
+		('screencapture', {
+			'select': ('-i',),
+			'full': ('-T0',),
+			'delay': '-T',
+			'file': None,
 		}),
 	])
 	cmd_default = COMMAND

--- a/zim/plugins/screenshot.py
+++ b/zim/plugins/screenshot.py
@@ -5,6 +5,7 @@
 
 import time
 import platform
+import os
 
 from gi.repository import Gtk
 
@@ -21,6 +22,7 @@ PLATFORM = platform.system()
 
 """
 TESTED:
+	- gnome-screenshot
 	- import (imagemagick)
 	- scrot
 UNTESTED:
@@ -28,11 +30,21 @@ UNTESTED:
 """
 COMMAND = 'import'
 SUPPORTED_COMMANDS_BY_PLATFORM = dict([
-	('Linux', ('import', 'scrot', 'gnome-screenshot')),
+	('Linux_Wayland', ('gnome-screenshot',)),
+	('Linux_X', ('import', 'scrot', 'gnome-screenshot')),
 	('Windows', ('boxcutter',)),
 	('Darwin', ('screencapture',)),
 ])
-SUPPORTED_COMMANDS = SUPPORTED_COMMANDS_BY_PLATFORM[PLATFORM]
+
+if PLATFORM == 'Linux':
+	if os.environ.get('XDG_SESSION_TYPE') == 'wayland':
+		platform = 'Linux_Wayland'
+	else:
+		platform = 'Linux_X'
+else:
+	platform = PLATFORM
+SUPPORTED_COMMANDS = SUPPORTED_COMMANDS_BY_PLATFORM[platform]
+
 if len(SUPPORTED_COMMANDS):
 	COMMAND = SUPPORTED_COMMANDS[0]  # set first available tool as default
 


### PR DESCRIPTION
Fixes #2424 

## Avoid incompatible screenshot utils on Wayland

Previously, the Insert Screenshot plugin chose the list of allowed screenshot utilities,
as well as the default option, based on the platform, either 'posix' or 'nt'.
However, most choices for POSIX, including the default utility 'import',
were not compatible with Wayland.
Improve platform detection to detect the Wayland case separately and offer only compatible utilities.
This means that at least for now, 'gnome-screenshot' is the only option on Wayland.

## Fix fullscreen screenshot using gnome-screenshot
    
When gnome-screenshot was used as the backend for the Insert Screenshot plugin,
the fullscreen screenshot was misbehaving by actually just recording the active Zim window.
Fix by adjusting the used command line parameters.