### PR TITLE
Markdown export: Fix inline verbatim

### DIFF
--- a/zim/formats/markdown.py
+++ b/zim/formats/markdown.py
@@ -49,7 +49,7 @@ class Dumper(TextDumper):
 		STRONG: ('**', '**'),
 		MARK: ('__', '__'), # OPEN ISSUE: not available in pandoc
 		STRIKE: ('~~', '~~'),
-		VERBATIM: ("``", "``"),
+		VERBATIM: ('`', '`'),
 		TAG: ('', ''), # No additional annotation (apart from the visible @)
 		SUBSCRIPT: ('~', '~'),
 		SUPERSCRIPT: ('^', '^'),


### PR DESCRIPTION
See https://spec.commonmark.org/0.30/#inlines. Inline code spans are marked up with backticks (`` ` ``).

Or does ``this`` also work?