### PR TITLE
add "internal-link" style to show internal links differently

### DIFF
--- a/zim/gui/pageview/textbuffer.py
+++ b/zim/gui/pageview/textbuffer.py
@@ -285,6 +285,7 @@ class TextBuffer(Gtk.TextBuffer):
 		'sub': {'rise': -3500, 'scale': 0.7},
 		'sup': {'rise': 7500, 'scale': 0.7},
 		'link': {'foreground': 'blue'},
+		'internal-link': {'foreground': 'green'},
 		'tag': {'foreground': '#ce5c00'},
 		'indent': {},
 		'bullet-list': {},
@@ -796,8 +797,12 @@ class TextBuffer(Gtk.TextBuffer):
 		if hasattr(href, 'uri'):
 			href = href.uri
 		assert isinstance(href, str) or href is None
-
-		tag = self.create_tag(None, **self.tag_styles['link'])
+		url: str = href or ''
+		is_external_link : bool = url.startswith('http://') or url.startswith('https://')
+		if is_external_link:
+			tag = self.create_tag(None, **self.tag_styles['link'])
+		else: 
+			tag = self.create_tag(None, **self.tag_styles['internal-link'])
 		tag.zim_tag = 'link'
 		tag.zim_attrib = attrib
 		if href == text or not href or href.isspace():

--- a/zim/gui/pageview/textbuffer.py
+++ b/zim/gui/pageview/textbuffer.py
@@ -797,12 +797,9 @@ class TextBuffer(Gtk.TextBuffer):
 		if hasattr(href, 'uri'):
 			href = href.uri
 		assert isinstance(href, str) or href is None
-		url: str = href or ''
-		is_external_link : bool = url.startswith('http://') or url.startswith('https://')
-		if is_external_link:
-			tag = self.create_tag(None, **self.tag_styles['link'])
-		else: 
-			tag = self.create_tag(None, **self.tag_styles['internal-link'])
+		is_internal_link = (link_type(href or '') == 'page')
+		styles = self.tag_styles['internal-link' if is_internal_link else 'link']
+		tag = self.create_tag(None, **styles)
 		tag.zim_tag = 'link'
 		tag.zim_attrib = attrib
 		if href == text or not href or href.isspace():

--- a/zim/gui/pageview/textbuffer.py
+++ b/zim/gui/pageview/textbuffer.py
@@ -15,6 +15,7 @@ from zim.formats import get_dumper, heading_to_anchor, increase_list_iter, \
 from zim.newfs import LocalFile
 from zim.config import String, Float, Integer, Boolean, \
 	ConfigDefinitionConstant
+from zim.parsing import link_type
 from zim.plugins import PluginManager
 from zim.gui.base.images import image_file_load_pixels
 from zim.gui.clipboard import textbuffer_register_serialize_formats
@@ -285,7 +286,7 @@ class TextBuffer(Gtk.TextBuffer):
 		'sub': {'rise': -3500, 'scale': 0.7},
 		'sup': {'rise': 7500, 'scale': 0.7},
 		'link': {'foreground': 'blue'},
-		'internal-link': {'foreground': 'green'},
+		'internal-link': {'foreground': 'green', 'underline': Pango.Underline.DOUBLE},
 		'tag': {'foreground': '#ce5c00'},
 		'indent': {},
 		'bullet-list': {},


### PR DESCRIPTION
This is to add the ability to make internal links look different than external links.

cf. https://github.com/zim-desktop-wiki/zim-desktop-wiki/discussions/2553#discussioncomment-8198243

Tested:
With this change, the internal links are rendered differently: 
![image](https://github.com/zim-desktop-wiki/zim-desktop-wiki/assets/1615196/2273742f-9feb-42c0-b58e-69f50700bf42)

And it's possible to add an entry in `styles.conf` to customize: 

```
[Tag internal-link]
foreground=#8e7cc3
underline=PANGO_UNDERLINE_SINGLE
```

with the modified styles, the internal links render as specified: 
![image](https://github.com/zim-desktop-wiki/zim-desktop-wiki/assets/1615196/f97ec1c6-4629-4281-94f2-86e0d61d313e)
