### PR TITLE
Quicknote plugin: automatically use heading as page name

### DIFF
--- a/zim/plugins/quicknote.py
+++ b/zim/plugins/quicknote.py
@@ -365,15 +365,13 @@ class QuickNoteDialog(Dialog):
 			self._updating_title = True
 			start, end = buffer.get_bounds()
 			text = start.get_text(end).strip()
-			# Try getting heading 1 as the page name
-			h1_pattern = r'======\s*(.*?)\s*======\n'
-			h1_match = re.search(h1_pattern, text)
+			# Limit page name to contents of first line
+			title = text.split('\n')[0]
+			# Get heading 1 as the page name, if present
+			h1_pattern = r'======\s*(.*?)\s*======'
+			h1_match = re.search(h1_pattern, title)
 			if h1_match:
-				# Use heading as page name
 				title = h1_match.group(1)
-			else:
-				# Use first line as page name
-				title = text.split('\n')[0]
 			# Remove colons and limit to 50 characters
 			title = title.replace(':', '')[:50]
 			try:

--- a/zim/plugins/quicknote.py
+++ b/zim/plugins/quicknote.py
@@ -282,7 +282,7 @@ class QuickNoteDialog(Dialog):
 		buffer = self.textview.get_buffer()
 		buffer.set_text(''.join(lines))
 		begin, end = buffer.get_bounds()
-		buffer.place_cursor(begin)
+		buffer.place_cursor(end)
 
 		buffer.set_modified(False)
 

--- a/zim/plugins/quicknote.py
+++ b/zim/plugins/quicknote.py
@@ -370,7 +370,7 @@ class QuickNoteDialog(Dialog):
 			if '\n' in title:
 				title, _ = title.split('\n', 1)
 			try:
-				title = Path.makeValidPageName(title.replace(':', ''))
+				title = Path.makeValidPageName(title)
 				self.form['basename'] = title
 			except ValueError:
 				pass

--- a/zim/plugins/quicknote.py
+++ b/zim/plugins/quicknote.py
@@ -368,10 +368,10 @@ class QuickNoteDialog(Dialog):
 			# Limit page name to contents of first line
 			title = text.split('\n')[0]
 			# Get heading 1 as the page name, if present
-			h1_pattern = r'======\s*(.*?)\s*======'
-			h1_match = re.search(h1_pattern, title)
-			if h1_match:
-				title = h1_match.group(1)
+			heading_pattern = r'={1,}\s*(.*?)\s*={1,}'
+			heading_match = re.search(heading_pattern, title)
+			if heading_match:
+				title = heading_match.group(1)
 			# Remove colons and limit to 50 characters
 			title = title.replace(':', '')[:50]
 			try:

--- a/zim/plugins/quicknote.py
+++ b/zim/plugins/quicknote.py
@@ -364,11 +364,18 @@ class QuickNoteDialog(Dialog):
 			# Automatically generate a (valid) page name
 			self._updating_title = True
 			start, end = buffer.get_bounds()
-			title = start.get_text(end).strip()[:50]
-				# Cut off at 50 characters to prevent using a whole paragraph
-			title = title.replace(':', '')
-			if '\n' in title:
-				title, _ = title.split('\n', 1)
+			text = start.get_text(end).strip()
+			# Try getting heading 1 as the page name
+			h1_pattern = r'======\s*(.*?)\s*======\n'
+			h1_match = re.search(h1_pattern, text)
+			if h1_match:
+				# Use heading as page name
+				title = h1_match.group(1)
+			else:
+				# Use first line as page name
+				title = text.split('\n')[0]
+			# Remove colons and limit to 50 characters
+			title = title.replace(':', '')[:50]
 			try:
 				title = Path.makeValidPageName(title)
 				self.form['basename'] = title


### PR DESCRIPTION
This pull request adds functionality to the Quick Note plugin to automatically generate the page name from a heading.

When trying to use a slightly modified Default template as the quick note template (to achieve #2656), I ran into the issue that the generated page name was not ideal (see image below).

Template:

```
====== [% strftime("%Y-%m-%dT%H%M%S") %] ======
[% gettext("Created") %] [% strftime("%A %d %B %Y") %]
[% text %]
```

Output:
![Screenshot from 2024-08-23 21-32-25](https://github.com/user-attachments/assets/2e0c980a-ff8a-4181-9008-71e4f1c0592d)

The modifications here try to match the heading pattern (any level) from the first line of the note to use as the page name (title). The result is this:

![image](https://github.com/user-attachments/assets/9be7343f-57e5-4435-8294-32f620abc9da)

If there's no match, it gets the first 50 characters of the first line as before:

![image](https://github.com/user-attachments/assets/f6b0e76b-044c-45f0-80dc-b0f9aeb21091)
