### PR TITLE
Fix issues #2728 and #2733

### DIFF
--- a/data/manual/Plugins/Indexed_Full_Text_Search.txt
+++ b/data/manual/Plugins/Indexed_Full_Text_Search.txt
@@ -7,3 +7,11 @@ Creation-Date: 2023-10-11T16:52:26+02:00
 This plugin allows to massively speed up the search in page contents, by up to 95%. Simply enable the plugin. The index will be automatically recreated, after which the faster full-text search will be available.
 
 This is achieved by caching a reverse index of tokens (i.e. words) in the index using ''sqlite''. For that to work, it requires a version of ''sqlite'' with the FTS5 extension. This new index will be around 5x bigger than before (for a 1500-page notebook with around 500 words per page, the index grows from 1.7 MiB to about 5.5 MiB).
+
+===== Options =====
+The option **Remove diacricitcs before indexing** alters the indexer such that for example "Apfel" and "Äpfel" are both indexed as "Apfel", and "avião" will be indexed as "aviao". This means searching for "apfel" will then return both pages with matches for "Apfel" and for "Äpfel". While this may be desireable for some use cases, it is turned off by default to more closely resemble the search functionality without this plugin.
+Note that currently, if "Remove diacritics before indexing" is set to true, in the example above, searching for "Äpfel" will not return any results due to implementation shortcomings of the full-text search module.
+
+The option **Additional token characters** can be used to set additional characters which will be considered part of a word (a "token"). Adding "-", for example, will lead to words such as "lorem-ipsum" being added to the index entirely, so they can be searched for using "lorem-ipsum" as a search string but not "lorem ipsum".
+
+After changing these options, the index of each notebook must be re-generated.

--- a/zim/plugins/indexed_fts.py
+++ b/zim/plugins/indexed_fts.py
@@ -8,6 +8,7 @@ page contents.
 import contextlib
 import sqlite3
 import logging
+import json
 
 from zim.plugins import PluginClass
 from zim.notebook import NotebookExtension, Path
@@ -50,6 +51,12 @@ sqlite.
 		'author': 'Nimrod Maclomhair',
 		'help': 'Plugins:Indexed Full Text Search'
 	}
+
+	plugin_preferences = (
+		# key, type, label, default
+		('remove_diacritics', 'bool', _('Remove diacritics before indexing'), False),
+		('tokenchars', 'string', _('Additional token characters'), ''),
+	)
 
 	@classmethod
 	def check_dependencies(klass):
@@ -95,6 +102,24 @@ sqlite.
 		# All keywords passed to this functions are content-related so
 		# we don't need to check the term.keyword property.
 
+		# We need to escape all keywords manually for use in the FTS5
+		# search query
+		def escape_for_fts(keyword):
+			return '"' + keyword.replace('"', '""') + '"'
+
+		# zim search syntax supports "*" but not the "?" glob operator,
+		# so this needs to be escaped, too.
+		def escape_for_glob(keyword):
+			return keyword.translate({
+				"?": "%?",
+				"%": "%%"
+			})
+
+		# Protect against a possibly long-running query if accidentally
+		# searching for "*"
+		if term.string == "*":
+			return SearchSelection(None)
+
 		# Beware: FTS5 only supports "*" expansion at the end of a word
 		# while we want to support it in the beginning and the middle as well
 		# We can emulate the globbing behavior by constructing an equivalent
@@ -103,17 +128,19 @@ sqlite.
 			# We need to find all tokens that match the search
 			query_token_result = db.execute(
 				"SELECT DISTINCT term FROM pages_ftsv WHERE term GLOB ?;",
-				(term.string.lower(),)
+				(escape_for_glob(term.string.lower()),)
 			).fetchall()
-			# Unfortunately, we also need to do escaping ourselves
 			query_token_list = [
-				'"' + row["term"].replace('"', '""') + '"'
+				escape_for_fts(row["term"])
 				for row in query_token_result
 			]
 			query_string = ' OR '.join(query_token_list)
 
 		else:
-			query_string = term.string.lower()
+			query_string = escape_for_fts(term.string.lower())
+
+
+		logger.debug("Full-Text Search for query %s", query_string)
 
 		# We use the GLOB operator for counting occurences,
 		# which also understands "*" expansion so we don't need the full list
@@ -126,7 +153,7 @@ sqlite.
 			"JOIN pages_ftsv AS v ON f.rowid = v.doc "
 			"WHERE v.term GLOB ? "
 			"GROUP BY p.name;",
-			(query_string, term.string.lower())
+			(query_string, escape_for_glob(term.string.lower()))
 		).fetchall()
 
 		myscores = {}
