### PR TITLE
Add full-text indexing and search functionality to zim search

### DIFF
--- a/data/manual/Plugins.txt
+++ b/data/manual/Plugins.txt
@@ -1,5 +1,5 @@
 Content-Type: text/x-zim-wiki
-Wiki-Format: zim 0.4
+Wiki-Format: zim 0.6
 
 ====== Plugins ======
 
@@ -16,6 +16,7 @@ The following plugins are standard included with zim:
 * [[+Equation Editor|Equation Editor]]
 * [[+GNU R Plot Editor|GNU R Plot Editor]]
 * [[+Gnuplot Editor|Gnuplot Editor]]
+* [[+Indexed Full Text Search|Indexed Full Text Search]]
 * [[+Insert Screenshot|Insert Screenshot]]
 * [[+Insert Symbol|Insert Symbol]]
 * [[+Inline Calculator|Inline Calculator]]

--- a/data/manual/Plugins/Indexed_Full_Text_Search.txt
+++ b/data/manual/Plugins/Indexed_Full_Text_Search.txt
@@ -1,0 +1,9 @@
+Content-Type: text/x-zim-wiki
+Wiki-Format: zim 0.6
+Creation-Date: 2023-10-11T16:52:26+02:00
+
+====== Indexed Full Text Search ======
+
+This plugin allows to massively speed up the search in page contents, by up to 95%. Simply enable the plugin. The index will be automatically recreated, after which the faster full-text search will be available.
+
+This is achieved by caching a reverse index of tokens (i.e. words) in the index using ''sqlite''. For that to work, it requires a version of ''sqlite'' with the FTS5 extension. This new index will be around 5x bigger than before (for a 1500-page notebook with around 500 words per page, the index grows from 1.7 MiB to about 5.5 MiB).

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -64,7 +64,8 @@ __all__ = [
 	'tasklist', 'tags', 'imagegenerators', 'tableofcontents',
 	'quicknote', 'attachmentbrowser', 'insertsymbol',
 	'sourceview', 'tableeditor', 'bookmarksbar', 'spell',
-	'arithmetic', 'linesorter', 'commandpalette', 'windowtitleeditor'
+	'arithmetic', 'linesorter', 'commandpalette', 'windowtitleeditor',
+	'indexed_fts'
 ]
 
 

--- a/tests/indexed_fts.py
+++ b/tests/indexed_fts.py
@@ -1,0 +1,23 @@
+# coding=utf-8
+
+import tests
+
+from zim.plugins import PluginManager
+
+class TestIndexedFTS(tests.TestCase):
+
+	def testIndexing(self):
+		'''Check indexing of Indexed Full Text Search plugin'''
+		plugin = PluginManager.load_plugin('indexed_fts')
+		notebook = self.setUpNotebook(content=tests.FULL_NOTEBOOK)
+
+		notebook.index.check_and_update()
+
+		# One page will never be indexed: the root page
+		self.assertNotEqual(
+			notebook.index._db.execute(
+				"SELECT count(*) FROM pages WHERE fts_id IS NOT NULL;"
+			).fetchone()[0], 0
+		)
+
+

--- a/tests/indexed_fts.py
+++ b/tests/indexed_fts.py
@@ -3,7 +3,12 @@
 import tests
 
 from zim.plugins import PluginManager
+from zim.plugins import indexed_fts
 
+@tests.skipIf(
+	indexed_fts.IndexedFTSPlugin.check_dependencies()[0] == False,
+	"Indexed FTS plugin not available"
+)
 class TestIndexedFTS(tests.TestCase):
 
 	def testIndexing(self):
@@ -13,7 +18,8 @@ class TestIndexedFTS(tests.TestCase):
 
 		notebook.index.check_and_update()
 
