### PR TITLE
Avoid unhandled exception when user cancels template copy

### DIFF
--- a/zim/gui/templateeditordialog.py
+++ b/zim/gui/templateeditordialog.py
@@ -110,7 +110,8 @@ class TemplateEditorDialog(Dialog):
 			source = default
 
 		name = PromptNameDialog(self).run()
-		assert name is not None
+		if name is None:
+			return # User cancelled the operation
 		_, ext = custom.basename.rsplit('.', 1)
 		basename = name + '.' + ext
 		newfile = custom.parent().file(basename)


### PR DESCRIPTION
When user copies a template via _Edit_ > _Templates_ > _Copy_, they are prompted for a name for the new template. Previously, if user cancelled this operation, an assertion exception was raised. This leads to a backtrace being printed in the debug log, which is not appropriate in this case, where no actual error happened. Replace with a simple return statement.

After this change, the relevant part of the debug log looks like this:

    DEBUG: Opening dialog "Copy Template"
    DEBUG: Dialog response CANCEL
    DEBUG: Closed dialog "Copy Template"

Which describes what happened very well.

The actual reason why this situation came under investigation is Fedora's Automatic Bug Reporting tool (ABRT), which creates crash reports for unhandled exceptions. See:
https://bugzilla.redhat.com/show_bug.cgi?id=2246676