### PR TITLE
Store the returned pid until callback

### DIFF
--- a/zim/applications.py
+++ b/zim/applications.py
@@ -416,6 +416,11 @@ class Application(object):
 			TEST_MODE_RUN_CB(argv)
 			return None
 
+		# https://github.com/zim-desktop-wiki/zim-desktop-wiki/issues/1697
+		def _callback_wrapper(pid, *args):
+			GLib.spawn_close_pid(pid)
+			callback(*args)
+
 		try:
 			try:
 				pid, stdin, stdout, stderr = \
@@ -437,10 +442,10 @@ class Application(object):
 				# child watch does implicit reaping -> no zombies
 				if data is None:
 					GObject.child_watch_add(pid,
-						lambda pid, status: callback(status))
+						lambda _, status: _callback_wrapper(pid, status))
 				else:
 					GObject.child_watch_add(pid,
-						lambda pid, status, data: callback(status, data), data)
+						lambda _, status, data: _callback_wrapper(pid, status, data), data)
 			return pid
 
 


### PR DESCRIPTION
On Windows, the returned PID from GObject.spawn_async is a handle, which ownership is transferred to the caller.

If this handle goes out of scope, it is freed, and its subsequent usage in WaitForMultipleObjectsEx through GObject.child_watch_add results in repeated failed calls and high CPU usage.

Tested on Windows 10 with MSYS2, Fedora 38 with a flatpak build and running from source.

Fixes #1697