### PR TITLE
Fix strftime on Windows (#2578)

### DIFF
--- a/zim/datetimetz.py
+++ b/zim/datetimetz.py
@@ -235,7 +235,7 @@ def strftime(format, date):
 	# to strftime under Windows we get a UnicodeEncodeError exception.
 	# To avoid this, we convert all non-ASCII characters to their \uXXXXXX representations,
 	# then pass to the strftime function and convert back to a Unicode string.
-	return date.strftime(format.encode('unicode-escape').decode()).encode().decode('unicode-escape')
+	return date.strftime(format.encode('unicode-escape').decode('utf-8')).encode('raw-unicode-escape').decode('unicode-escape')
 
 
 if __name__ == '__main__': #pragma: no cover


### PR DESCRIPTION
Closes #2578

Tested on win10 with locales `ar-IQ`, `de-DE`, `en_US`, `hi-IN`, `ja-JP`, `ru-RU`, `zh-CN`, `zh-HK`