@@ -168,6 +195,7 @@ class FTSIndexer(IndexerBase):
 	the FTS index up-to-date.
 	'''
 	PLUGIN_NAME = "IndexedFTS"
+	PLUGIN_CONFIG_KEY = "IndexedFTS_configuration"
 	PLUGIN_DB_FORMAT = "0.2"
 	_TABLE_DROP_STATEMENTS = """
 		DROP TABLE IF EXISTS pages_fts;
@@ -181,22 +209,19 @@ class FTSIndexer(IndexerBase):
 	def teardown(cls, db):
 		db.executescript(cls._TABLE_DROP_STATEMENTS)
 		db.execute("DELETE FROM zim_index WHERE key = ?;", (cls.PLUGIN_NAME,))
+		db.execute("DELETE FROM zim_index WHERE key = ?;", (cls.PLUGIN_CONFIG_KEY,))
 
-	def __init__(self, db, pages_indexer):
+	def __init__(self, db, pages_indexer, plugin_preferences):
 		IndexerBase.__init__(self, db)
 		self.db = db
 
-		# Perform a version check first! We require our specific DB format
-		current_format = self.db.execute("SELECT value FROM zim_index WHERE key = ?;",
-			(self.PLUGIN_NAME,)
-		).fetchone()
-		if current_format is not None and current_format["value"] != self.PLUGIN_DB_FORMAT:
-			self.db.executescript(self._TABLE_DROP_STATEMENTS)
+		# Version checks are performed by IndexedFTSNotebookExtension
+		# before we are instantiated (it's easier there)
 
 		self.db.executescript('''
 			CREATE VIRTUAL TABLE IF NOT EXISTS pages_fts USING fts5(
 				page_content,
-				tokenize = 'unicode61 remove_diacritics 0',
+				tokenize = "unicode61 remove_diacritics {0} tokenchars '{1}'",
 				content = '',
 				contentless_delete = 1
 			);
@@ -208,10 +233,16 @@ class FTSIndexer(IndexerBase):
 				fts_id INTEGER REFERENCES pages_fts(rowid)
 			);
 			CREATE INDEX IF NOT EXISTS keys_pages_fts_rowid ON keys_pages_fts(fts_id);
-		''')
+		'''.format(
+			'2' if plugin_preferences['remove_diacritics'] else '0',
+
+			plugin_preferences['tokenchars'].replace('"', '""')
+				if plugin_preferences['tokenchars'] is not None else ''
+		))
 		self.db.execute(
-			"INSERT OR REPLACE INTO zim_index VALUES (?, ?);",
-			(self.PLUGIN_NAME, self.PLUGIN_DB_FORMAT)
+			"INSERT OR REPLACE INTO zim_index VALUES (?, ?), (?, ?);",
+			(self.PLUGIN_NAME, self.PLUGIN_DB_FORMAT,
+			self.PLUGIN_CONFIG_KEY, json.dumps(plugin_preferences),)
 		)
 
 		self.connectto_all(pages_indexer, (
@@ -292,15 +323,42 @@ class IndexedFTSNotebookExtension(NotebookExtension):
 			self.index.flag_reindex()
 
 		self.indexer = None
-		self.setup_indexer(self.index, self.index.update_iter)
+		self.setup_indexer()
 		self.index.connect('new-update-iter', self.setup_indexer)
 
-	def setup_indexer(self, index, update_iter):
+		self.plugin.preferences.connect('changed', self.on_preferences_changed)
+
+
+	def setup_indexer(self):
 		if self.indexer is not None:
 			self.indexer.disconnect_all()
 
-		self.indexer = FTSIndexer(index._db, update_iter.pages)
-		update_iter.add_indexer(self.indexer)
+		self.indexer = FTSIndexer(self.index._db,
+			self.index.update_iter.pages, self.plugin.preferences)
+
+		self.index.update_iter.add_indexer(self.indexer)
+
+	def on_preferences_changed(self, preferences):
+		"""Callback to update index when plugin preferences are changed
+		This method assumes self.plugin.preferences is up-to-date anyway
+		"""
+		stored_prefs = self.index.get_property(FTSIndexer.PLUGIN_CONFIG_KEY)
+		if stored_prefs is None:
+			FTSIndexer.teardown(self.index._db)
+			self.index.flag_reindex()
+			self.setup_indexer()
+			return
+
+		stored_prefs = json.loads(stored_prefs)
+
+		for key, value in preferences.items():
+			if stored_prefs[key] != value:
+				FTSIndexer.teardown(self.index._db)
+				self.index.flag_reindex()
+				self.setup_indexer()
+				return
+
+
 
 	def teardown(self):
 		'''This should be called when the plugin is disabled.


### PR DESCRIPTION
Issue #2728 is because the tokenizer was set to remove diacritics on words, but not in the search query. To be closer to the expected, traditional behavior of the search, I disabled the removal of diacritics now and introduced a change to detect if the full-text table schema is outdated, in which case the tables are recreated. This should fix the issue for everyone without having to delete the entire index.db.

Issue #2733 stems from a misunderstanding about the sqlite full-text search query language when I implemented the plugin. The query language doesn't actually support proper globbing. Instead, I now simulate the globbing by first globbing through all terms known to the index and constructing a query from that, then searching with that newly constructed query instead. I haven't done performance measurements on this approach but I expect that it should be unnoticable fast in general. A potential speedup might otherwise be to introduce an index on all tokens known to sqlite FTS.

I'm looking forward to the review and I'm happy to incorporate the review findings!