### PR TITLE
fix: Redeclared 'zim/notebook/operations.py:NotebookOperation.is_running' defined above without usage

### DIFF
--- a/zim/notebook/operations.py
+++ b/zim/notebook/operations.py
@@ -235,9 +235,6 @@ class NotebookOperation(SignalEmitter):
 		self.notebook._operation_check = self # start blocking
 		GObject.idle_add(self._start) # ensure start happens in main thread
 
-	def is_running(self):
-		return self.notebook._operation_check == self
-
 	def _start(self):
 		my_iter = iter(self)
 		GObject.idle_add(lambda: next(my_iter, False), priority=GObject.PRIORITY_LOW)


### PR DESCRIPTION
https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/1ccaffc181671a71b6d66cbe99ae14688db1fc6c/zim/notebook/operations.py#L208

https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/1ccaffc181671a71b6d66cbe99ae14688db1fc6c/zim/notebook/operations.py#L238