### PR TITLE
Trayicon plugin: Fix missing icon

### DIFF
--- a/zim/plugins/trayicon.py
+++ b/zim/plugins/trayicon.py
@@ -312,7 +312,7 @@ class AppIndicatorTrayIcon(TrayIconBase, SignalEmitter):
 
 		if not _GLOBAL_INDICATOR:
 			_GLOBAL_INDICATOR = AppIndicator.Indicator.new(
-				'zim-desktop-wiki', 'zim',
+				'zim-desktop-wiki', 'org.zim_wiki.Zim',
 				AppIndicator.IndicatorCategory.APPLICATION_STATUS
 			)
 


### PR DESCRIPTION
On my system (Arch Linux, KDE Plasma 6.3.3, wayland), the tray icon plugin is taking up space in the status bar, and the right-click context menu is accessible, but no icon is displayed

I don't know if I'm the only one affected (e.g. this PR #2712 is only two months old and there the icon seems to be displayed). At least in my case I can fix it by specifying the DNS style name, which has been introduced in adb1cb9. 

NB:
* I haven't tested other desktop environments,
*so I don't know if the monochrome icons (mentioned in the comment at the beginning of the `__init__ ` function) would still work.
* And I didn't touch the `StatusIconTrayIcon` class.