### PR TITLE
distractionfree - set caret-color to text color

### DIFF
--- a/zim/plugins/distractionfree.py
+++ b/zim/plugins/distractionfree.py
@@ -62,6 +62,7 @@ class DistractionFreeMainWindowExtension(MainWindowExtension):
 		css = '''
 		#zim-pageview text {
 			color: %(textcolor)s;
+			caret-color : %(textcolor)s;
 			background-color: %(basecolor)s;
 		}
 		#zim-window-main-box scrolledwindow{


### PR DESCRIPTION
fixes #2574

problem: is the default the exact text color? if not, this'll degrade the appearance

alt fix: separate caret-color pref in plugin - perhaps some would enjoy a more colorful cursor anyway?