### PR TITLE
Improve error handling for UI actions using `NotebookOperation`

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -376,7 +376,7 @@ class LoggingFilter(logging.Filter):
 
 	# Due to how the "logging" module works, logging channels do inherit
 	# handlers of parents but not filters. Therefore setting a filter
-	# on the "zim" channel will not surpress messages from sub-channels.
+	# on the "zim" channel will not supress messages from sub-channels.
 	# Instead we need to set the filter both on the channel and on
 	# top level handlers to get the desired effect.
 

--- a/tests/uiactions.py
+++ b/tests/uiactions.py
@@ -253,8 +253,9 @@ class TestUIActions(tests.TestCase):
 			dialog.set_input(name='ExistingPage')
 			self.assertRaises(PageExistsError, dialog.do_response_ok)
 
-		with tests.DialogContext(renamepage):
-			self.uiactions.move_page()
+		with tests.LoggingFilter('zim', 'Page already exists'):
+			with tests.DialogContext(renamepage):
+				self.uiactions.move_page()
 
 	def testRenamePageNonExistingPageFails(self):
 		from zim.notebook import PageNotFoundError
@@ -264,8 +265,9 @@ class TestUIActions(tests.TestCase):
 			dialog.set_input(name='NewName')
 			self.assertRaises(PageNotFoundError, dialog.do_response_ok)
 
-		with tests.DialogContext(renamepage):
-			self.uiactions.move_page(page)
+		with tests.LoggingFilter('zim', 'No such page'):
+			with tests.DialogContext(renamepage):
+				self.uiactions.move_page(page)
 
 	def testRenamePageWithPageUpdateHeading(self):
 		page = self.notebook.get_page(Path('MyPage'))
@@ -427,8 +429,9 @@ class TestUIActions(tests.TestCase):
 			dialog.set_input(parent=':')
 			self.assertRaises(PageExistsError, dialog.do_response_ok)
 
-		with tests.DialogContext(movepage):
-			self.uiactions.move_page(page)
+		with tests.LoggingFilter('zim', 'Page already exists'):
+			with tests.DialogContext(movepage):
+				self.uiactions.move_page(page)
 
 	def testMovePageFailsForExistingTextFile(self):
 		from zim.notebook import PageNotAvailableError
@@ -443,8 +446,9 @@ class TestUIActions(tests.TestCase):
 			dialog.set_input(parent=':')
 			self.assertRaises(PageNotAvailableError, dialog.do_response_ok)
 
-		with tests.DialogContext(movepage):
-			self.uiactions.move_page(page)
+		with tests.LoggingFilter('zim', 'Page not available'):
+			with tests.DialogContext(movepage):
+				self.uiactions.move_page(page)
 
 	def testMovePageNonExistingPageFails(self):
 		from zim.notebook import PageNotFoundError
@@ -454,8 +458,9 @@ class TestUIActions(tests.TestCase):
 			dialog.set_input(parent='NewParent')
 			self.assertRaises(PageNotFoundError, dialog.do_response_ok)
 
-		with tests.DialogContext(movepage):
-			self.uiactions.move_page(page)
+		with tests.LoggingFilter('zim', 'No such page'):
+			with tests.DialogContext(movepage):
+				self.uiactions.move_page(page)
 
 	def testMovePageUpdateLinks(self):
 		referrer = self.notebook.get_page(Path('Referrer'))
@@ -787,13 +792,14 @@ class TestUIActionsRealFile(tests.TestCase):
 
 		def fail_trash(dialog):
 			assert isinstance(dialog, TrashPageDialog)
-			dialog.do_response_ok() # NOT assert_response_ok - we want to fail
+			dialog.do_response_ok() # NOT assert_repsonse_ok - we want to fail
 
 		def question_yes(dialog):
 			dialog.answer_yes()
 
-		with tests.DialogContext(fail_trash, question_yes, DeletePageDialog):
-			self.uiactions.delete_page()
+		with tests.LoggingFilter('zim', 'Test'):
+			with tests.DialogContext(fail_trash, question_yes, DeletePageDialog):
+				self.uiactions.delete_page()
 
 		self.assertFalse(self.page.exists())
 