-		# One page will never be indexed: the root page
+		# Only pages with content will actually be indexed, so
+		# after indexing some should be FTS-indexed.
 		self.assertNotEqual(
 			notebook.index._db.execute(
 				"SELECT count(*) FROM pages WHERE fts_id IS NOT NULL;"

--- a/tests/search.py
+++ b/tests/search.py
@@ -5,6 +5,7 @@ import tests
 
 from zim.search import *
 from zim.notebook import Path
+from zim.plugins import indexed_fts
 
 class TestSearchRegex(tests.TestCase):
 
@@ -243,6 +244,20 @@ class TestSearchFiles(TestSearch):
 
 	def runTest(self):
 		'''Test search API with file based notebook'''
+		TestSearch.runTest(self)
+
+@tests.skipIf(
+	indexed_fts.IndexedFTSPlugin.check_dependencies()[0] == False,
+	"Indexed FTS plugin not available"
+)
+class TestSearchIndexed(TestSearch):
+	'''Test case for integration with the indexed_fts plugin'''
+
+	def setUp(self):
+		plugin = PluginManager.load_plugin('indexed_fts')
+		TestSearch.setUp(self)
+
+	def runTest(self):
 		TestSearch.runTest(self)
 
 

--- a/zim/gui/searchdialog.py
+++ b/zim/gui/searchdialog.py
@@ -176,8 +176,8 @@ class SearchResultsTreeView(BrowserTreeView):
 				column.set_expand(True)
 			self.append_column(column)
 
-		model.set_sort_column_id(1, Gtk.SortType.DESCENDING)
-			# By default sort by score
+		# Don't sort here because we'll do more elaborate sorting later manually#
+		#model.set_sort_column_id(1, Gtk.SortType.DESCENDING)
 
 		self.connect('row-activated', self._do_open_page)
 		self.connect('destroy', self.__class__._cancel)
@@ -225,7 +225,7 @@ class SearchResultsTreeView(BrowserTreeView):
 			else:
 				score = -1 # went missing !??? - technically a bug
 			row[self.SCORE_COL] = score
-			order.append((score, i))
+			order.append((path, i, score))
 			seen.add(path)
 
 		# Add new paths
@@ -234,11 +234,12 @@ class SearchResultsTreeView(BrowserTreeView):
 			score = results.scores.get(path, 0)
 			model.append((path.name, score, path))
 			i += 1
-			order.append((score, i))
+			order.append((path, i, score))
 
-		# re-order
-		#order.sort() # sort on first item, which is score
-		#model.reorder([x[1] for x in order]) # use second item
+		# sort by score, then by name. This doesn't seem to work by setting a sort column.
+		order.sort(key=lambda i: i[0].name)
+		order.sort(key=lambda i: i[2], reverse=True)
+		model.reorder([x[1] for x in order])
 
 		self.hasresults = len(model) > 0
 

--- a/zim/main/__init__.py
+++ b/zim/main/__init__.py
@@ -593,9 +593,17 @@ class SearchCommand(NotebookCommand):
 
 		selection = SearchSelection(notebook)
 		selection.search(query)
-		for path in sorted(selection, key=lambda p: p.name):
-			print(path.name)
 
+		if self.opts.get("with-scores", False):
+			sorted_sel = sorted(selection.scores.items(),
+				key=lambda i:i[0].name, reverse=False)
+			sorted_sel.sort(key=lambda i:i[1], reverse=True)
+
+			for result in sorted_sel:
+				print(str(result[1]) + "\t" + result[0].name)
+		else:
+			for path in sorted(selection, key=lambda p: p.name):
+				print(path.name)
 
 class IndexCommand(NotebookCommand):
 	'''Class implementing the C{--index} command'''

--- a/zim/notebook/index/pages.py
+++ b/zim/notebook/index/pages.py
@@ -138,7 +138,7 @@ class PagesIndexer(IndexerBase):
 			file = self.layout.root.file(filerow['path'])
 			format = self.layout.get_format(file)
 			mtime = file.mtime()
-			tree = format.Parser().parse(file.read())
+			tree = format.Parser().parse(file.read(), file_input=True)
 			self.update_page(pagename, mtime, tree)
 		else:
 			pass # some conflict file changed

--- a/zim/plugins/indexed_fts.py
+++ b/zim/plugins/indexed_fts.py
@@ -1,0 +1,281 @@
+# coding=utf-8
+
+'''Plugin for indexing page contents using sqlite's FTS5 module
+It borrows a lot from the task list plugin which also needs to index all
+page contents.
+'''
+
+import sqlite3
+import logging
+
+from zim.plugins import PluginClass
+from zim.notebook import NotebookExtension, Path
+from zim.notebook.index.base import IndexerBase
+from zim.tokenparser import TEXT
+from zim.search import SearchSelection
+
+logger = logging.getLogger("zim.plugins.indexed_fts")
+
+
+def compare_version(curv, minv):
+	'''Check if a passed tuple of version numbers curv is equal or higher
+	than the version tuple passed in minv
+	Most significant digits come first, all should be integers.
+	'''
+	for i, j in zip(curv, minv):
+		if i > j:
+			return True
+
+		elif i == j:
+			continue
+
+		else:
+			return False
+
+	# Coming here means we have the minimum working version.
+	return True
+
+
+class IndexedFTSPlugin(PluginClass):
+
+	plugin_info = {
+		'name': _('Indexed Full-Text Search'),
+		'description': _('''\
+This plugin provides full-text indexing of
+page contents for fast full-text search,
+based on the FTS5 virtual table module of
+sqlite.
+'''),
+		'author': 'Nimrod Maclomhair',
+	}
+
+	@classmethod
+	def check_dependencies(klass):
+		conn = sqlite3.connect(":memory:")
+		has_fts5 = (
+			len(conn.execute(
+				"SELECT name FROM pragma_module_list() "
+				"WHERE name = ?;", ("fts5",)
+				).fetchall()
+			) == 1
+		)
+		has_min_version = compare_version(
+			sqlite3.sqlite_version_info, (3, 43, 0)
+		)
+
+		return (has_fts5 and has_min_version), [
+			('sqlite FTS5 module', has_fts5, True),
+			('sqlite version 3.43.0 or higher', has_min_version, True)
+		]
+
+	@staticmethod
+	def process_index_fts(searchselection, term, scope):
+		'''
+		The workhorse for actually searching the index, called by the
+		search function if available.
+
+		@param searchselection: the L{SearchSelection} instance to use
+		@param term: a term to look for
+		@param scope: if passed, a set of valid page names to search in
+
+		NOTE: Currently, we don't use the more advanced BM25 ranking method
+		but instead try to replicate what zim internally uses: the number
+		of times the word was found in the page.
+		'''
+		db = searchselection.notebook.index._db
+
+		# All keywords passed to this functions are content-related so
+		# we don't need to check the term.keyword property.
+		# Beware: FTS5 supports a complex search syntax, including "*"
+		# expansion, but we cannot use this for counting the occurences.
+		# Instead, we use the GLOB operator for counting occurences,
+		# which also understands "*" expansion but might otherwise
+		# provide different results.
+		query_results = db.execute(
+			"SELECT p.name AS name, count(v.offset) as score "
+			"FROM pages_fts(?) as f "
+			"JOIN keys_pages_fts as k ON f.rowid = k.fts_id "
+			"JOIN pages as p ON k.page_id = p.id "
+			"JOIN pages_ftsv AS v ON f.rowid = v.doc "
+			"WHERE v.term GLOB ? "
+			"GROUP BY p.name;",
+			(term.string, term.string.lower())
+		).fetchall()
+
+		myscores = {}
+
+		myresults = SearchSelection(None)
+		myresults.scores = searchselection.scores
+
+		for row in query_results:
+			p = Path(row["name"])
+			myscores[p] = row["score"]
+			myresults.add(p)
+
+		# Most of the following is taken form SearchSelection._process_from_index
+		# Only keep results in scope (if scope is not empty)
+		if scope:
+			myresults &= scope
+
+		# Inverse selection
+		if term.inverse:
+			if not scope:
+				# initialize scope with whole notebook :S
+				scope = set()
+				for p in self.notebook.pages.walk():
+					scope.add(p)
+			inverse = scope - myresults
+			myresults.clear()
+			myresults.update(inverse)
+
+		# Recalculate scores of left-over matches
+		for path in myresults:
+			myresults.scores[path] = \
+				myresults.scores.get(path, 0) + myscores.get(path, 0)
+
+		return myresults
+
+
+class FTSIndexer(IndexerBase):
+	'''Indexer for adding page content to the FTS index table, to keep
+	the FTS index up-to-date.
+	'''
+	PLUGIN_NAME = "IndexedFTS"
+	PLUGIN_DB_FORMAT = "0.1"
+
+	__signals__ = {}
+
+	@classmethod
+	def teardown(cls, db):
+		db.execute("DROP TABLE IF EXISTS pages_fts;")
+		db.execute("DROP TABLE IF EXISTS keys_pages_fts;")
+		db.execute("DELETE FROM zim_index WHERE key = ?;", (cls.PLUGIN_NAME,))
+
+	def __init__(self, db, pages_indexer):
+		IndexerBase.__init__(self, db)
+		self.db = db
+		self.db.executescript('''
+			CREATE VIRTUAL TABLE IF NOT EXISTS pages_fts USING fts5(
+				page_content,
+				tokenize = 'unicode61 remove_diacritics 2',
+				content = '',
+				contentless_delete = 1
+			);
+			CREATE VIRTUAL TABLE IF NOT EXISTS pages_ftsv
+			USING fts5vocab(pages_fts, instance);
+
+			CREATE TABLE IF NOT EXISTS keys_pages_fts (
+				page_id INTEGER PRIMARY KEY,
+				fts_id INTEGER REFERENCES pages_fts(rowid)
+			);
+			CREATE INDEX IF NOT EXISTS keys_pages_fts_rowid ON keys_pages_fts(fts_id);
+		''')
+		self.db.execute(
+			"INSERT OR REPLACE INTO zim_index VALUES (?, ?);",
+			(self.PLUGIN_NAME, self.PLUGIN_DB_FORMAT)
+		)
+
+		self.connectto_all(pages_indexer, (
+			'page-changed', 'page-row-deleted'
+		))
+
+	def get_fts_id(self, page_id):
+		fts_id = self.db.execute("SELECT fts_id FROM keys_pages_fts "
+			"WHERE page_id = ?;", (page_id,)).fetchone()
+		return fts_id[0] if fts_id is not None else None
+
+	def delete_fts_row(self, rowid):
+		self.db.execute("DELETE FROM pages_fts WHERE rowid = ?;",
+			(rowid,)
+		)
+		self.db.execute("DELETE FROM keys_pages_fts WHERE fts_id = ?;",
+			(rowid,)
+		)
+
+	def on_page_changed(self, o, row, content_tree):
+		'''
+		This is the centerpiece of the plugin: FTS-index all text in the
+		document and store the newly created row.
+		'''
+		allcont = [
+			token[1]
+			for token in content_tree.iter_tokens()
+			if token[0] == TEXT
+		]
+		allcont_str = ''.join(allcont)
+
+		logger.debug("Indexing full text of page %s", row["name"])
+
+		fts_id = self.get_fts_id(row["id"])
+
+		if fts_id is not None:
+			# Page was searched before, we can update
+			self.db.execute("UPDATE pages_fts SET page_content = ? "
+				"WHERE rowid = ?;",
+				(allcont_str, fts_id)
+			)
+		else:
+			cur = self.db.execute(
+				"INSERT INTO pages_fts (page_content) VALUES (?);",
+				(allcont_str,))
+			cur.execute(
+				"INSERT OR REPLACE INTO keys_pages_fts (page_id, fts_id) "
+				"VALUES (?, ?);",
+				(row["id"], cur.lastrowid,))
+
+	def on_page_row_deleted(self, o, row):
+		fts_id = self.get_fts_id(row["id"])
+		if fts_id is not None:
+			self.delete_fts_row(fts_id)
+
+
+
+class IndexedFTSNotebookExtension(NotebookExtension):
+	'''Extend notebook by adding special hooks when pages in the index
+	are added or changed or deleted, so these changes can be reflected
+	in the FTS index.
+
+	Additionally, we flag all pages with content for re-indexing so that
+	we get a full FTS index.
+	'''
+
+	def __init__(self, plugin, notebook):
+		NotebookExtension.__init__(self, plugin, notebook)
+
+		self.index = notebook.index
+
+		# Check if the current index contains the latest version of the
+		# FTS index table (if any at all):
+		if self.index.get_property(FTSIndexer.PLUGIN_NAME) \
+			!= FTSIndexer.PLUGIN_DB_FORMAT:
+
+			FTSIndexer.teardown(self.index._db)
+			self.index.flag_reindex()
+
+		self.indexer = None
+		self.setup_indexer(self.index, self.index.update_iter)
+		self.index.connect('new-update-iter', self.setup_indexer)
+
+	def setup_indexer(self, index, update_iter):
+		if self.indexer is not None:
+			self.indexer.disconnect_all()
+
+		self.indexer = FTSIndexer(index._db, update_iter.pages)
+		update_iter.add_indexer(self.indexer)
+
+	def teardown(self):
+		'''This should be called when the plugin is disabled.
+		It will not, however, remove the plugins data from the index
+		because this might be tedious to restore and only be called on
+		the open notebooks anyway - closed notebooks will remain with
+		their FTS index as well.
+		'''
+		self.indexer.disconnect_all()
+		self.index.update_iter.remove_indexer(self.indexer)
+
+
+
+
+
+
+

--- a/zim/plugins/indexed_fts.py
+++ b/zim/plugins/indexed_fts.py
@@ -47,6 +47,7 @@ based on the FTS5 virtual table module of
 sqlite.
 '''),
 		'author': 'Nimrod Maclomhair',
+		'help': 'Plugins:Indexed Full Text Search'
 	}
 
 	@classmethod


### PR DESCRIPTION
This is an attempt at providing fast full-text search by leveraging the sqlite module FTS5, as mentioned on #64 

While the indexing and search itself is implemented in a plugin, modifications to the core zim code are made to include an extra column and to make use of the additional search functionality if enabled.

Tests and a help page for the plugin are included as well.

Also, currently another minor change not directly related to the indexed FTS functionality is included: the command line search option now also show the ranking.

My initial tests have shown over 95% speed increase in searching. At the same time, the index size of a typical 1500-page, 500 words each notebook increased from 1.7 MiB to around 5.5 MiB, which I think is still acceptable.
