### PR TITLE
Fix #2457: The ``Insert Date and Time`` dialog box does not correctly process Unicode strings from the ``dates.list`` file

### DIFF
--- a/tests/datetimetz.py
+++ b/tests/datetimetz.py
@@ -50,6 +50,18 @@ class TestDateTimeZ(tests.TestCase):
 		#s = datetime.strftime('%V', dt)
 		#self.assertTrue(isinstance(s, str) and len(s) > 0)
 
+		s = datetime.strftime('%Y 道', dt)
+		self.assertTrue(isinstance(s, str) and len(s) == 4 + 1 + 1)
+
+		s = datetime.strftime('%Y ❗', dt)
+		self.assertTrue(isinstance(s, str) and len(s) == 4 + 1 + 1)
+
+		s = datetime.strftime('%Y 👨‍👩‍👧‍👦', dt)
+		self.assertTrue(isinstance(s, str) and len(s) >= 4 + 1 + 1)
+
+		s = datetime.strftime('%Y ƑÊẶṜ', dt)
+		self.assertTrue(isinstance(s, str) and len(s) >= 4 + 1 + 4)
+
 		# strfcal
 		s = datetime.strfcal('%w', dt)
 		self.assertTrue(isinstance(s, str) and len(s) > 0)

--- a/zim/datetimetz.py
+++ b/zim/datetimetz.py
@@ -230,7 +230,12 @@ def strfcal(format, date):
 
 def strftime(format, date):
 	# TODO: deprecate this function
-	return date.strftime(format)
+	# see issue #2457
+	# When we pass some unicode characters (e.g. emoji)
+	# to strftime under Windows we get a UnicodeEncodeError exception.
+	# To avoid this, we convert all non-ASCII characters to their \uXXXXXX representations,
+	# then pass to the strftime function and convert back to a Unicode string.
+	return date.strftime(format.encode('unicode-escape').decode()).encode().decode('unicode-escape')
 
 
 if __name__ == '__main__': #pragma: no cover


### PR DESCRIPTION
Fixes: #2457