### PR TITLE
arithmetic: add option for limiting output decimals

### DIFF
--- a/data/manual/Plugins/Arithmetic.txt
+++ b/data/manual/Plugins/Arithmetic.txt
@@ -10,6 +10,9 @@ This plugin allows you to evaluate arithmetic expressions in a zim page.
 
 **See also:** the [[Inline Calculator|Inline Calculator plugin]] which does something similar
 
+===== Plugin options =====
+The option **Output precision** sets the maximum number of decimals shown in the output; extraneous decimals aren't shown. The precision of the underlying [[https://docs.python.org/3/library/decimal.html|''decimal'']] library is always set to 100 places.
+
 ===== Tutorial =====
 You may do standard arithmetic operations in a document,
 ending the operation with an equals sign, for example:

--- a/zim/inc/arithmetic.py
+++ b/zim/inc/arithmetic.py
@@ -295,8 +295,9 @@ def TypeAndValueOf(expression):
 class Parser:
     'Base class'
 
-    def __init__(self):
+    def __init__(self, output_decimals=6):
         # Written by parseLine(), read by evaluate():
+        self.output_decimals = output_decimals
         self.functions = {}
         self.variables = {}
 
@@ -487,6 +488,12 @@ class ParserGTK(Parser):
 
     def writeResult(self, i, textBuffer, start, end, text):
         'Write text in line i of lines from start to end offset.'
+        # Format decimals
+        formatted = f"{float(text):.{self.output_decimals}f}"
+        # Don't add unnecessary zeros
+        if len(formatted) < len(text):
+            text = formatted
+
         # Delete
         if end > start:
             # handle start at end of line or beyond

--- a/zim/plugins/arithmetic.py
+++ b/zim/plugins/arithmetic.py
@@ -23,12 +23,17 @@ http://pp.com.mx/python/arithmetic.
 		'help': 'Plugins:Arithmetic',
 	}
 
-	#~ plugin_preferences = (
+	plugin_preferences = (
 		# key, type, label, default
-	#~ )
+		('output_decimals', 'int', _('Output precision'), 6, (0, 100)), # T: plugin preference
+	)
 
 
 class ArithmeticPageViewExtension(PageViewExtension):
+
+	def __init__(self, plugin, window):
+		PageViewExtension.__init__(self, plugin, window)
+		self.preferences = plugin.preferences
 
 	@action(_('_Arithmetic'), accelerator='F5', icon='accessories-calculator', menuhints='tools') # T: menu item
 	def calculate(self):
@@ -38,5 +43,5 @@ class ArithmeticPageViewExtension(PageViewExtension):
 		buf = self.pageview.textview.get_buffer() # XXX
 
 		# parse and return modified text
-		parser = ParserGTK()
+		parser = ParserGTK(output_decimals=self.preferences['output_decimals'])
 		parser.parse(buf)


### PR DESCRIPTION
- doesn't affect calculation accuracy
- doesn't add extra zeros
- defaults to 6 decimals
- documented in the manual
- closes  #2476