@@ -813,8 +819,9 @@ class TestUIActionsRealFile(tests.TestCase):
 		def question_no(dialog):
 			dialog.answer_no()
 
-		with tests.DialogContext(fail_trash, question_no):
-			self.uiactions.delete_page()
+		with tests.LoggingFilter('zim', 'Test'):
+			with tests.DialogContext(fail_trash, question_no):
+				self.uiactions.delete_page()
 
 		self.assertTrue(self.page.exists())
 

--- a/tests/uiactions.py
+++ b/tests/uiactions.py
@@ -787,7 +787,7 @@ class TestUIActionsRealFile(tests.TestCase):
 
 		def fail_trash(dialog):
 			assert isinstance(dialog, TrashPageDialog)
-			dialog.do_response_ok() # NOT assert_repsonse_ok - we want to fail
+			dialog.do_response_ok() # NOT assert_response_ok - we want to fail
 
 		def question_yes(dialog):
 			dialog.answer_yes()
@@ -808,7 +808,7 @@ class TestUIActionsRealFile(tests.TestCase):
 
 		def fail_trash(dialog):
 			assert isinstance(dialog, TrashPageDialog)
-			dialog.do_response_ok() # NOT assert_repsonse_ok - we want to fail
+			dialog.do_response_ok() # NOT assert_response_ok - we want to fail
 
 		def question_no(dialog):
 			dialog.answer_no()

--- a/zim/gui/exportdialog.py
+++ b/zim/gui/exportdialog.py
@@ -58,6 +58,8 @@ class ExportDialog(Assistant):
 			dialog = ProgressDialog(self, op)
 			dialog.run()
 
+		if op.exception:
+			raise op.exception
 		if op.cancelled:
 			return False
 		else:

--- a/zim/gui/uiactions.py
+++ b/zim/gui/uiactions.py
@@ -396,6 +396,9 @@ class UIActions(object):
 			dialog = ProgressDialog(self.widget, op)
 			dialog.run()
 
+			if op.exception:
+				raise op.exception
+
 			if update_only or isinstance(op, IndexCheckAndUpdateOperation):
 				return not dialog.cancelled
 			else:
@@ -409,6 +412,9 @@ class UIActions(object):
 			op = IndexCheckAndUpdateOperation(self.notebook)
 			dialog = ProgressDialog(self.widget, op)
 			dialog.run()
+
+			if op.exception:
+				raise op.exception
 
 			return not dialog.cancelled
 
@@ -650,8 +656,10 @@ class MovePageDialog(Dialog):
 		)
 		dialog = ProgressDialog(self, op)
 		dialog.run()
-
-		return True
+		if op.exception:
+			raise op.exception
+		else:
+			return True
 
 
 class DeletePageDialogBase(Dialog):

--- a/zim/notebook/notebook.py
+++ b/zim/notebook/notebook.py
@@ -28,7 +28,7 @@ from zim.parsing import link_type, is_win32_path_re, valid_interwiki_key
 from zim.signals import ConnectorMixin, SignalEmitter, SIGNAL_NORMAL
 
 from .operations import notebook_state, NOOP, SimpleAsyncOperation, ongoing_operation
-from .page import Path, Page, HRef, HREF_REL_ABSOLUTE, HREF_REL_FLOATING, HREF_REL_RELATIVE
+from .page import Path, Page, PageError, HRef, HREF_REL_ABSOLUTE, HREF_REL_FLOATING, HREF_REL_RELATIVE
 from .index import IndexNotFoundError, LINK_DIR_BACKWARD, ROOT_PATH
 
 DATA_FORMAT_VERSION = (0, 4)
@@ -108,13 +108,6 @@ def _cache_dir_for_dir(dir):
 	return XDG_CACHE_HOME.folder(('zim', path))
 
 
-class PageError(Error):
-
-	def __init__(self, path):
-		self.path = path
-		self.msg = self._msg % path.name
-
-
 class PageNotFoundError(PageError):
 	_msg = _('No such page: %s') # T: message for PageNotFoundError
 
