### PR TITLE
Update default colors to match the Tomorrow Theme

### DIFF
--- a/data/style.conf
+++ b/data/style.conf
@@ -38,18 +38,18 @@ strikethrough = true
 
 [Tag code]
 # For in-line verbatim text (gray background)
-foreground=#4d4d4c
+foreground=#4d4d4d
 background=#efefef
-foreground[darktheme]=#c5c8c6
+foreground[darktheme]=#c7c7c7
 background[darktheme]=#3c3c3c
 family = monospace
 #wrap-mode = none
 
 [Tag pre]
 # For multi-line verbatim blocks (gray background)
-foreground = #4d4d4c
+foreground = #4d4d4d
 paragraph-background = #efefef
-foreground[darktheme] = #c5c8c6
+foreground[darktheme] = #c7c7c7
 paragraph-background[darktheme] = #3c3c3c
 family    = monospace
 wrap-mode = none

--- a/data/style.conf
+++ b/data/style.conf
@@ -27,14 +27,12 @@ style = italic
 [Tag mark]
 # For highlighted text (yellow)
 background=#eab700
-#FIXME: Dark background is not being applied
-background[darktheme]=#f0c674
+background[darktheme]=#b58c1d
 #underline = single
 
 [Tag strike]
 # For struck-out text (gray)
 foreground=#8e908c
-#FIXME: Dark foreground is not being applied
 foreground[darktheme]=#969896
 strikethrough = true
 
@@ -43,7 +41,6 @@ strikethrough = true
 foreground=#4d4d4c
 background=#efefef
 foreground[darktheme]=#c5c8c6
-#FIXME: Dark background is not being applied
 background[darktheme]=#282a2e
 family = monospace
 #wrap-mode = none
@@ -52,7 +49,6 @@ family = monospace
 # For multi-line verbatim blocks (gray background)
 foreground = #4d4d4c
 paragraph-background = #efefef
-#FIXME: Dark theme is not being applied
 foreground[darktheme] = #c5c8c6
 paragraph-background[darktheme] = #282a2e
 family    = monospace
@@ -62,20 +58,17 @@ indent    = 20
 [Tag link]
 # For external links (blue)
 foreground=#4271ae
-#FIXME: Dark theme is not being applied
 foreground[darktheme]=#81a2be
 underline  = single
 
 [Tag page-link]
 # For internal links (blue)
 foreground=#4271ae
-#FIXME: Dark theme is not being applied
 foreground[darktheme]=#81a2be
 
 [Tag tag]
 # For zim tags (orange)
 foreground=#f5871f
-#FIXME: Dark theme is not being applied
 foreground[darktheme]=#de935f
 
 # Headings
@@ -85,7 +78,6 @@ foreground[darktheme]=#de935f
 
 [Tag h1]
 foreground=#718c00
-#FIXME: Dark theme is not being applied
 foreground[darktheme]=#b5bd68
 underline = single
 weight = PANGO_WEIGHT_BOLD
@@ -164,17 +156,17 @@ foreground[darktheme]=#b294bb
 [TaskList Prio High]
 # For high priority tasks (red)
 background=#c82829
-background[darktheme]=#cc6666
+background[darktheme]=#a94242
 
 [TaskList Prio Medium]
 # For medium priority tasks (orange)
 background=#f5871f
-background[darktheme]=#de935f
+background[darktheme]=#b06530
 
 [TaskList Prio Alert]
 # For low priority tasks (yellow)
 background=#eab700
-background[darktheme]=#f0c674
+background[darktheme]=#b58c1d
 
 [TaskList Inactive]
 # For inactive tasks (gray)

--- a/data/style.conf
+++ b/data/style.conf
@@ -124,24 +124,37 @@ foreground[darktheme]=#b5bd68
 
 # Task states
 #
-# For styling the text next to the task checkboxes. The default color chosen
-# marked tasks is gray.
+# For styling the text next to the task checkboxes.
 
 [Tag checked-checkbox]
-foreground=#8e908c
-foreground[darktheme]=#969896
+# For completed tasks (green)
+#foreground=#8e908c
+foreground=#718c00
+#foreground[darktheme]=#969896
+foreground[darktheme]=#b5bd68
+strikethrough = true
 
 [Tag xchecked-checkbox]
-foreground=#8e908c
-foreground[darktheme]=#969896
+# For cancelled tasks (red)
+#foreground=#8e908c
+foreground=#c82829
+#foreground[darktheme]=#969896
+foreground[darktheme]=#cc6666
+strikethrough = true
 
 [Tag migrated-checkbox]
