### PR TITLE
Add keybind for ToC plugin float size toggle

### DIFF
--- a/zim/plugins/tableofcontents.py
+++ b/zim/plugins/tableofcontents.py
@@ -145,6 +145,11 @@ class ToCPageViewExtension(PageViewExtension):
 			preferences['fontsize']
 		)
 
+	@action('', accelerator='<ctrl>grave', menuhints='accelonly')
+	def toggle_floating_size(self):
+		# toggle collapsed/expanded size of floating ToC, same as mouse click
+		if isinstance(self.tocwidget, FloatingToC):
+			self.tocwidget.on_toggle()
 
 TEXT_COL = 0
 LINE_COL = 1


### PR DESCRIPTION
The tableofcontents plugin has a mode in which the table floats above the page, and where clicking its title toggles minimised/expanded size. This is very useful, since the table obscures text on the page, but is inconvenient to access with the mouse.
Add an accelerator action (defaults to `<ctrl>grave`) to be able to toggle the size via keyboard.

This is my first zim contribution attempt, so please feel free to steer me towards any changes that would be better.