@@ -135,7 +128,7 @@ class PageNotAvailableError(PageNotFoundError):
 		self.file = file
 
 
-class PageExistsError(Error):
+class PageExistsError(PageError):
 	_msg = _('Page already exists: %s') # T: message for PageExistsError
 
 

--- a/zim/notebook/operations.py
+++ b/zim/notebook/operations.py
@@ -144,7 +144,7 @@ except ImportError:
 
 
 from zim.signals import SignalEmitter
-from zim.errors import Error
+from zim.errors import Error, log_error
 
 NOOP = lambda: None
 
@@ -276,7 +276,7 @@ class NotebookOperation(SignalEmitter):
 		except Exception as err:
 			self.cancelled = True
 			self.exception = err
-			raise
+			log_error(err)
 		finally:
 			if self.notebook._operation_check == self:
 				self.notebook._operation_check = NOOP # stop blocking

--- a/zim/notebook/page.py
+++ b/zim/notebook/page.py
@@ -413,7 +413,14 @@ class HRef():
 		return link
 
 
-class PageReadOnlyError(Error):
+class PageError(Error):
+
+	def __init__(self, path):
+		self.path = path
+		self.msg = self._msg % path.name
+
+
+class PageReadOnlyError(PageError):
 	_msg = _('Can not modify page: %s') # T: error message for read-only pages
 
 


### PR DESCRIPTION
Fixes issue #2382.

## Fix PageExistsError and PageReadOnlyError inheritance

Classes `PageExistsError` and `PageReadOnlyError` were inherited directly from `zim.Error`,
yet their implementations only make sense as subclasses of `PageError`. Make it so.

Previously, the error message for these two errors was just the page name.
After this fix, the page name is prefixed with _Page already exists_ and Can not modify page respectively.
This makes the error messages much more understandable.

## Propagate exceptions from progress dialogs

`NotebookOperation` performs its work inside the GTK main loop.
Any unhandled exceptions occuring within the main loop are processed within the main loop
and do not propagate to code that started operation.
To allow informing the calling side about exceptions, `NotebookOperation` has attribute exception,
which together with the cancelled is filled by `NotebookOperation`'s top level exception handler.

However, for many UI actions that use NotebookOperation wrapped in a `ProgressDialog`,
the exception attribute is not considered at all.
For these dialogs, the user does not see the expected error dialog should an exception occur.

Fix by re-raising any exception reported by NotebookOperation in the following actions:

* MovePageDialog
* ExportDialog
* check_and_update_index, which has its own menu item, and is also  started in multiple other UI actions

## Avoid unhandled exceptions in `NotebookOperation`

`NotebookOperation` is intended to be executed in the GTK main loop via `run_on_idle()`.
Even if such execution terminates in an unhandled exception, execution of Zim still continues.
Thus, normally the effect of an unhandled exception is to print an error message and a traceback in Zim's debug log.

However, if `sys.excepthook` is overridden, different action may result.
In particular, in Fedora Linux, Automatic Bug Reporting Tool (ABRT)'s Python plugin overrides `sys.excepthook`
to notify the user about unhandled exception in Zim,
and also to upload a crash report to Fedora Analytics Framework.
Since multiple `NotebookOperation` subclasses use exceptions to communicate failures that are preventable by the user,
such as trying to create a page that already exists,
this is not desirable.

To avoid triggering `sys.excepthook`,
stop re-raising exceptions in the already existing `NotebookOperation` catch-all exception handler.
Just print them to the debug log instead.

Note that since the catch-all handler already communicates the exceptions to `NotebookOperation` caller via the `cancelled` and `exception` properties,
it could be argued that all handling of exceptions, even logging them, should be left to the caller.
However, there are places where `NotebookOperation` subclasses are executed,
but those properties are not checked afterwards at all,
and thus the *only* error handling they already have is the debug log.
Since the author of this change does not feel comfortable adding exception handling to all those places,
the solution is to keep logging the exception inside `NotebookOperation`.

Since the error logging is now done explicitly via Python's logging
mechanism, tests also need to be modified to expect the new log rows.

## Also some typo fixes in comments