### PR TITLE
Fix issue with linesorter plugin (#2713)

### DIFF
--- a/tests/linesorter.py
+++ b/tests/linesorter.py
@@ -87,6 +87,18 @@ class TestLineSorterWindowExtension(tests.TestCase, TextBufferTestCaseMixin):
 		self.extension.move_line_up()
 		self.assertEqual(self.get_text(), 'B line\nA line\nC line\n')
 
+	def testMoveUpStyledTextIntoCheckboxList(self):
+		self.set_text('[ ] Checkbox #1\n[ ] Checkbox #2\nLine with **bold** text\n')
+		self.place_cursor(32)
+		self.extension.move_line_up()
+		self.assertBufferEqual(self.buffer, '[ ] Checkbox #1\nLine with <strong>bold</strong> text\n[ ] Checkbox #2\n')
+
+	def testMoveUpLineWithPageLinkIntoList(self):
+		self.set_text('* List item #1\n* List item #2\nLine containing a [[page link]]\n')
+		self.place_cursor(30)
+		self.extension.move_line_up()
+		self.assertBufferEqual(self.buffer, '* List item #1\nLine containing a <link href="None">page link</link>\n* List item #2\n')
+
 	def testMoveDownNoSelection(self):
 		self.set_text('A line\nB line\nC line\n')
 		self.place_cursor(10)

--- a/zim/plugins/linesorter.py
+++ b/zim/plugins/linesorter.py
@@ -1,22 +1,17 @@
-
 # Copyright 2011 NorfCran <norfcran@gmail.com>
 # License:  same as zim (gpl)
 
-
-
-from gi.repository import Gtk
+from __future__ import annotations
 
 from zim.errors import Error
 from zim.plugins import PluginClass
 from zim.actions import action
 from zim.base.naturalsort import natural_sort_key
-
 from zim.gui.pageview import PageViewExtension
-from zim.gui.pageview.serialize import textbuffer_internal_serialize_range, textbuffer_internal_insert_at_cursor
 
-import logging
+#~ import logging
 
-logger = logging.getLogger('zim.plugins.linesorter')
+#~ logger = logging.getLogger('zim.plugins.linesorter')
 
 
 class LineSorterPlugin(PluginClass):
@@ -130,7 +125,7 @@ class LineSorterPageViewExtension(PageViewExtension):
 			cursor_offset = cursor.get_line_offset()
 
 		# get copy tree
-		linedata = textbuffer_internal_serialize_range(buffer, start, end)
+		linedata = buffer.get_parsetree(bounds=(start, end))
 
 		with buffer.user_action:
 			# delete lines and insert at target
@@ -151,7 +146,7 @@ class LineSorterPageViewExtension(PageViewExtension):
 
 			# actual insert
 			insert_line = iter.get_line()
-			textbuffer_internal_insert_at_cursor(buffer, linedata)
+			buffer.insert_parsetree_at_cursor(linedata)
 
 			# Fixup line end if selection happened to be end of buffer without newline
 			# and moving up


### PR DESCRIPTION
Moving a line up/down as implemented before triggered insertion of bullet when inserting text into a list context. Using insert_parsetree_at_cursor() avoids this unwanted behaviour. In addition, this change should also fix the text editing undo functionality.