-foreground=#8e908c
-foreground[darktheme]=#969896
+# For migrated tasks (orange)
+#foreground=#8e908c
+foreground=#f5871f
+#foreground[darktheme]=#969896
+foreground[darktheme]=#f5871f
 
 [Tag transmigrated-checkbox]
-foreground=#8e908c
-foreground[darktheme]=#969896
+# For trans-migrated tasks (purple)
+#foreground=#8e908c
+foreground=#8959a8
+#foreground[darktheme]=#969896
+foreground[darktheme]=#b294bb
 
 # Task priority
 #

--- a/data/style.conf
+++ b/data/style.conf
@@ -170,7 +170,7 @@ background[darktheme]=#b58c1d
 
 [TaskList Inactive]
 # For inactive tasks (gray)
-foreground=#8e908c
+foreground=#757575
 foreground[darktheme]=#969896
 
 # vim: syntax=desktop

--- a/data/style.conf
+++ b/data/style.conf
@@ -26,15 +26,15 @@ style = italic
 
 [Tag mark]
 # For highlighted text (yellow)
-foreground=#ffffff
 background=#eab700
-foreground[darktheme]=#1d1f21
+#FIXME: Dark background is not being applied
 background[darktheme]=#f0c674
 #underline = single
 
 [Tag strike]
 # For struck-out text (gray)
 foreground=#8e908c
+#FIXME: Dark foreground is not being applied
 foreground[darktheme]=#969896
 strikethrough = true
 
@@ -50,11 +50,11 @@ family = monospace
 
 [Tag pre]
 # For multi-line verbatim blocks (gray background)
-foreground=#4d4d4c
-paragraph-background=#efefef
-foreground[darktheme]=#c5c8c6
-#FIXME: Dark background is not being applied
-paragraph-background[darktheme]=#282a2e
+foreground = #4d4d4c
+paragraph-background = #efefef
+#FIXME: Dark theme is not being applied
+foreground[darktheme] = #c5c8c6
+paragraph-background[darktheme] = #282a2e
 family    = monospace
 wrap-mode = none
 indent    = 20
@@ -62,17 +62,20 @@ indent    = 20
 [Tag link]
 # For external links (blue)
 foreground=#4271ae
+#FIXME: Dark theme is not being applied
 foreground[darktheme]=#81a2be
 underline  = single
 
 [Tag page-link]
 # For internal links (blue)
 foreground=#4271ae
+#FIXME: Dark theme is not being applied
 foreground[darktheme]=#81a2be
 
 [Tag tag]
 # For zim tags (orange)
 foreground=#f5871f
+#FIXME: Dark theme is not being applied
 foreground[darktheme]=#de935f
 
 # Headings
@@ -82,6 +85,7 @@ foreground[darktheme]=#de935f
 
 [Tag h1]
 foreground=#718c00
+#FIXME: Dark theme is not being applied
 foreground[darktheme]=#b5bd68
 underline = single
 weight = PANGO_WEIGHT_BOLD

--- a/data/style.conf
+++ b/data/style.conf
@@ -26,7 +26,7 @@ style = italic
 
 [Tag mark]
 # For highlighted text (yellow)
-background=#eab700
+background=#ffd028
 background[darktheme]=#b58c1d
 #underline = single
 
@@ -155,17 +155,17 @@ foreground[darktheme]=#b294bb
 
 [TaskList Prio High]
 # For high priority tasks (red)
-background=#c82829
+background=#e84749
 background[darktheme]=#a94242
 
 [TaskList Prio Medium]
 # For medium priority tasks (orange)
-background=#f5871f
+background=#ff9d3e
 background[darktheme]=#b06530
 
 [TaskList Prio Alert]
 # For low priority tasks (yellow)
-background=#eab700
+background=#ffd028
 background[darktheme]=#b58c1d
 
 [TaskList Inactive]

--- a/data/style.conf
+++ b/data/style.conf
@@ -116,32 +116,24 @@ weight=PANGO_WEIGHT_BOLD
 
 [Tag checked-checkbox]
 # For completed tasks (green)
-#foreground=#8e908c
 foreground=#718c00
-#foreground[darktheme]=#969896
 foreground[darktheme]=#b5bd68
 strikethrough = true
 
 [Tag xchecked-checkbox]
 # For cancelled tasks (red)
-#foreground=#8e908c
 foreground=#c82829
