### PR TITLE
Skip favicon.ico in tests/attachmentbrowser

### DIFF
--- a/tests/attachmentbrowser.py
+++ b/tests/attachmentbrowser.py
@@ -29,6 +29,8 @@ class TestThumbnailCreators(tests.TestCase):
 			for i, basename in enumerate(dir.list_names()):
 				if basename.endswith('.svg'):
 					continue # fails on windows in some cases
+				if basename.endswith('.ico'):
+					continue # Support removed in gdk-pixbuf 2.42.11
 				file = dir.file(basename)
 				thumbfile = thumbdir.file('thumb--' + basename)
 
@@ -150,10 +152,14 @@ class TestThumbnailQueue(tests.TestCase):
 		dir = tests.ZIM_DATA_FOLDER.folder('pixmaps')
 		pixmaps = set()
 		for basename in dir.list_names():
-			if not basename.endswith('.svg'):
-				file = dir.file(basename)
-				pixmaps.add(file.path)
-				queue.queue_thumbnail_request(file, 64)
+			if basename.endswith('.svg'):
+				continue # fails on windows in some cases
+			if basename.endswith('.ico'):
+				continue # Support removed in gdk-pixbuf 2.42.11
+
+			file = dir.file(basename)
+			pixmaps.add(file.path)
+			queue.queue_thumbnail_request(file, 64)
 
 		self.assertFalse(queue.queue_empty())
 


### PR DESCRIPTION
gdk-pixbuf 2.42.11 [removes support][1] for multiple less common image formats, including ICO. Skip that format in thumbnail generation tests to make the test pass.

Other than the test failure, Zim remains functional with gdk-pixbuf 2.42.11. Attachment Browser still works even for ICO files. The thumbnails naturally fail to show up, but otherwise the browser remains functional. ICO files cannot be attached to pages anymore, instead error dialog with text _File type not supported: image/x-icon_ is displayed.

[1]: https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/e052a112075a19fb75f1f2ff3de4c82923de13f2