### PR TITLE
Fix deprecated import of DotWidget from xdot module #2613

### DIFF
--- a/zim/plugins/linkmap.py
+++ b/zim/plugins/linkmap.py
@@ -21,7 +21,7 @@ logger = logging.getLogger('zim.plugins')
 
 try:
 	import xdot
-	from xdot import DotWidget
+	from xdot.ui import DotWidget
 except ImportError:
 	xdot = None
 	class DotWidget:  # workaround


### PR DESCRIPTION
Attempt to fix the following warning message related to BUG report #2613:
```
WARNING: /home/jklust/zim-desktop-wiki/zim/plugins/linkmap.py:24: UserWarning: w xdot.DotWidget is deprecated, use xdot.ui.DotWidget instead
  from xdot import DotWidget
```