-#foreground[darktheme]=#969896
 foreground[darktheme]=#cc6666
 strikethrough = true
 
 [Tag migrated-checkbox]
 # For migrated tasks (orange)
-#foreground=#8e908c
 foreground=#e5750a
-#foreground[darktheme]=#969896
 foreground[darktheme]=#f5871f
 
 [Tag transmigrated-checkbox]
 # For trans-migrated tasks (purple)
-#foreground=#8e908c
 foreground=#8959a8
-#foreground[darktheme]=#969896
 foreground[darktheme]=#b294bb
 
 # Task priority

--- a/data/style.conf
+++ b/data/style.conf
@@ -1,3 +1,5 @@
+# General settings
+
 [TextView]
 indent = 30
 tabs =
@@ -6,8 +8,15 @@ justify =
 linespacing = 3
 wrapped-lines-linespacing = 0
 
-# Colors in this style sheet are taken from the Tango palette. This
-# palette is choosen to look good with most basic desktop themes.
+# Colorscheme
+#
+# Colors in this style sheet are based on the Tomorrow Theme. This palette
+# provides a clean and balanced default for most desktop themes.
+#
+# - Light theme: Tomorrow
+# - Dark theme: Tomorrow Night
+#
+# Source: https://github.com/chriskempson/tomorrow-theme
 
 [Tag strong]
 weight = PANGO_WEIGHT_BOLD
@@ -16,110 +25,137 @@ weight = PANGO_WEIGHT_BOLD
 style = italic
 
 [Tag mark]
+# For highlighted text (yellow)
+foreground=#ffffff
+background=#eab700
+foreground[darktheme]=#1d1f21
+background[darktheme]=#f0c674
 #underline = single
-background = yellow
-background[darktheme] = #8f5902
 
 [Tag strike]
+# For struck-out text (gray)
+foreground=#8e908c
+foreground[darktheme]=#969896
 strikethrough = true
-foreground = grey
-
-# Verbatim gets a slightly different color to distinguish easier
-# used the light/dark "aluminium" color from the Tango palette.
 
 [Tag code]
-foreground = #2e3436
-foreground[darktheme] = #d3d7cf
+# For in-line verbatim text (gray)
+foreground=#8e908c
+foreground[darktheme]=#969896
 family = monospace
 #wrap-mode = none
 
 [Tag pre]
-# This style is used for multi-line verbatim blocks
-foreground = #2e3436
-foreground[darktheme] = #d3d7cf
+# For multi-line verbatim blocks (gray)
+foreground=#8e908c
+foreground[darktheme]=#969896
 family    = monospace
 wrap-mode = none
 indent    = 20
 
 [Tag link]
-foreground = blue
-foreground[darktheme] = #729fcf
+# For external links (blue)
+foreground=#4271ae
+foreground[darktheme]=#81a2be
 underline  = single
 
 [Tag page-link]
-foreground = blue
-foreground[darktheme] = #729fcf
+# For internal links (blue)
+foreground=#4271ae
+foreground[darktheme]=#81a2be
 
 [Tag tag]
-foreground = #ce5c00
-foreground[darktheme] = #fcaf3e
+# For zim tags (orange)
+foreground=#f5871f
+foreground[darktheme]=#de935f
 
+# Headings
+#
 # For the various headings we scale the size relative to the font size.
-# The color choosen is the dark green -or "Chameleon"- as defined in the
-# Tango color palette in order to fit with the default color scheme for
-# most desktops.
+# The default color chosen for headings is green.
 
 [Tag h1]
-foreground = #4e9a06
+foreground=#718c00
+foreground[darktheme]=#b5bd68
 underline = single
 weight = PANGO_WEIGHT_BOLD
 scale  = 1.75
 # 1.15**4 =~ 1.75
 
 [Tag h2]
-foreground = #4e9a06
+foreground=#718c00
+foreground[darktheme]=#b5bd68
 weight = PANGO_WEIGHT_BOLD
 scale  = 1.52
 # 1.15**3 =~ 1.52
 
 [Tag h3]
-foreground = #4e9a06
+foreground=#718c00
+foreground[darktheme]=#b5bd68
 style=italic
 weight = PANGO_WEIGHT_BOLD
 scale  = 1.32
 # 1.15**2 =~ 1.32
 
 [Tag h4]
-foreground=#4e9a06
+foreground=#718c00
+foreground[darktheme]=#b5bd68
 weight=PANGO_WEIGHT_BOLD
 scale=1.15
 
 [Tag h5]
