### PR TITLE
Adds gitignore entry for ".vs"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ debian/python-module-stampdir/
 
 # PyCharm
 .idea
+
+# Rider
+.vs


### PR DESCRIPTION
JetBrains Rider, with the python plugin, creates a ".vs" temporary directory. This is akin to the ".idea" directory used by PyCharm, and can be safely ignored in the repository.