### PR TITLE
Use markdown blockquote to export indented paragraphs

### DIFF
--- a/tests/data/formats/export.markdown
+++ b/tests/data/formats/export.markdown
@@ -8,13 +8,13 @@ reprehenderit in voluptate velit esse cillum dolore eu fugiat
 nulla pariatur.  Excepteur sint occaecat cupidatat non proident,
 sunt in culpa qui officia deserunt mollit anim id est laborum.
 
-Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-aliquip ex ea commodo consequat. Duis aute irure dolor in
-reprehenderit in voluptate velit esse cillum dolore eu fugiat
-nulla pariatur.  Excepteur sint occaecat cupidatat non proident,
-sunt in culpa qui officia deserunt mollit anim id est laborum.
+> Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+> eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+> ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+> aliquip ex ea commodo consequat. Duis aute irure dolor in
+> reprehenderit in voluptate velit esse cillum dolore eu fugiat
+> nulla pariatur.  Excepteur sint occaecat cupidatat non proident,
+> sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 head 2
 ------

--- a/zim/formats/markdown.py
+++ b/zim/formats/markdown.py
@@ -61,8 +61,13 @@ class Dumper(TextDumper):
 		return TextDumper.dump(self, tree)
 
 	def dump_indent(self, tag, attrib, strings):
-		# OPEN ISSUE: no indent for para
-		return strings
+		# Prefix lines with one or more tabs
+		if attrib and 'indent' in attrib:
+			prefix = '> ' * int(attrib['indent'])
+			return self.prefix_lines(prefix, strings)
+			# TODO enforces we always end such a block with \n unless partial
+		else:
+			return strings
 
 	dump_p = dump_indent
 	dump_div = dump_indent


### PR DESCRIPTION
Fixes #41

Hello!

I implemented a simple solution to support Markdown blockquotes. I used the thought in the last comment: to map an indented paragraph to a blockquote. I even first thought of it myself, started to implement it, saw a TODO about an open issue and after searching, saw the same thought in there. It was really easy to implement it this way.

- [x] I updated the test export.markdown file using the test update.sh script.
- [x] Verified that my change is in unit tests (the export.markdown file changed)
- [x] I ran all tests, saw no errors.
- [x] I exported a file with indented and not indented paragraphs, saw the correct result there.

For a little background, I have a fun and ambitious project of enabling zim to use markdown format by default (reading and writing). When I started using the testing system to start showing me parser errors, this missing functionality immediately jumped out and is in some form required to make all the tests pass after a Markdown parser is added.