-foreground=#4e9a06
+foreground=#718c00
+foreground[darktheme]=#b5bd68
 weight=PANGO_WEIGHT_BOLD
 
 [Tag h6]
-foreground=#4e9a06
+foreground=#718c00
+foreground[darktheme]=#b5bd68
 
+# Task states
+#
+# For styling the text next to the task checkboxes. The default color chosen
+# marked tasks is gray.
 
 [Tag checked-checkbox]
-#foreground = grey
+foreground=#8e908c
+foreground[darktheme]=#969896
 
 [Tag xchecked-checkbox]
-#foreground = grey
+foreground=#8e908c
+foreground[darktheme]=#969896
 
 [Tag migrated-checkbox]
-#foreground = grey
+foreground=#8e908c
+foreground[darktheme]=#969896
 
 [Tag transmigrated-checkbox]
-#foreground = grey
+foreground=#8e908c
+foreground[darktheme]=#969896
 
-# Below config for tasklist highlighting only support background/foreground
-# colors, not the full set of the texttags above
+# Task priority
+#
+# For color-coding task priority in the tasklist. Only background and
+# foreground colors are supported (no other styling tags).
 
 [TaskList Prio High]
-background = #ef2929
-background[darktheme] = #a40000
+# For high priority tasks (red)
+background=#c82829
+background[darktheme]=#cc6666
 
 [TaskList Prio Medium]
-background = #f57900
-background[darktheme] = #ce5c00
+# For medium priority tasks (orange)
+background=#f5871f
+background[darktheme]=#de935f
 
 [TaskList Prio Alert]
-background = #fce947
-background[darktheme] = #c4a000
+# For low priority tasks (yellow)
+background=#eab700
+background[darktheme]=#f0c674
 
 [TaskList Inactive]
-foreground = darkgrey
+# For inactive tasks (gray)
+foreground=#8e908c
+foreground[darktheme]=#969896
 
 # vim: syntax=desktop

--- a/data/style.conf
+++ b/data/style.conf
@@ -110,10 +110,6 @@ foreground=#718c00
 foreground[darktheme]=#b5bd68
 weight=PANGO_WEIGHT_BOLD
 
-[Tag h6]
-foreground=#718c00
-foreground[darktheme]=#b5bd68
-
 # Task states
 #
 # For styling the text next to the task checkboxes.

--- a/data/style.conf
+++ b/data/style.conf
@@ -25,7 +25,7 @@ weight = PANGO_WEIGHT_BOLD
 style = italic
 
 [Tag mark]
-# For highlighted text (yellow)
+# For highlighted text (light yellow)
 background=#ffd028
 background[darktheme]=#b58c1d
 #underline = single
@@ -154,17 +154,17 @@ foreground[darktheme]=#b294bb
 # foreground colors are supported (no other styling tags).
 
 [TaskList Prio High]
-# For high priority tasks (red)
+# For high priority tasks (light red)
 background=#e84749
 background[darktheme]=#a94242
 
 [TaskList Prio Medium]
-# For medium priority tasks (orange)
+# For medium priority tasks (light orange)
 background=#ff9d3e
 background[darktheme]=#b06530
 
 [TaskList Prio Alert]
-# For low priority tasks (yellow)
+# For low priority tasks (light yellow)
 background=#ffd028
 background[darktheme]=#b58c1d
 

--- a/data/style.conf
+++ b/data/style.conf
@@ -26,22 +26,22 @@ style = italic
 
 [Tag mark]
 # For highlighted text (light yellow)
-background=#ffd028
-background[darktheme]=#b58c1d
+background = #ffd028
+background[darktheme] = #b58c1d
 #underline = single
 
 [Tag strike]
 # For struck-out text (gray)
-foreground=#757575
-foreground[darktheme]=#979797
+foreground = #757575
+foreground[darktheme] = #979797
 strikethrough = true
 
 [Tag code]
 # For in-line verbatim text (gray background)
-foreground=#4d4d4d
-background=#efefef
-foreground[darktheme]=#c7c7c7
-background[darktheme]=#3c3c3c
+foreground = #4d4d4d
+background = #efefef
+foreground[darktheme] = #c7c7c7
+background[darktheme] = #3c3c3c
 family = monospace
 #wrap-mode = none
 
@@ -51,25 +51,25 @@ foreground = #4d4d4d
 paragraph-background = #efefef
 foreground[darktheme] = #c7c7c7
 paragraph-background[darktheme] = #3c3c3c
