### PR TITLE
Diagram default text revisited

### DIFF
--- a/data/manual/Plugins/Diagram_Editor.txt
+++ b/data/manual/Plugins/Diagram_Editor.txt
@@ -30,4 +30,5 @@ For full documentation of the script language see: http://www.graphviz.org/
 This plugin has the following options:
 
 * The option **Generate diagrams in SVG format** determines whether the diagrams will be generated in the SVG format. This is only enabled by default if your system supports it.
+* The option **Default text** sets the default text for each new diagram, to help get you started. An example default is ''digraph G {rankdir=LR}''
 

--- a/zim/plugins/diagrameditor.py
+++ b/zim/plugins/diagrameditor.py
@@ -38,6 +38,12 @@ This is a core plugin shipping with zim.
             _('Generate diagrams in SVG format'), # T: plugin preference
 			supports_image_format('svg')
 		),
+		(
+			'default_text',
+			'string',
+			_('Default text'),
+			''
+		),
 	)
 
 	@classmethod
@@ -72,6 +78,7 @@ class DiagramGenerator(ImageGeneratorClass):
 		ImageGeneratorClass.__init__(self, plugin, notebook, page)
 		self.dotfile = TmpFile('diagram.dot')
 		self.dotfile.touch()
+		self.default_text = plugin.preferences['default_text']
 
 	def generate_image(self, text):
 		# Write to tmp file
@@ -101,3 +108,7 @@ class DiagramGenerator(ImageGeneratorClass):
 			self.imgfile.remove()
 		except AttributeError:
 			logger.debug('Closed dialog before generating image, nothing to remove')
+
+	def get_default_text(self):
+		'''Provides a template or starting point for the user to begin editing.'''
+		return self.default_text

--- a/zim/plugins/diagrameditor.py
+++ b/zim/plugins/diagrameditor.py
@@ -111,4 +111,4 @@ class DiagramGenerator(ImageGeneratorClass):
 
 	def get_default_text(self):
 		'''Provides a template or starting point for the user to begin editing.'''
-		return self.default_text
+		return self.default_text or ''


### PR DESCRIPTION
Wrapping up the work of @e3rd on [ #1073](https://github.com/zim-desktop-wiki/zim-desktop-wiki/pull/1073). 

Original description:

> Inserting quick diagram is very handy feature. Unfortunately, we could not set up default text so that we have write every time the same line again and again.
>
> Now we may have ex: 'digraph G {rankdir=LR}' as the base.

This PR replaces #1073, adding the necessary manual edit, and a tiny fix for something I found whilst testing.