### PR TITLE
Add formats to insert the week number as date

### DIFF
--- a/data/dates.list
+++ b/data/dates.list
@@ -8,3 +8,5 @@
 %A %d %B %Y
 [d: %Y-%m-%d]
 %Y-%m-%d
+Week %W %Y
+Week %W


### PR DESCRIPTION
Since the Journal plugin supports a weekly calendar, I thought the insert date dialog could also have the option to insert the week number (I use it often). Here's a screenshot of the dialog with the added formats:

![Screenshot from 2023-12-19 13-13-35](https://github.com/zim-desktop-wiki/zim-desktop-wiki/assets/361179/d2da4349-e0aa-4b71-8ade-6e64139eb8ce)