-family    = monospace
+family = monospace
 wrap-mode = none
-indent    = 20
+indent = 20
 
 [Tag link]
 # For external links (blue)
-foreground=#4271ae
-foreground[darktheme]=#81a2be
-underline  = single
+foreground = #4271ae
+foreground[darktheme] = #81a2be
+underline = single
 
 [Tag page-link]
 # For internal links (blue)
-foreground=#4271ae
-foreground[darktheme]=#81a2be
+foreground = #4271ae
+foreground[darktheme] = #81a2be
 
 [Tag tag]
 # For zim tags (orange)
-foreground=#e5750a
-foreground[darktheme]=#de935f
+foreground = #e5750a
+foreground[darktheme] = #de935f
 
 # Headings
 #
@@ -77,38 +77,38 @@ foreground[darktheme]=#de935f
 # The default color chosen for headings is green.
 
 [Tag h1]
-foreground=#718c00
-foreground[darktheme]=#b5bd68
+foreground = #718c00
+foreground[darktheme] = #b5bd68
 underline = single
 weight = PANGO_WEIGHT_BOLD
-scale  = 1.75
+scale = 1.75
 # 1.15**4 =~ 1.75
 
 [Tag h2]
-foreground=#718c00
-foreground[darktheme]=#b5bd68
+foreground = #718c00
+foreground[darktheme] = #b5bd68
 weight = PANGO_WEIGHT_BOLD
-scale  = 1.52
+scale = 1.52
 # 1.15**3 =~ 1.52
 
 [Tag h3]
-foreground=#718c00
-foreground[darktheme]=#b5bd68
-style=italic
+foreground = #718c00
+foreground[darktheme] = #b5bd68
+style = italic
 weight = PANGO_WEIGHT_BOLD
-scale  = 1.32
+scale = 1.32
 # 1.15**2 =~ 1.32
 
 [Tag h4]
-foreground=#718c00
-foreground[darktheme]=#b5bd68
-weight=PANGO_WEIGHT_BOLD
-scale=1.15
+foreground = #718c00
+foreground[darktheme] = #b5bd68
+weight = PANGO_WEIGHT_BOLD
+scale = 1.15
 
 [Tag h5]
-foreground=#718c00
-foreground[darktheme]=#b5bd68
-weight=PANGO_WEIGHT_BOLD
+foreground = #718c00
+foreground[darktheme] = #b5bd68
+weight = PANGO_WEIGHT_BOLD
 
 # Task states
 #
@@ -116,25 +116,25 @@ weight=PANGO_WEIGHT_BOLD
 
 [Tag checked-checkbox]
 # For completed tasks (green)
-foreground=#718c00
-foreground[darktheme]=#b5bd68
+foreground = #718c00
+foreground[darktheme] = #b5bd68
 strikethrough = true
 
 [Tag xchecked-checkbox]
 # For cancelled tasks (red)
-foreground=#c82829
-foreground[darktheme]=#cc6666
+foreground = #c82829
+foreground[darktheme] = #cc6666
 strikethrough = true
 
 [Tag migrated-checkbox]
 # For migrated tasks (orange)
-foreground=#e5750a
-foreground[darktheme]=#f5871f
+foreground = #e5750a
+foreground[darktheme] = #f5871f
 
 [Tag transmigrated-checkbox]
 # For trans-migrated tasks (purple)
-foreground=#8959a8
-foreground[darktheme]=#b294bb
+foreground = #8959a8
+foreground[darktheme] = #b294bb
 
 # Task priority
 #
@@ -143,22 +143,22 @@ foreground[darktheme]=#b294bb
 
 [TaskList Prio High]
 # For high priority tasks (light red)
-background=#e84749
-background[darktheme]=#a94242
+background = #e84749
+background[darktheme] = #a94242
 
 [TaskList Prio Medium]
 # For medium priority tasks (light orange)
-background=#ff9d3e
-background[darktheme]=#b06530
+background = #ff9d3e
+background[darktheme] = #b06530
 
 [TaskList Prio Alert]
 # For low priority tasks (light yellow)
-background=#ffd028
-background[darktheme]=#b58c1d
+background = #ffd028
+background[darktheme] = #b58c1d
 
 [TaskList Inactive]
 # For inactive tasks (gray)
-foreground=#757575
-foreground[darktheme]=#969896
+foreground = #757575
+foreground[darktheme] = #969896
 
 # vim: syntax=desktop

