### PR TITLE
Table editor fixes

### DIFF
--- a/zim/base/naturalsort.py
+++ b/zim/base/naturalsort.py
@@ -27,6 +27,7 @@ def natural_sort_key(string, numeric_padding=5):
 	@returns: string transformed to sorting key
 	'''
 	templ = '%0' + str(numeric_padding) + 'i'
+	string = string or ''  # Handle None by sorting as empty string
 	string = unicodedata.normalize('NFC', string.strip())
 	string = _num_re.sub(lambda m: templ % int(m.group()), string)
 	string = string.lower() # sort case insensitive

--- a/zim/plugins/tableeditor.py
+++ b/zim/plugins/tableeditor.py
@@ -708,6 +708,11 @@ class TableViewWidget(InsertedObjectWidget):
 			model.set_value(newiter, col, value)
 			model.set_value(treeiter, col, newvalue)
 
+		# Move cursor to the new position of the moved row
+		nextiter = model.iter_next(treeiter) if direction > 0 else model.iter_previous(treeiter)
+		path = model.get_path(nextiter)
+		self.treeview.set_cursor(path, None, True)
+
 	def on_open_link(self, action, link):
 		''' Context menu: Open a link, which is written in a cell '''
 		self.emit('link-clicked', {'href': str(link)})


### PR DESCRIPTION
Two fixes to the tableeditor plugin. Split off from the https://github.com/zim-desktop-wiki/zim-desktop-wiki/pull/2570 PR, so that these fixes are separated from feature WIP on table tab-key navigation.

| Issue| Description| 
|--------|--------|
| #1061 | Uncaught exception when sorting "None"| 
| Discussion #2269, Issue #853 | Maintain row selection when moving rows up or down | 