### PR TITLE
Avoid unhandled exceptions in `NotebookOperation`

### DIFF
--- a/zim/notebook/operations.py
+++ b/zim/notebook/operations.py
@@ -144,7 +144,7 @@ except ImportError:
 
 
 from zim.signals import SignalEmitter
-from zim.errors import Error
+from zim.errors import Error, log_error
 
 NOOP = lambda: None
 
@@ -279,7 +279,7 @@ class NotebookOperation(SignalEmitter):
 		except Exception as err:
 			self.cancelled = True
 			self.exception = err
-			raise
+			log_error(err)
 		finally:
 			if self.notebook._operation_check == self:
 				self.notebook._operation_check = NOOP # stop blocking


### PR DESCRIPTION
`NotebookOperation` is intended to be executed in the GTK main loop via `run_on_idle()`.
Even if such execution terminates in an unhandled exception, execution of Zim still continues.
Thus, normally the effect of an unhandled exception is to print an error message and a traceback in Zim's debug log.

However, if `sys.excepthook` is overridden, different action may result.
In particular, in Fedora Linux, Automatic Bug Reporting Tool (ABRT)'s Python plugin overrides `sys.excepthook`
to notify the user about unhandled exception in Zim,
and also to upload a crash report to Fedora Analytics Framework.
Since multiple `NotebookOperation` subclasses use exceptions to communicate failures that are preventable by the user,
such as trying to create a page that already exists,
this is not desirable.

To avoid triggering `sys.excepthook`,
stop re-raising exceptions in the already existing `NotebookOperation` catch-all exception handler.
Just print them to the debug log instead.

Note that since the catch-all handler already communicates the exceptions to `NotebookOperation` caller via the `cancelled` and `exception` properties,
it could be argued that all handling of exceptions, even logging them, should be left to the caller.
However, there are places where `NotebookOperation` subclasses are executed,
but those properties are not checked afterwards at all,
and thus the *only* error handling they already have is the debug log.
Since the author of this change does not feel comfortable adding exception handling to all those places,
the solution is to keep logging the exception inside `NotebookOperation`.

Fixes #2382 
Relates to #2482 