--- a/data/style.conf
+++ b/data/style.conf
@@ -41,7 +41,7 @@ strikethrough = true
 foreground=#4d4d4c
 background=#efefef
 foreground[darktheme]=#c5c8c6
-background[darktheme]=#282a2e
+background[darktheme]=#3c3c3c
 family = monospace
 #wrap-mode = none
 
@@ -50,7 +50,7 @@ family = monospace
 foreground = #4d4d4c
 paragraph-background = #efefef
 foreground[darktheme] = #c5c8c6
-paragraph-background[darktheme] = #282a2e
+paragraph-background[darktheme] = #3c3c3c
 family    = monospace
 wrap-mode = none
 indent    = 20

--- a/data/style.conf
+++ b/data/style.conf
@@ -68,7 +68,7 @@ foreground[darktheme]=#81a2be
 
 [Tag tag]
 # For zim tags (orange)
-foreground=#f5871f
+foreground=#e5750a
 foreground[darktheme]=#de935f
 
 # Headings
@@ -137,7 +137,7 @@ strikethrough = true
 [Tag migrated-checkbox]
 # For migrated tasks (orange)
 #foreground=#8e908c
-foreground=#f5871f
+foreground=#e5750a
 #foreground[darktheme]=#969896
 foreground[darktheme]=#f5871f
 

--- a/data/style.conf
+++ b/data/style.conf
@@ -32,7 +32,7 @@ background[darktheme]=#b58c1d
 
 [Tag strike]
 # For struck-out text (gray)
-foreground=#8e8e8e
+foreground=#757575
 foreground[darktheme]=#979797
 strikethrough = true
 

--- a/data/style.conf
+++ b/data/style.conf
@@ -39,9 +39,12 @@ foreground[darktheme]=#969896
 strikethrough = true
 
 [Tag code]
-# For in-line verbatim text (gray)
-foreground=#8e908c
-foreground[darktheme]=#969896
+# For in-line verbatim text (gray background)
+foreground=#4d4d4c
+background=#efefef
+foreground[darktheme]=#c5c8c6
+#FIXME: Dark background is not being applied
+background[darktheme]=#282a2e
 family = monospace
 #wrap-mode = none
 

--- a/data/style.conf
+++ b/data/style.conf
@@ -32,8 +32,8 @@ background[darktheme]=#b58c1d
 
 [Tag strike]
 # For struck-out text (gray)
-foreground=#8e908c
-foreground[darktheme]=#969896
+foreground=#8e8e8e
+foreground[darktheme]=#979797
 strikethrough = true
 
 [Tag code]

--- a/data/style.conf
+++ b/data/style.conf
@@ -46,9 +46,12 @@ family = monospace
 #wrap-mode = none
 
 [Tag pre]
-# For multi-line verbatim blocks (gray)
-foreground=#8e908c
-foreground[darktheme]=#969896
+# For multi-line verbatim blocks (gray background)
+foreground=#4d4d4c
+paragraph-background=#efefef
+foreground[darktheme]=#c5c8c6
+#FIXME: Dark background is not being applied
+paragraph-background[darktheme]=#282a2e
 family    = monospace
 wrap-mode = none
 indent    = 20


### PR DESCRIPTION
Dear Jaap,

As discussed in #1727, this PR proposes to update the default Zim color scheme to match the [Tomorrow Theme](https://github.com/chriskempson/tomorrow-theme). This palette provides a more balanced set of colors that adapt equally well for light and dark themes. It is also similar to the current theme, so it won't be a drastic change of style. I put some before/after screenshots below.

I would love to hear what you and the community think about these changes. There are some tweaks and ideas that I would like to discuss if they make sense to be included as defaults. But I'll add these updates later on. For now, any feedback on this initial version is welcome!

## Headings
![tomorrow-zim-headings](https://github.com/user-attachments/assets/a5e214c5-4cbd-4b86-b0e3-b9aab0835fb1)

## Formatting
![tomorrow-zim-formatting](https://github.com/user-attachments/assets/572cea13-214b-46b1-af93-e9c2852ef649)

## Task priority
![tomorrow-zim-priority](https://github.com/user-attachments/assets/4b658f6c-362a-4e77-a515-9b9ca1992ee7)

## Dark theme (formatting)
![tomorrow-zim-formatting-dark](https://github.com/user-attachments/assets/981d8963-aa09-4674-98a8-1a7e82f10418)

Cheers,
Buno