### PR TITLE
Mark use of MD5 as not being for security to fix FIPS-enabled systems

### DIFF
--- a/zim/fs.py
+++ b/zim/fs.py
@@ -242,7 +242,7 @@ def format_file_size(bytes):
 
 def _md5(content):
 	import hashlib
-	m = hashlib.md5()
+	m = hashlib.md5(usedforsecurity=False)
 	if isinstance(content, str):
 		m.update(content.encode('UTF-8'))
 	else:

--- a/zim/main/ipc.py
+++ b/zim/main/ipc.py
@@ -55,7 +55,7 @@ def set_in_main_process(in_main_process):
 
 
 
-_m = hashlib.md5()
+_m = hashlib.md5(usedforsecurity=False)
 _m.update(zim.ZIM_EXECUTABLE.encode('UTF-8'))
 
 key = zim.__version__ + '-' + _m.hexdigest()[:8]

--- a/zim/newfs/base.py
+++ b/zim/newfs/base.py
@@ -658,7 +658,7 @@ def _md5(content):
 	if isinstance(content, str):
 		content = (content,)
 
-	m = hashlib.md5()
+	m = hashlib.md5(usedforsecurity=False)
 	for l in content:
 		m.update(l.encode('UTF-8'))
 	return m.digest()

--- a/zim/plugins/attachmentbrowser/thumbnailer.py
+++ b/zim/plugins/attachmentbrowser/thumbnailer.py
@@ -231,7 +231,7 @@ class ThumbnailManager(object):
 		@param size: thumbnail size in pixels (C{THUMB_SIZE_NORMAL}, C{THUMB_SIZE_LARGE}, or integer)
 		@returns: a L{File} object
 		'''
-		basename = hashlib.md5(file.uri.encode('ascii')).hexdigest() + '.png'
+		basename = hashlib.md5(file.uri.encode('ascii'), usedforsecurity=False).hexdigest() + '.png'
 			# file.uri should already be URL encoded for unicode characters - use 'ascii' to check
 		if size <= THUMB_SIZE_NORMAL:
 			return LOCAL_THUMB_STORAGE_NORMAL.file(basename)

--- a/zim/plugins/base/imagegenerator.py
+++ b/zim/plugins/base/imagegenerator.py
@@ -146,7 +146,7 @@ class ImageGeneratorModel(ImageGeneratorModelBase):
 			for k, v in sorted(self.attrib.items()):
 				content.extend([k, v])
 			content.append(self.data)
-			basename = hashlib.md5(''.join(content).encode()).hexdigest() + self.generator.imagefile_extension
+			basename = hashlib.md5(''.join(content).encode(), usedforsecurity=False).hexdigest() + self.generator.imagefile_extension
 		else:
 			basename = 'empty_image' + self.generator.imagefile_extension
 		file = cache_dir.file(basename)


### PR DESCRIPTION
Zim fails for me with the following error:

```
Traceback (most recent call last):
  File "/usr/bin/zim", line 137, in <module>
    main()
  File "/usr/bin/zim", line 114, in main
    import zim.main
  File "/usr/lib/python3.9/site-packages/zim/main/__init__.py", line 35, in <module>
    from .ipc import dispatch as _ipc_dispatch
  File "/usr/lib/python3.9/site-packages/zim/main/ipc.py", line 56, in <module>
    _m = hashlib.md5()
ValueError: [digital envelope routines] unsupported
```

This is on a Redhat EL 9.4 system where FIPS is enabled. FIPS is a US Federal cryptography standard that limits the available algorithms to an approved set and enabling the support for it is something that was imposed on us. On a RHEL system, you can run `fips-mode-setup --enable` and reboot and it will apply limited policies for allowable crypt algorithms on everything from openssl, ssh, gnutls, the linux kernel and, as you see here, Python.  Something like MD5 is often used for things that you wouldn't really consider security sensitive and in this case, Python allows you to pass `usedforsecurity=False` to assert that to be the case. That is what this pull-request does.

In the case of Zim, you appear to be constructing the name for a unix domain socket including a partial MD5 digest. I'm guessing this socket is used for a single instance when zim is invoked more than once. There's also use for images/thumbnails. Either way, I'm fairly sure the usage is just as a fast way to separate unique items and a conflict would not have security implications. If you think the usage is in anyway security sensitive then the fix should be to switch to something better than MD5 such as SHA256.

I'm not certain my testing has covered the changes to the two plugins so you may want to verify those.