### PR TITLE
Collections Plugin - Organize Notes w/ Collections

### DIFF
--- a/data/manual/Plugins/Collections.txt
+++ b/data/manual/Plugins/Collections.txt
@@ -1,0 +1,39 @@
+Content-Type: text/x-zim-wiki
+Wiki-Format: zim 0.6
+Creation-Date: 2025-05-18T09:13:24+02:00
+
+====== Collections ======
+Created Sunday 18 May 2025
+
+Many users maintain central notes(often called hubs or MoCs) with collections of links to better organize their notes. These notes act as maps, linking to related content without containing any original material themselves. Hubs help users efficiently gather, navigate, and retrieve related content, making their notes more structured. For background, see Zettelkarsten or Linking Your Thinking.
+
+The plugin enhances this workflow in Zim. It pulls all links from existing hubs and displays them in a side pane for quick access and easy navigation, similar to the Index. The key features are:
+	* **Dedicated Collections Pane:** A new pane alongside the Index and Tags, where users can manage their collections of links pulled from their existing hubs.
+	* **Auto-Generation:** Users can define queries to dynamically add matching notes to the hubs, saving time and effort.
+===== Why Collections? =====
+	* Think of collections as //non-intrusive overlays//—they organize your existing notes without altering the notes themselves. For example, I might build a collection of books I want to recommend to my friend Rick, and then another collection for Lisa. Some books may appear in both collections, but the collections themselves can change, grow, or be removed without any updates necessary to the pages about a particular book themselves.
+	* Tags can serve various purposes, such as marking note types (e.g., ''@book'' or ''@person''), topics (e.g., ''@history_of_music''), statuses (e.g., ''@postponed''), or actions. Collections can help separate these roles, e.g. organize by topic with collections while using tags for status. For example, you can tag book review notes with  ''@book'' and notes about authors with ''@author'', while using collections to organize books about a war or all books by a specific author.
+	* Unlike flat-level tags, hubs can include other hubs, introducing hierarchy. However, unlike a hierarchical index, the same page can belong to multiple collections. Collections blend features both of a strict hierarchy and flat tags.
+	* Zim offers hierarchical index and tags for organization, but with this plugin, users can also mix an match tags with collections or index with collections for their organization methods.
+===== Atomic Notes =====
+This plugin is built around atomic notes—self-contained pieces of information or insights that focus on a single idea or concept. Since Zim shows only one page at a time, it’s impractical to have a dedicated page for each atomic note, especially if they are short. To overcome this, the plugin works at the heading level instead of the whole page, allowing different sections of the same page to belong to different collections. A single page can contain several hubs as well without conflict. Importantly, tags and links below a heading are considered to be part of that section, not the entire page.
+===== Collections Hierarchy =====
+If a hub links to another hub, the corresponding collections of links form a parent-child relationship, creating a hierarchy—or rather a lattice, since a single collection can have multiple parent collections. Each collection in the Collections pane shows parent or child collections in addition to the actual member pages, enabling navigation within the lattice.
+===== Hub Tags =====
+All pages tagged with any of the hub tags (as specified in the configuration page) are automatically recognized as hubs, creating corresponding collections.
+===== Archived Pages =====
+Pages tagged as archived (using tags specified in the configuration page) or their descendants are always listed at the end of a collection and grayed out to signal low importance visually.
+===== Styling =====
+The Collections pane supports color coding of pages based on their tags. Use the Styling dialog to assign colors to different tags.
+===== Auto-Generation =====
+To avoid the manually adding links to hubs, users can specify a query to dynamically add links to all matching pages in the hub. The syntax is somewhat similar to the Search syntax. Auto-generation can be viewed as saved search queries, eliminating the need for repetitive manual searches, saving thus time and effort.
+
+Users are free to customize and decorate the auto-generated list, such as highlighting important entries, adding supporting information, or using different formatting styles. Auto-generation runs automatically but does not interfere with existing links in the hub; it only adds new links if found.
+Auto-generation can be enabled in the New Collection or Edit dialogs by checking the “Enable Autogeneration” checkbox. This will display a dedicated tab to edit a query.
+===== Auto-Generation Syntax =====
+The query syntax is similar to the Search syntax but is simplified. It consists of one or several commands separated by spaces as follows:
+	* ''+tag:XXX''– Required tag; the matching page must have all specified tags.
+	* ''?tag:XXX''– Optional tag; the matching page must have at least one of the specified optional tags.
+	* ''-tag:XXX''– Excluded tag; the matching page must not have any of the excluded tags.
+	* ''links:XXX'' or ''linksfrom:XXX'' – Matches all pages that are linked by a certain page.
+	* ''linksto:XXX'' – Matches all pages that link to a certain page. Can appear only once in a query.

--- a/zim/plugins/collections/__init__.py
+++ b/zim/plugins/collections/__init__.py
@@ -1,0 +1,172 @@
+import typing
+from typing import Protocol
+
+from gi.repository import Gtk, Gdk, GLib, Pango, GObject  # type: ignore
+from zim.gui.notebookview import NotebookViewExtension
+from zim.gui.widgets import LEFT_PANE, PANE_POSITIONS
+from zim.notebook import (
+    HRef,
+    HREF_REL_FLOATING,
+)
+from zim.plugins import PluginClass
+from zim.plugins.collections.misc import Misc
+from zim.plugins.collections.autogen import Autogen
+from zim.plugins.collections.common import Collection, R, Toast
+from zim.plugins.collections.dlgs import RmCollConfirmDlg, AddCollDlg
+from zim.plugins.collections.floatpagebar import FloatPageBar
+from zim.plugins.collections.sidepane import SidePane
+
+if typing.TYPE_CHECKING:
+
+    def _(_: str) -> str:
+        pass
+
+
+class ColPlugin(PluginClass):
+    plugin_info = {
+        "name": _("Collections"),
+        "description": _("Manages note collections"),
+        "author": "pgess",
+    }
+
+    plugin_preferences = (  # type: ignore
+        # key, type, label, default
+        ("pane", "choice", R.PREF_POSITION, LEFT_PANE, PANE_POSITIONS),
+        ("hub_tags", "string", R.PREF_HUB_TAGS, "moc"),
+        ("archive_tags", "string", R.PREF_ARCHIVE_TAGS, "archive"),
+        ("archive_color", "color", R.PREF_ARCHIVE_COLOR, "#A1A9B1"),
+    )
+
+
+class ColNotebookViewExtension(NotebookViewExtension):
+    STYLE = b"""
+    #toast{
+        background-color: #926d2b;
+        border-radius: 12px;
+        color: black;
+        padding: 12px 12px; 
+        margin: 4px;
+    }
+    #collection-tag{
+        border-radius: 12px;
+        color: black;
+        padding: 4px 8px; 
+        margin: 0px;
+    }
+    
+    .hover>#hub-tag{
+        background-color: #c9963c;
+    }
+    #hub-tag{
+        background-color: #926d2b;
+        color: black;
+        padding: 4px 8px; 
+        margin: 0px;
+    }
+    """
+
+    def __init__(self, plugin, pageview) -> None:
+        NotebookViewExtension.__init__(self, plugin, pageview)
+
+        style = Gtk.CssProvider()
+        style.load_from_data(self.STYLE)
+        Gtk.StyleContext.add_provider_for_screen(
+            Gdk.Screen.get_default(),
+            style,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        )
+
+        self.sidepane = SidePane(pageview, plugin, notifier=self)
+        # bug changing model inside handler - use deferred handling
+        self.add_sidepane_widget(self.sidepane, "pane")
+        self.connectto(self.pageview, "page-changed")
+
+        self.bar = FloatPageBar(pageview)
+        pageview.overlay.add_overlay(self.bar)
+        self.on_page_changed(pageview, pageview.page)
+        self.connectto(
+            self.bar,
+            "goto-collection",
+            handler=lambda sender, href: self.sidepane.goto_collection(href),
+        )
+
+        self.connectto(
+            pageview.textview, "populate-popup", handler=self.on_textview_populate_popup
+        )
+        self.pageview = pageview
+
+        self.toast = Toast()
+        pageview.overlay.add_overlay(self.toast)
+        self.connectto(plugin.preferences, "changed", self.on_pref_changed)
+        self.bar.show_all()
+
+    def teardown(self):
+        self.bar.destroy()
+        self.disconnect_all()
+
+    def on_pref_changed(self, sender):
+        self.sidepane.on_archive_roots_changed()
+        self.sidepane.on_collections_changed()
+        pass
+
+    def on_add_collection_clicked(self, sender, href) -> None:
+        dlg = AddCollDlg(self.pageview)
+        dlg.href_entry.set_text(href)
+        collection = dlg.run()
+        if collection is None:
+            return
+        self.sidepane.add_collection(collection)
+        self.sidepane.focus()
+        self.notify(R.COLLECTION_ADDED.format(col=collection.title))
+
+    def on_rm_collection(self, sender, c: Collection):
+        ok = RmCollConfirmDlg(self, c.title).run()
+        if not ok:
+            return
+
+        self.sidepane.db.rm_collection(c.id)
+        self.notify(R.COLLECTION_REMOVED.format(col=c.title))
+
+    def on_textview_populate_popup(self, sender, menu):
+        textview = self.pageview.textview
+        pos = max(len(menu) - 4, 0)
+        iter = textview._get_popup_menu_mark()
+        if iter is None:
+            return
+        anchor, title, level = Misc.get_heading_info(iter)
+        if anchor is None:
+            return
+        href = (
+            self.pageview.page.name
+            if level == 1
+            else HRef(HREF_REL_FLOATING, self.pageview.page.name, anchor).to_wiki_link()
+        )
+
+        if self.sidepane.db.is_existing_coll_href(href):
+            c = next(
+                filter(lambda c: c.href == href, self.sidepane.db.all_collections()),
+                None,
+            )
+            assert c is not None
+            item = Gtk.MenuItem.new_with_label(R.REMOVE_COL.format(title=c.title))
+            item.connect("activate", self.on_rm_collection, c)
+        else:
+            item = Gtk.MenuItem.new_with_label(R.MAKE_HUB.format(title=title))
+            item.connect("activate", self.on_add_collection_clicked, href)
+
+        item.show_all()
+        menu.insert(item, pos)
+
+    def on_page_changed(self, pageview, page) -> None:
+        colls = self.sidepane.get_collections_for_page(page.name)
+        hubs = self.sidepane.db.get_hubs_for_page(page.name)
+        self.bar.setup(colls, hubs, self.sidepane.styling)
+
+        for hub in hubs:
+            if not hub.query:
+                continue
+            gen = Autogen(hub, pageview)
+            gen.run()
+
+    def notify(self, msg):
+        self.toast.fire(msg)

--- a/zim/plugins/collections/autogen.py
+++ b/zim/plugins/collections/autogen.py
@@ -1,0 +1,174 @@
+import collections
+import typing
+from tokenize import single_quoted
+
+from gi.repository import Gtk  # type: ignore
+from zim.formats import (
+    ParseTree,
+    FORMATTEDTEXT,
+    END,
+    BULLETLIST,
+    NUMBEREDLIST,
+    UNCHECKED_BOX,
+    BULLET,
+    LISTITEM,
+    LINK,
+    TEXT,
+    MARK,
+)
+
+from zim.notebook import (
+    HRef,
+    IndexNotFoundError,
+    LINK_DIR_BACKWARD,
+    LINK_DIR_FORWARD,
+    Path,
+)
+
+from zim.plugins.collections import Misc
+from zim.plugins.collections.common import Query, Collection
+
+# {hdr-href: (hdr-href, hdr-title, {tags}, {urls})}
+HubT: typing.TypeAlias = dict[
+    str, typing.Tuple[str, str, typing.AbstractSet[str], typing.AbstractSet[str]]
+]
+
+
+class Autogen:
+    def __init__(self, coll: Collection, pageview):
+        self.coll = coll
+        self.query = Query.from_str(coll.query, pageview.page.name)
+        self.hub: HubT = {}
+        self.existing_entries: set[str] = set()
+        self.notebook = pageview.notebook
+        self.pageview = pageview
+
+    def run(self) -> None:
+        if self.query is None:
+            return
+
+        self.existing_entries = set(
+            entry.href
+            for entry in Misc.parse_section_links(self.coll.href, self.notebook)
+        )
+        self._search()
+        output = self._render()
+        if not output:
+            return
+        buffer = self.pageview.page.get_textbuffer()
+        insertion_point = self._guess_insertion_point()
+        buffer.insert_parsetree(insertion_point, output)
+
+    def _search(self) -> None:
+        assert self.query is not None
+        pages_visited = set()
+
+        if self.query.linksFrom is None:
+            tags_all = self.query.requiredTags | self.query.optTags
+            for tag in tags_all:
+                try:
+                    for page in self.notebook.tags.list_pages(tag):
+                        page = self.notebook.get_page(page)
+                        if page.name in pages_visited:
+                            continue
+                        self.hub.update(Misc.parse_page_structure(page, self.notebook))
+                        pages_visited.add(page.name)
+                except IndexNotFoundError:
+                    pass
+
+            if self.query.linksTo is not None:
+                href_to = HRef.new_from_wiki_link(self.query.linksTo)
+                path_to = self.notebook.pages.resolve_link(page, href_to)
+                for page in self.notebook.links.list_links(path_to, LINK_DIR_BACKWARD):
+                    page = self.notebook.get_page(page.source)
+                    if page.name in pages_visited:
+                        continue
+                    self.hub.update(Misc.parse_page_structure(page, self.notebook))
+                    pages_visited.add(page.name)
+
+        else:  # self.query.linksFrom is not None
+            href_from = HRef.new_from_wiki_link(self.query.linksFrom)
+            hub_path = Path(self.coll.href)
+            path_from = self.notebook.pages.resolve_link(hub_path, href_from)
+            for link in self.notebook.links.list_links(path_from, LINK_DIR_FORWARD):
+                page = self.notebook.get_page(link.target)
+                if page.name in pages_visited:
+                    continue
+                pages_visited.add(page.name)
+                self.hub.update(Misc.parse_page_structure(page, self.notebook))
+
+        self.hub = {
+            href: entry
+            for href, entry in self.hub.items()
+            if self.query.requiredTags.issubset(entry[2])
+            and (len(self.query.optTags) == 0 or len(entry[2] & self.query.optTags) > 0)
+            and (len(entry[2] & self.query.excludeTags) == 0)
+            and href not in self.existing_entries
+            and (self.query.section is None or href.startswith(self.query.section))
+            and (self.query.linksTo is None or self.query.linksTo in entry[3])
+        }
+
+    def _render(self) -> ParseTree | None:
+        assert self.query is not None
+
+        tokens = []
+        if len(self.hub) > 0:
+            list_tag = BULLETLIST if self.query.list == "cbl" else self.query.list
+            list_bullet = {
+                BULLETLIST: BULLET,
+                NUMBEREDLIST: None,
+                "cbl": UNCHECKED_BOX,
+            }[self.query.list]
+
+            for item in self.hub.values():
+                single_entry_tokens = [
+                    (
+                        LISTITEM,
+                        {"bullet": list_bullet} if list_bullet is not None else {},
+                    ),
+                    (LINK, {"href": item[0]}),
+                    (TEXT, item[1]),
+                    (END, "link"),
+                    (END, "li"),
+                ]
+
+                if self.query.mark_tag is not None and self.query.mark_tag in item[2]:
+                    single_entry_tokens = (
+                        [(MARK, {})] + single_entry_tokens + [(END, MARK)]
+                    )
+                tokens.extend(single_entry_tokens)
+
+            tokens = (
+                [(list_tag, {"indent": 0})] + tokens + [(END, list_tag), (TEXT, "\n")]
+            )
+            tokens = [(FORMATTEDTEXT, None)] + tokens + [(END, FORMATTEDTEXT)]
+        return ParseTree.new_from_tokens(tokens) if tokens else None
+
+    def _guess_insertion_point(self):
+        """
+        Finds an appropriate insertion point in the buffer.
+
+        Inserts at the first blank line, before the next heading, or before any list items.
+        Returns a text iterator positioned at the chosen insertion point.
+        """
+
+        _is_term_tag = lambda tag: hasattr(tag, "zim_tag") and (
+            tag.zim_tag == "h" or tag.zim_tag == "li"
+        )
+        buffer = self.pageview.page.get_textbuffer()
+        href = HRef.new_from_wiki_link(self.coll.href)
+        section_start_it = (
+            buffer.find_anchor(href.anchor)
+            if href.anchor is not None
+            else buffer.get_start_iter()
+        )
+        ok = True
+        while ok:
+            ok = section_start_it.forward_line()
+            line_end_it = section_start_it.copy()
+            line_end_it.forward_to_line_end()
+            line = section_start_it.get_text(line_end_it)
+            ok &= bool(line) and line[0] != "\n"
+
+            ok &= not any(filter(_is_term_tag, section_start_it.get_tags()))
+        return section_start_it

--- a/zim/plugins/collections/common.py
+++ b/zim/plugins/collections/common.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import re
+import typing
+from typing import NamedTuple
+
+from gi.repository import Gtk, Gdk, GLib, GObject  # type: ignore
+
+
+class R:
+    DBG_REFRESH_COLLECTIONS = "ReIndex collections"
+    REMOVE_TAG = "Remove Tags"
+    ADD_TAG = "Add Tags"
+    RMCOLDLG_MSG = "Are you sure you want to delete {title}?\nNote: This action does not actually delete the pages in the collection."
+    RMCOLDLG_SUBTITLE = "Confirm Deletion"
+    COLLECTION_REMOVED = "{col} Removed"
+    COLLECTION_ADDED = "{col} Added"
+    PREF_ARCHIVE_COLOR = "Archive color"
+    PREF_POSITION = "Position in the window"
+    PREF_HUB_TAGS = "Hub Tags"
+    PREF_ARCHIVE_TAGS = "Archive Tags"
+
+    NOCOLS = "No collections yet.\nLet's make a first one"
+    EMPTYCOL = "Collection looks empty.\n Add the first page"
+    SELECTCOL = "No collection is selected.\nSelect any collection"
+
+    QUERY = "Autogeneration"
+    GENERAL = "General"
+    ENABLE_AUTOGEN = "Enable Autogeneration"
+    FIND_COLLECTION_PLACEHOLDER = "Find Collection..."
+    ADD = "Add"
+    ADD_TAG_DLG = "Add Tag(s)"
+    ADDCOLLDLG_TITLE = "New Collection"
+
+    TAG_STYLING_TITLE = "Styling"
+    ADD_TAG_PLACEHOLDER = "E.g.: relax, exciting, food, tomorrow"
+    TagDefProject = "project"
+    TagDefIdea = "idea"
+    TagDefImportant = "important"
+    TagDefWork = "work"
+    TagDefPin = "pin"
+
+    ASSIGN_COLOR_FOR_TAG = "Assign color for tag"
+    TAG = "Tag"
+    SLAB_PIN = "🖈"
+    SLAB_UP = "⮝"
+    SLAB_DOWN = "⮟"
+    TITLE = "Configure Tags"
+    CHOOSE_COLOR = "Choose color:"
+    ENTER_TEXT = "Enter text:"
+    ADD_STRING = "Add Tag"
+
+    NEW_NAME = "New name:"
+
+    UPDATE = "Update"
+    EDIT_COLLECTION = "Edit Collection"
+    EDIT_COLLECTION_2 = "Edit {col}"
+    REMOVE_COLLECTION = "Remove Collection"
+    ADD_A_NEW_COLLECTION = "Add New Collection"
+    GO_TO_HUB = "Go to Hub"
+
+    # Autogen
+    STRIKE = "Strike Through Existing Items that aren't in Search Results"
+    INDIVIDUAL_HEADERS = "Include individual headers"
+    MARK = "Marks entries with a specified tag"
+    HIGHLIGHT = "Highlight:"
+    ALPHABETICALLY = "Alphabetically"
+    SCORE = "Score"
+    TASK_LIST = "Task list"
+    UNORDERED_LIST = "Unordered list"
+    BULLETS = "Bullets:"
+    ROOT_CURRENT = "Current Page as Root"
+    ROOT_PLACEHOLDER = "Limit Results to Specified Page and its Subpages"
+    ROOT_PAGE = "Root page:"
+    SYNTAX_HELP = (
+        "See Help for Syntax. e.g.: +tag:project -tag:archive links:Onboarding"
+    )
+    AG_QUERY = "Query:"
+    AG_UPDATE = "_Update"
+    AG_TITLE = "Masterlist"
+
+    RMCOLDLG_TITLE = "Collections"
+    SELECT_PAGE = "Select Page or Heading to Serve as Hub for Collection:"
+
+    MAKE_HUB = "Make Hub for {title}"
+    REMOVE_COL = "Remove Collection {title}"
+
+
+class CollectionNote(NamedTuple):
+    title: str
+    href: str
+
+    def __eq__(self, other):
+        if not isinstance(other, CollectionNote):
+            return NotImplemented
+        return self.href == other.href
+
+    def __hash__(self):
+        return hash(self.href)
+
+
+class Collection(NamedTuple):
+    id: int
+    title: str
+    href: str
+    query: str | None
+
+
+THIS = "this"
+QUERY_RE = re.compile(
+    r"""
+    \s*(\+tag:|\-tag:|\?tag:|links:|linksto:|linksfrom:|section:|mark:)?\s*
+    (
+     '[^']*' |  # single quoted word
+     "[^"]*" |  # double quoted word
+	 \S+        # word without spaces
+	)\s*
+""",
+    re.X | re.IGNORECASE,
+)
+
+
+def join(parts: typing.Iterable[str | None]) -> str:
+    parts2 = [part.strip() for part in parts if part is not None]
+    parts2 = [part for part in parts2 if part != ""]
+
+    return " ".join(parts2)
+
+
+class Query:
+    def __init__(self):
+        self.list = "ul"
+        self.requiredTags = set()
+        self.excludeTags = set()
+        self.optTags = set()
+        self.section: str | None = None
+        self.linksFrom: str | None = None
+        self.linksTo: str | None = None
+        self.list = "ul"
+        self.mark_tag: str | None = None
+
+    @staticmethod
+    def from_str(query: str | None, current_page: str) -> Query | None:
+        if not query or not query.strip():
+            return None
+
+        self = Query()
+        raw_query = QUERY_RE.findall(query)
+        for entry in raw_query:
+            cmd = entry[0][:-1] if len(entry[0]) > 0 else entry[1]
+            cmd = cmd.lower()
+
+            if cmd == "+tag":
+                self.requiredTags.add(entry[1])
+            elif cmd == "-tag":
+                self.excludeTags.add(entry[1])
+            elif cmd == "?tag":
+                self.optTags.add(entry[1])
+            elif cmd == "section":
+                self.section = self._unescape_quoted_string(entry[1])
+            elif cmd == "linksto":
+                self.linksTo = self._unescape_quoted_string(entry[1])
+            elif cmd == "links" or cmd == "linksfrom":
+                self.linksFrom = self._unescape_quoted_string(entry[1])
+            elif cmd in ["ul", "ol", "cbl"]:
+                self.list = cmd
+            elif cmd == "mark":
+                self.mark_tag = entry[1]
+
+        for attr in ["section", "linksFrom", "linksTo"]:
+            if getattr(self, attr) == THIS:
+                setattr(self, attr, current_page)
+        if (
+            not self.requiredTags
+            and not self.optTags
+            and not self.linksFrom
+            and not self.linksTo
+        ):
+            return None
+
+        return self
+
+    def __repr__(self) -> str:
+        core = self.get_core_part()
+        section = (
+            f'section:"{self.section}"'
+            if self.section is not None and len(self.section) > 0
+            else None
+        )
+        mark_tag = (
+            f"mark:{self.mark_tag}"
+            if self.mark_tag is not None and len(self.mark_tag) > 0
+            else None
+        )
+
+        return join(
+            [
+                core,
+                section,
+                mark_tag,
+                self.list,
+            ]
+        )
+
+    def get_core_part(self) -> str:
+        tags_required = " ".join([f"+tag:{tag}" for tag in self.requiredTags])
+        tags_opt = " ".join([f"?tag:{tag}" for tag in self.optTags])
+        tags_excl = " ".join([f"-tag:{tag}" for tag in self.excludeTags])
+
+        links_from = (
+            f'links:"{self.linksFrom.strip()}"' if self.linksFrom is not None else None
+        )
+
+        links_to = (
+            f'linksto:"{self.linksTo.strip()}"' if self.linksTo is not None else None
+        )
+
+        return join(
+            [
+                tags_required,
+                tags_opt,
+                tags_excl,
+                links_to,
+                links_from,
+            ]
+        )
+
+    def _unescape_quoted_string(self, string):
+        """Removes quotes from a string and unescapes embedded quotes
+        @returns: string
+        """
+        if not string:
+            return string
+        elif string[0] in ('"', "'") and string[-1] == string[0]:
+            return string[1:-1]
+
+        return string
+
+
+class Toast(Gtk.Revealer):
+    def __init__(self):
+        Gtk.Revealer.__init__(self)
+
+        self.set_reveal_child(False)
+        self.set_transition_duration(300)
+        self.set_transition_type(Gtk.RevealerTransitionType.SLIDE_UP)
+
+        layout = Gtk.HBox(spacing=6)
+        layout.set_name("toast")
+        img = Gtk.Image.new_from_icon_name("notification-symbolic", Gtk.IconSize.MENU)
+        layout.pack_start(img, False, False, 0)
+        self.lbl = Gtk.Label()
+        layout.pack_start(self.lbl, False, False, 0)
+
+        self.set_valign(Gtk.Align.END)
+        self.set_halign(Gtk.Align.CENTER)
+        layout.set_margin_bottom(20)
+        self.add(layout)
+
+    def fire(self, message):
+        self.lbl.set_label(message)
+        self.set_reveal_child(True)
+        GLib.timeout_add(3000, self._stop)
+
+    def _stop(self):
+        self.set_reveal_child(False)
+        return False  # Stop the timeout
+
+
+class Notifier(typing.Protocol):
+    """Protocol for objects that can display notifications to the user."""
+
+    def notify(self, msg: str) -> None:
+        """Display a notification message to the user.
+
+        Args:
+            msg: The message to display
+        """
+        ...

--- a/zim/plugins/collections/db.py
+++ b/zim/plugins/collections/db.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import collections
+from typing import Sequence, Iterable, List
+from zim.notebook import HRef
+from zim.plugins.collections import Collection
+from zim.plugins.collections.styling import StylingData
+from gi.repository import Gtk, Gdk, GObject  # type: ignore
+
+
+class ColDB(GObject.GObject):
+    __gsignals__ = {"changed": (GObject.SIGNAL_RUN_FIRST, None, ())}
+    _idx_collections: List[Collection]
+
+    CREATE_TABLE_SQL = """CREATE TABLE IF NOT EXISTS "collections" (
+	"id"	INTEGER NOT NULL UNIQUE,
+	"title"	TEXT NOT NULL,
+	"href"	TEXT NOT NULL,
+	"query" TEXT,
+	PRIMARY KEY("id" AUTOINCREMENT)
+);
+    CREATE TABLE IF NOT EXISTS "styling" (
+        "id"	INTEGER NOT NULL UNIQUE,
+        "tag"	TEXT NOT NULL UNIQUE,
+        "color"	TEXT NOT NULL,
+        PRIMARY KEY("id" AUTOINCREMENT)
+    );
+"""
+
+    def __init__(self, db) -> None:
+        GObject.GObject.__init__(self)
+        self._idx_coll_names: frozenset[str] | None = None
+        self._idx_coll_hrefs: frozenset[str] | None = None
+        self._idx_coll_pages: dict[str, list[Collection]] | None = None
+        self.db = db
+        self.db.executescript(ColDB.CREATE_TABLE_SQL)
+        self.invalidate()
+
+    def all_collections(self) -> Iterable[Collection]:
+        return self._idx_collections
+
+    def get_collection_by_href(self, href) -> Collection:
+        return next(filter(lambda c: c.href == href, self.all_collections()))
+
+    def is_existing_coll_name(self, c: str) -> bool:
+        return (
+            len(c) == 0
+            or self._idx_coll_names is not None
+            and c in self._idx_coll_names
+        )
+
+    def is_existing_coll_href(self, href: str) -> bool:
+        return (
+            len(href) != 0
+            and self._idx_coll_hrefs is not None
+            and href in self._idx_coll_hrefs
+        )
+
+    def add_collections(self, cols: Sequence[Collection]) -> None:
+        self.db.executemany(
+            "INSERT  INTO collections(title, href, query) VALUES (:title, :href, :query)",
+            (
+                {"title": col.title, "href": col.href, "query": col.query}
+                for col in cols
+            ),
+        )
+        self.db.commit()
+        self.invalidate()
+
+    def rm_collection(self, col_id: int) -> None:
+        self.db.execute("DELETE FROM collections WHERE id = :id", {"id": col_id})
+        self.db.commit()
+        self.invalidate()
+
+    def update_collection(self, col: Collection, new_href: str) -> None:
+        self.db.execute(
+            "UPDATE collections SET title=:title, href=:href, query=:query WHERE id=:id",
+            {"id": col.id, "title": col.title, "href": new_href, "query": col.query},
+        )
+        self.db.commit()
+        self.invalidate()
+
+    def invalidate(self):
+        self._idx_collections = [
+            Collection(*entry)
+            for entry in self.db.execute(
+                'SELECT id, title, href, query FROM "collections"'
+            )
+        ]
+
+        assert self._idx_collections is not None
+        self._idx_coll_names = frozenset(c.title for c in self._idx_collections)
+        self._idx_coll_hrefs = frozenset(c.href for c in self._idx_collections)
+
+        self._idx_coll_pages = collections.defaultdict(list)
+        for c in self._idx_collections:
+            page = HRef.new_from_wiki_link(c.href).names
+            self._idx_coll_pages[page].append(c)
+
+        self.emit("changed")
+
+    def get_hubs_for_page(self, page: str) -> list[Collection]:
+        """
+        Get hubs located on this page
+        """
+        if self._idx_coll_pages is None or page not in self._idx_coll_pages:
+            return []
+        return self._idx_coll_pages[page]
+
+    def save_styling(self, data: StylingData):
+        tags = sorted(data.order_dict, key=lambda k: data.order_dict[k])
+        db_data = (
+            {"tag": tag, "color": data.clr_dict[tag].to_string()} for tag in tags
+        )
+        self.db.execute("DELETE FROM styling")
+        self.db.executemany(
+            "INSERT INTO styling(tag, color) VALUES(:tag, :color)", db_data
+        )
+        self.db.commit()
+
+    def load_styling(self) -> StylingData:
+        result = StylingData()
+        # sorted(data.)
+        db_data = list(self.db.execute("SELECT tag, color FROM styling ORDER BY id"))
+        result.order_dict = {tag: id for id, (tag, _) in enumerate(db_data)}
+
+        for tag, clr_str in db_data:
+            color = Gdk.RGBA()
+            color.parse(clr_str)
+            result.clr_dict[tag] = color
+
+        return result

--- a/zim/plugins/collections/dlgs.py
+++ b/zim/plugins/collections/dlgs.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import typing
+
+from gi.repository import Gtk, Gdk, GObject, GLib  # type: ignore
+
+from zim.gui.widgets import Dialog, PageEntry, InputEntry
+from zim.notebook import HRef, Path
+from zim.plugins.collections import Misc
+from zim.plugins.collections.common import R, Query, Collection
+
+
+class RmCollConfirmDlg(Dialog):
+    def __init__(self, parent, title: str) -> None:
+        Dialog.__init__(self, parent, R.RMCOLDLG_TITLE)
+
+        grid = Gtk.Grid()
+        grid.set_column_spacing(12)
+        grid.set_row_spacing(12)
+        self.vbox.add(grid)
+
+        img_warn = Gtk.Image.new_from_icon_name(
+            "dialog-warning-symbolic", Gtk.IconSize.DIALOG
+        )
+        grid.attach(img_warn, 0, 0, 1, 2)
+
+        lbl_title = Gtk.Label(
+            "<b>{title}</b>".format(title=R.RMCOLDLG_SUBTITLE), halign=Gtk.Align.START
+        )
+        lbl_title.set_use_markup(True)
+        lbl_title.get_style_context().add_class(Gtk.STYLE_CLASS_TITLE)
+        grid.attach(lbl_title, 1, 0, 1, 1)
+
+        lbl_message = Gtk.Label(
+            R.RMCOLDLG_MSG.format(title=title), halign=Gtk.Align.START
+        )
+        grid.attach(lbl_message, 1, 1, 1, 1)
+
+    def do_response_ok(self):
+        self.result = True
+        return True
+
+
+class QueryDlgMixin:
+    query_enabled_cb: typing.Any
+
+    def _setup_query_tab(self):
+        grid = Gtk.Grid()
+
+        # Query
+        query_label = Gtk.Label(label=R.AG_QUERY, halign=Gtk.Align.START)
+        grid.attach(query_label, 0, 0, 1, 1)
+
+        self.query_entry = Gtk.Entry()
+        self.query_entry.set_hexpand(True)
+        self.query_entry.set_placeholder_text(R.SYNTAX_HELP)
+        grid.attach(self.query_entry, 1, 0, 1, 1)
+
+        # Root page
+        root_page_label = Gtk.Label(label=R.ROOT_PAGE, halign=Gtk.Align.START)
+        self.root_page_entry = Gtk.Entry()
+        self.root_page_entry.set_placeholder_text(R.ROOT_PLACEHOLDER)
+        self.root_page_entry.set_hexpand(True)
+        grid.attach(root_page_label, 0, 1, 1, 1)
+        grid.attach(self.root_page_entry, 1, 1, 1, 1)
+
+        self.current_page_cb = Gtk.CheckButton(
+            label=R.ROOT_CURRENT, halign=Gtk.Align.START
+        )
+        grid.attach(self.current_page_cb, 1, 2, 1, 1)
+
+        # Bullets
+        bullets_label = Gtk.Label(label=R.BULLETS, halign=Gtk.Align.START)
+        grid.attach(bullets_label, 0, 3, 1, 1)
+
+        self.bullets_combo = Gtk.ComboBoxText()
+        self.bullets_combo.set_hexpand(True)
+        self.bullets_combo.append_text(R.UNORDERED_LIST)
+        self.bullets_combo.append_text(R.TASK_LIST)
+
+        self.bullets_combo.props.active = 0
+        grid.attach(self.bullets_combo, 1, 3, 1, 1)
+
+        # Sort
+        sort_lbl = Gtk.Label(label="Sort by:", halign=Gtk.Align.START)
+        grid.attach(sort_lbl, 0, 4, 1, 1)
+        self.sort_by_combo = Gtk.ComboBoxText()
+        self.sort_by_combo.append_text(R.SCORE)
+        self.sort_by_combo.append_text(R.ALPHABETICALLY)
+        self.sort_by_combo.set_hexpand(True)
+        grid.attach(self.sort_by_combo, 1, 4, 1, 1)
+
+        # Mark entries
+        mark_label = Gtk.Label(label=R.HIGHLIGHT, halign=Gtk.Align.START)
+        self.mark_entry = Gtk.Entry()
+        self.mark_entry.set_placeholder_text(R.MARK)
+        self.mark_entry.set_hexpand(True)
+        grid.attach(mark_label, 0, 5, 1, 1)
+        grid.attach(self.mark_entry, 1, 5, 1, 1)
+
+        # Checkboxes
+        self.headers_cb = Gtk.CheckButton(
+            label=R.INDIVIDUAL_HEADERS, halign=Gtk.Align.START
+        )
+        grid.attach(self.headers_cb, 0, 6, 2, 1)
+
+        self.strike_cb = Gtk.CheckButton(
+            label=R.STRIKE,
+            halign=Gtk.Align.START,
+        )
+        grid.attach(self.strike_cb, 0, 7, 2, 1)
+
+        grid.set_margin_start(12)
+        grid.set_margin_end(12)
+        grid.set_column_spacing(6)
+        grid.set_row_spacing(12)
+        grid.set_margin_top(12)
+        # grid.set_margin_bottom(50)
+
+        return grid
+
+    def set_query(self, query: Query | None):
+        if query is None:
+            self.query_enabled_cb.props.active = False
+            return
+
+        self.query_entry.props.text = query.get_core_part()
+        self.root_page_entry.props.text = (
+            query.section if query.section is not None else ""
+        )
+        self.bullets_combo.props.active = {"ul": 0, "cbl": 1}[query.list]
+        self.mark_entry.props.text = (
+            query.mark_tag if query.mark_tag is not None else ""
+        )
+        self.query_enabled_cb.props.active = True
+
+    def get_query(self, current_page: str) -> Query | None:
+        if not self.query_enabled_cb.props.active:
+            return None
+
+        query = Query.from_str(self.query_entry.props.text, current_page)
+        if not query:
+            return None
+        section = self.root_page_entry.props.text
+        if self.current_page_cb.props.active:
+            section = "this"
+        query.section = section.strip() if section is not None else None
+
+        query.list = ["ul", "cbl"][self.bullets_combo.props.active]
+        query.mark_tag = (
+            self.mark_entry.props.text.strip()
+            if self.mark_entry.props.text is not None
+            else None
+        )
+
+        return query
+
+
+class AddCollDlg(Dialog, QueryDlgMixin):
+    def __init__(self, pageview) -> None:
+        self.pageview = pageview
+        Dialog.__init__(
+            self,
+            pageview,
+            R.ADDCOLLDLG_TITLE,
+            button=R.ADD,
+            use_default_button=True,
+            help="Plugins:Collections#auto-generation",
+        )
+        tabs = Gtk.Notebook()
+        self.vbox.pack_start(tabs, True, True, 0)
+
+        tab1 = self._setup_general_tab()
+        tab1_label = Gtk.Label(label=R.GENERAL)
+        tab1_label.set_margin_start(12)
+        tab1_label.set_margin_end(12)
+        tabs.append_page(tab1, tab1_label)
+
+        self.tab2 = self._setup_query_tab()
+        tab2_label = Gtk.Label(label=R.QUERY)
+        tab2_label.set_margin_start(12)
+        tab2_label.set_margin_end(12)
+        tabs.append_page(self.tab2, tab2_label)
+
+        self.vbox.set_spacing(6)
+        self.vbox.set_margin_start(12)
+        self.vbox.set_margin_end(12)
+
+        GLib.idle_add(lambda: self.tab2.hide())
+
+    def _setup_general_tab(self):
+        tab = Gtk.VBox(spacing=6)
+        label = Gtk.Label(label=R.SELECT_PAGE, halign=Gtk.Align.START)
+        tab.pack_start(label, False, False, 0)
+
+        self.href_entry = PageEntry(self.pageview.notebook)
+        self.href_entry.props.text = self.pageview.page.name
+        tab.pack_start(self.href_entry, False, False, 0)
+
+        self.query_enabled_cb = Gtk.CheckButton(label=R.ENABLE_AUTOGEN)
+        tab.pack_start(self.query_enabled_cb, False, False, 0)
+        self.query_enabled_cb.connect("toggled", self.on_enable_autogen)
+
+        tab.set_margin_top(12)
+        tab.set_margin_bottom(12)
+        tab.set_margin_start(12)
+        tab.set_margin_end(12)
+        return tab
+
+    def on_enable_autogen(self, sender):
+        if sender.get_active():
+            self.tab2.show()
+        else:
+            self.tab2.hide()
+
+    def _get_heading(self, page, anchor) -> str:
+        buffer = Misc.get_buffer(page, self.pageview.notebook)
+        iter_from = buffer.find_anchor(anchor)
+        iter_from.set_line_offset(0)
+        iter_to = iter_from.copy()
+        iter_to.forward_to_line_end()
+        return iter_from.get_text(iter_to)
+
+    def do_response_ok(self) -> bool:
+        href = HRef.new_from_wiki_link(self.href_entry.props.text)
+        page = self.pageview.notebook.get_page(Path(href.names))
+        if not page.exists():
+            self.result = None
+            return False
+
+        title = (
+            page.get_title()
+            if href.anchor is None
+            else self._get_heading(page, href.anchor)
+        )
+        query = self.get_query(current_page=page.name)
+        self.result = Collection(
+            id=-1,
+            title=title,
+            href=href.to_wiki_link(),
+            query=(str(query) if query is not None else None),
+        )
+
+        return True
+
+
+class EditCollDlg(Dialog, QueryDlgMixin):
+    def __init__(self, parent, col: Collection) -> None:
+        Dialog.__init__(
+            self,
+            parent,
+            R.EDIT_COLLECTION_2.format(col=col.title),
+            button=R.UPDATE,
+            use_default_button=True,
+        )
+        self.col = col
+        tabs = Gtk.Notebook()
+        self.vbox.pack_start(tabs, True, True, 0)
+
+        tab1 = self._setup_general_tab()
+        tab1_label = Gtk.Label(label=R.GENERAL)
+        tab1_label.set_margin_start(12)
+        tab1_label.set_margin_end(12)
+        tabs.append_page(tab1, tab1_label)
+
+        self.tab2 = self._setup_query_tab()
+        self.set_query(Query.from_str(query=col.query, current_page=col.href))
+
+        tab2_label = Gtk.Label(label=R.QUERY)
+        tab2_label.set_margin_start(12)
+        tab2_label.set_margin_end(12)
+        tabs.append_page(self.tab2, tab2_label)
+
+        self.vbox.set_spacing(6)
+        self.vbox.set_margin_start(12)
+        self.vbox.set_margin_end(12)
+
+        self.show_all()
+        GLib.idle_add(
+            lambda: self.tab2.show() if self.col.query is not None else self.tab2.hide()
+        )
+
+    def _setup_general_tab(self) -> Gtk.VBox:
+        tab = Gtk.VBox(spacing=6)
+
+        label = Gtk.Label(label=R.NEW_NAME, halign=Gtk.Align.START)
+        tab.pack_start(label, False, False, 0)
+
+        self.entry = InputEntry(
+            allow_empty=False,
+            show_empty_invalid=True,
+        )
+        self.entry.set_text(self.col.title)
+        tab.pack_start(self.entry, False, False, 0)
+
+        self.query_enabled_cb = Gtk.CheckButton(label=R.ENABLE_AUTOGEN)
+        tab.pack_start(self.query_enabled_cb, False, False, 0)
+        self.query_enabled_cb.props.active = self.col.query is not None
+        self.query_enabled_cb.connect("toggled", self.on_enable_autogen)
+
+        tab.set_margin_top(12)
+        tab.set_margin_bottom(12)
+        tab.set_margin_start(12)
+        tab.set_margin_end(12)
+
+        return tab
+
+    def on_enable_autogen(self, sender):
+        if sender.get_active():
+            self.tab2.show()
+        else:
+            self.tab2.hide()
+
+    def do_response_ok(self) -> bool:
+        title = self.entry.get_text().strip()
+        if not title:
+            self.result = None
+            return False
+
+        query = self.get_query(current_page=self.col.href)
+        self.result = Collection(
+            id=self.col.id,
+            title=title,
+            href=self.col.href,
+            query=str(query) if query is not None else None,
+        )
+        return True

--- a/zim/plugins/collections/floatpagebar.py
+++ b/zim/plugins/collections/floatpagebar.py
@@ -1,0 +1,140 @@
+import colorsys
+from typing import Sequence
+
+from gi.repository import Gtk, Gdk, GObject  # type: ignore
+
+from zim.gui.widgets import widget_set_css
+from zim.plugins.collections import Collection
+from zim.plugins.collections.styling import StylingData
+from zim.signals import ConnectorMixin
+
+
+def highlight(gdk_rgba: Gdk.RGBA) -> Gdk.RGBA:
+    factor = 1.2
+    h, l, s = colorsys.rgb_to_hls(gdk_rgba.red, gdk_rgba.green, gdk_rgba.blue)
+    l = min(l * factor, 1.0)
+    return Gdk.RGBA(*colorsys.hls_to_rgb(h, l, s))
+
+
+class FloatPageBar(Gtk.VBox, ConnectorMixin):
+    MARGIN_V = 16
+    MARGIN_H = 12
+
+    __gsignals__ = {"goto-collection": (GObject.SIGNAL_RUN_FIRST, None, (str,))}
+
+    def __init__(self, pageview) -> None:
+        GObject.GObject.__init__(self)
+
+        self.content = None
+        self.pageview = pageview
+        self._handler_dict: dict[object, Collection] = {}
+
+        widget_set_css(
+            self,
+            "collections-page-bar",
+            "",  # "background-color: blue; border: 1px solid @fg_color",
+        )
+        self.set_halign(Gtk.Align.END)
+        self.set_valign(Gtk.Align.END)
+        self.set_margin_end(self.MARGIN_H)
+        self.set_margin_bottom(self.MARGIN_V)
+
+    def setup(
+        self,
+        colls: Sequence[Collection],
+        hubs: Sequence[Collection],
+        styling: StylingData,
+    ) -> None:
+        if self.content is not None:
+            self.content.destroy()
+
+        self._handler_dict = {}
+        self.content = Gtk.FlowBox()
+        assert self.content is not None
+        self.pack_start(self.content, False, False, 0)
+
+        nb = self.pageview.notebook
+        colls_combined = set(colls) | set(hubs)
+        for col in colls_combined:
+            self._add_tag(
+                col,
+                css_class="collection-tag",
+                icon="emblem-favorite",
+                handler=self.goto_collection,
+                style=styling.get_collection_style(col, nb),
+            )
+
+        self.content.set_valign(Gtk.Align.START)
+        self.content.set_min_children_per_line(2)
+        self.content.set_max_children_per_line(5)
+        self.content.set_selection_mode(Gtk.SelectionMode.NONE)
+
+        self.content.show_all()
+
+    def _add_tag(
+        self, col: Collection, css_class, icon, handler, style: Gdk.RGBA
+    ) -> None:
+        assert self.content is not None
+
+        tag = Gtk.HBox(spacing=6)
+        tag.set_name(css_class)
+        img = Gtk.Image.new_from_icon_name(icon, Gtk.IconSize.MENU)
+        tag.pack_start(img, False, False, 0)
+        lbl = Gtk.Label(label=col.title)
+        tag.pack_start(lbl, False, False, 0)
+
+        event_box = Gtk.EventBox()
+        event_box.connect("button-press-event", handler)
+
+        def on_enter(sender, ev):
+            sender.get_style_context().add_class("hover")
+
+        def on_leave(sender, ev):
+            sender.get_style_context().remove_class("hover"),
+
+        event_box.connect("enter-notify-event", on_enter)
+        event_box.connect("leave-notify-event", on_leave)
+        event_box.add(tag)
+        self._handler_dict[event_box] = col
+        self.content.add(event_box)
+
+        tag.get_style_context().add_provider(
+            self.get_tag_css_style(style),
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        )
+
+    def get_tag_css_style(self, clr_rgba: Gdk.RGBA | None):
+        if not clr_rgba:
+            clr_rgba = Gdk.RGBA(0.5, 0.5, 0.5)
+
+        clr = clr_rgba.to_string()
+        clr_hi = highlight(clr_rgba).to_string()
+
+        style = Gtk.CssProvider()
+        style.load_from_data(
+            f"""
+        #collection-tag{{
+            background-color: {clr};
+        }}
+        
+        .hover>#collection-tag{{
+            background-color: {clr_hi};
+        }}
+        """
+        )
+        return style
+
+    def goto_hub(self, sender, ev):
+        try:
+            c = self._handler_dict[sender]
+            self.pageview.activate_link(c.href)
+
+        except KeyError:
+            pass
+
+    def goto_collection(self, sender, ev) -> None:
+        try:
+            col = self._handler_dict[sender]
+            self.emit("goto-collection", col.href)
+        except KeyError:
+            pass

--- a/zim/plugins/collections/misc.py
+++ b/zim/plugins/collections/misc.py
@@ -1,0 +1,138 @@
+import typing
+from zim.formats import HEADING, heading_to_anchor, TAG, LINK, TokenListElement
+from zim.gui.pageview import TextBuffer
+from zim.gui.widgets import to_utf8_normalized_casefolded
+from zim.notebook import HRef, HREF_REL_FLOATING, Page, Path
+from zim.parse import tokenlist
+from zim.parse.links import link_type
+from zim.parse.tokenlist import tokens_to_text, collect_until_end_token
+from zim.plugins.collections.common import CollectionNote
+
+# {hdr_id: (hdr_id, hdr_title, {tags}, {urls})}
+PageStructureT: typing.TypeAlias = dict[str, typing.Tuple[str, str, set[str], set[str]]]
+
+
+class Misc:
+    @staticmethod
+    def canonical_href(link: str, nb, page: Path) -> str:
+        href = HRef.new_from_wiki_link(link)
+        href.names = nb.pages.resolve_link(page, href).name
+        href.rel = HREF_REL_FLOATING
+        return href.to_wiki_link()
+
+    @staticmethod
+    def get_next_heading(start_it):
+        _is_heading_tag = lambda tag: hasattr(tag, "zim_tag") and tag.zim_tag == "h"
+        it = start_it.copy()
+        it.set_line_offset(0)
+
+        ok = True
+        while ok and not any(filter(_is_heading_tag, it.get_tags())):
+            ok = it.forward_line()
+
+        return it
+
+    @staticmethod
+    def get_buffer(page, notebook):
+        buffer = page.get_textbuffer()
+        if buffer is None:
+            tree = page.get_parsetree()
+            buffer = TextBuffer(notebook, page, parsetree=tree)
+        return buffer
+
+    @staticmethod
+    def rename_heading(page, anchor, new_title):
+        tree = page.get_parsetree()
+        new_title = new_title.strip() + "\n"
+        for e in tree._etree.iter(HEADING):
+            if heading_to_anchor(e.text) == anchor:
+                e.text = new_title
+        page.set_parsetree(tree)
+
+    @staticmethod
+    def get_heading_link(page, h):
+        anchor = heading_to_anchor(h)
+        return HRef(HREF_REL_FLOATING, page.name, anchor).to_wiki_link()
+
+    @staticmethod
+    def parse_page_structure(page: Page, nb) -> PageStructureT:
+        assert page.hascontent
+        tree = page.get_parsetree()
+        tokens = tree.iter_tokens()
+        structure: PageStructureT = {}
+        hdr = page.name
+        for t in tokens:
+            if t[0] == HEADING:
+                h = tokens_to_text(collect_until_end_token(tokens, HEADING)).strip()
+                hdr = (
+                    Misc.get_heading_link(page, h) if t[1]["level"] != 1 else page.name
+                )
+                structure[hdr] = (hdr, h, set(), set())
+
+            elif t[0] == TAG:
+                tag = t[1]["name"]
+                if hdr:
+                    structure[hdr][2].add(tag)
+
+            elif t[0] == LINK:
+                structure[hdr][3].add(Misc.canonical_href(t[1]["href"], nb, page))
+
+        return structure
+
+    @staticmethod
+    def get_heading_info(it) -> tuple[str | None, str | None, int]:
+        is_heading_tag = lambda tag: hasattr(tag, "zim_tag") and tag.zim_tag == "h"
+        it2 = it.copy()
+        it2.set_line_offset(0)
+        tag = next(filter(is_heading_tag, it2.get_tags()), None)
+        if tag is None:
+            return None, None, 0
+
+        it2_end = it2.copy()
+        it2_end.forward_to_line_end()
+        text = it2.get_text(it2_end).strip()
+        anchor = heading_to_anchor(text) if len(text) > 0 else None
+        level = tag.zim_attrib["level"]
+
+        return anchor, text, level
+
+    @staticmethod
+    def parse_section_links(section_href: str, nb) -> typing.Iterable[CollectionNote]:
+        entries_seen = set()
+
+        def not_seen_before(href: str):
+            if href in entries_seen:
+                return False
+            entries_seen.add(href)
+            return True
+
+        href = HRef.new_from_wiki_link(section_href)
+        page = nb.get_page(Path(href.names))
+        buffer = Misc.get_buffer(page, nb)
+        section_start_it = (
+            buffer.find_anchor(href.anchor)
+            if href.anchor is not None
+            else buffer.get_start_iter()
+        )
+        if section_start_it is None:
+            return []
+        section_start_it.forward_line()
+        section_end_it = Misc.get_next_heading(section_start_it)
+        section_tree = buffer.get_parsetree(bounds=(section_start_it, section_end_it))
+
+        return [
+            CollectionNote(
+                title="".join(link_el.itertext()),
+                href=href_canonical,
+            )
+            for link_el in section_tree._etree.iter(LINK)
+            if link_type(href_ := link_el.attrib.get("href")) == "page"
+            and not_seen_before(href_canonical := Misc.canonical_href(href_, nb, page))
+        ]
+
+    @staticmethod
+    def get_href_ns(href: str) -> str:
+        href_ = HRef.new_from_wiki_link(href)
+        if href_.anchor:
+            return href_.names
+        return Path(href_.names).namespace

--- a/zim/plugins/collections/sidepane.py
+++ b/zim/plugins/collections/sidepane.py
@@ -1,0 +1,581 @@
+import typing
+from collections.abc import Iterable
+from enum import Enum
+from typing import Tuple, Any, NamedTuple
+
+from gi.repository import Gtk, GObject, Pango, Gdk  # type: ignore
+from zim.signals import SignalHandler
+
+from zim import signals
+from zim.formats import heading_to_anchor
+from zim.gui.widgets import (
+    WindowSidePaneWidget,
+    InputEntry,
+    StatusPage,
+    SingleClickTreeView,
+    to_utf8_normalized_casefolded,
+)
+from zim.notebook import (
+    Path,
+    IndexNotFoundError,
+    HRef,
+    HREF_REL_FLOATING,
+    LINK_DIR_BACKWARD,
+)
+from zim.notebook.index import IndexLink
+from zim.plugins.collections import Autogen
+from zim.plugins.collections.common import Collection, R, Notifier, CollectionNote
+from zim.plugins.collections.db import ColDB
+from zim.plugins.collections.dlgs import RmCollConfirmDlg, AddCollDlg, EditCollDlg
+from zim.plugins.collections.misc import Misc, PageStructureT
+from zim.plugins.collections.styling import StylingDlg
+
+if typing.TYPE_CHECKING:
+
+    def _(_: str) -> str:
+        pass
+
+
+class IndexRecDir(Enum):
+    FORW = 0
+    BACK = 1
+
+
+class IndexEntry(NamedTuple):
+    title: str
+    href: str
+    dir: IndexRecDir
+    is_col: bool
+    is_archived: bool
+    tags: Iterable[str]
+
+
+class CollectionFilterEntry(InputEntry):
+    def __init__(self, check_func, handler):
+        super().__init__(
+            placeholder_text=R.FIND_COLLECTION_PLACEHOLDER,
+            check_func=check_func,
+        )
+        self.handler = handler
+        # name, namespace(see Misc.get_href_ns), href
+        self.model = Gtk.ListStore(str, str, str)
+        self.set_icon_to_clear()
+
+        completion = Gtk.EntryCompletion()
+        self.set_completion(completion)
+        completion.set_model(self.model)
+        completion.set_text_column(0)
+        completion.set_minimum_key_length(0)
+        completion.set_match_func(self.match_collection)
+
+        ns_renderer = Gtk.CellRendererText()
+        ns_renderer.set_property("style", Pango.Style.ITALIC)
+        ns_renderer.set_property("foreground", "gray")
+        completion.pack_start(ns_renderer, True)
+        completion.add_attribute(ns_renderer, "text", 1)
+        completion.connect("match-selected", self.on_selected)
+
+        # layout = completion.get_area()
+        # layout.set_orientation(Gtk.Orientation.VERTICAL)
+
+    def populate(self, collections: Iterable[Collection]):
+        self.model.clear()
+        for col in collections:
+            self.model.append((col.title, Misc.get_href_ns(col.href), col.href))
+
+    def on_selected(self, completion, model, iter):
+        href = completion.get_model().get_value(iter, 2)
+        self.handler(href)
+
+    @staticmethod
+    def match_collection(completion, key, iter):
+        if key is None:
+            return False
+        model = completion.get_model()
+        title = to_utf8_normalized_casefolded(model.get_value(iter, 0))
+        href = to_utf8_normalized_casefolded(model.get_value(iter, 2))
+        return key in title or key in href
+
+
+class SidePane(Gtk.VBox, WindowSidePaneWidget):
+    """Side pane widget for managing and displaying collections."""
+
+    title = _("Collections")
+    __gsignals__ = {
+        "goto-collection": (GObject.SIGNAL_RUN_FIRST, None, (str,)),
+    }
+
+    def __init__(self, pageview, plugin, notifier: Notifier) -> None:
+        GObject.GObject.__init__(self)
+        self.plugin = plugin
+        self.pageview = pageview
+        self.notifier = notifier
+        self.index: dict[str, Tuple[Collection, Any]] = {}
+        self.db = ColDB(pageview.notebook.index._db)
+        self.db.connect("changed", self.on_collections_changed)
+        self.archive_roots = self._find_archive_roots(
+            plugin.preferences["archive_tags"]
+        )
+        self.props.spacing = 6
+        self.set_margin_start(6)
+        self.set_margin_end(6)
+
+        # Toolbar
+        toolbar = self._init_toolbar()
+        self.pack_start(toolbar, False, False, 0)
+
+        # Collection Search Entry
+        self.coll_filter = CollectionFilterEntry(
+            check_func=self.db.is_existing_coll_name,
+            handler=self.goto_collection,
+        )
+        self.pack_start(self.coll_filter, False, False, 0)
+
+        # Main view
+        self.main_view = Gtk.Stack()
+        self.pack_start(self.main_view, True, True, 0)
+
+        placeholder_no_cols = StatusPage(icon_name=None, title=None, info_text=R.NOCOLS)
+        placeholder_no_cols.show_all()
+        self.main_view.add_named(placeholder_no_cols, "no-cols-placeholder")
+
+        placeholder_empty_col = StatusPage(
+            icon_name=None, title=None, info_text=R.EMPTYCOL
+        )
+        placeholder_empty_col.show_all()
+        self.main_view.add_named(placeholder_empty_col, "empty-col-placeholder")
+
+        placeholder_select_col = StatusPage(
+            icon_name=None, title=None, info_text=R.SELECTCOL
+        )
+        placeholder_select_col.show_all()
+        self.main_view.add_named(placeholder_select_col, "select-col-placeholder")
+
+        # Current Collection Notes View
+        self._current_coll: Collection | None = None
+        self.collection_view = SingleClickTreeView()
+        self.collection_view.props.headers_visible = False
+        self.collection_view.show_all()
+        self.main_view.add_named(self.collection_view, "collection-view")
+        self.collection_view.connect("row-activated", self.goto_note)
+
+        tag_color_rend = Gtk.CellRendererText()
+        tag_color_rend.props.xalign = 0.5
+        tag_color_rend.props.yalign = 0.5
+        col_tag_color = Gtk.TreeViewColumn(
+            " ", tag_color_rend, text=6, foreground_rgba=7
+        )
+        self.collection_view.append_column(col_tag_color)
+
+        title_renderer = Gtk.CellRendererText()
+        col_note = Gtk.TreeViewColumn(
+            "note",
+            title_renderer,
+            weight=1,
+            text=0,
+            strikethrough=3,
+            style=4,
+            foreground_rgba=5,
+        )
+        self.collection_view.append_column(col_note)
+
+        # Styling
+        self.styling = self.db.load_styling()
+
+        updated = self._find_tagged_hubs(plugin.preferences["hub_tags"])
+        if not updated:
+            self.on_collections_changed()
+
+        nb = self.pageview.notebook
+        self.connectto(
+            nb.index.update_iter.pages, "page-changed", order=signals.SIGNAL_RUN_LAST
+        )
+
+    def _init_toolbar(self) -> Gtk.Toolbar:
+        """Initialize and return the toolbar."""
+        toolbar = Gtk.Toolbar()
+        toolbar.set_icon_size(Gtk.IconSize.SMALL_TOOLBAR)
+
+        self.bt_home = Gtk.ToolButton()
+        self.bt_home.set_tooltip_text(R.GO_TO_HUB)
+        self.bt_home.set_icon_name("go-home-symbolic")
+        self.bt_home.connect("clicked", self.on_goto_hub_clicked)
+        toolbar.add(self.bt_home)
+
+        self.bt_add = Gtk.ToolButton()
+        self.bt_add.set_tooltip_text(R.ADD_A_NEW_COLLECTION)
+        self.bt_add.set_icon_name("list-add-symbolic")
+        self.bt_add.connect("clicked", self.on_add_collection_clicked)
+        toolbar.add(self.bt_add)
+
+        self.bt_rm = Gtk.ToolButton()
+        self.bt_rm.set_tooltip_text(R.REMOVE_COLLECTION)
+        self.bt_rm.set_icon_name("list-remove-symbolic")
+        self.bt_rm.connect("clicked", self.on_rm_collection_clicked)
+        toolbar.add(self.bt_rm)
+
+        self.bt_edit = Gtk.ToolButton()
+        self.bt_edit.set_tooltip_text(R.EDIT_COLLECTION)
+        self.bt_edit.set_icon_name("edit-symbolic")
+        self.bt_edit.connect("clicked", self.on_edit_collection_clicked)
+        toolbar.add(self.bt_edit)
+
+        self.bt_styling = Gtk.ToolButton()
+        self.bt_styling.set_icon_name("tag-symbolic")
+        self.bt_styling.set_tooltip_text(R.TAG_STYLING_TITLE)
+        self.bt_styling.connect("clicked", self.on_styling_clicked)
+        toolbar.add(self.bt_styling)
+
+        self.bt_refresh = Gtk.ToolButton()
+        self.bt_refresh.set_icon_name("view-refresh-symbolic")
+        self.bt_refresh.set_tooltip_text(R.DBG_REFRESH_COLLECTIONS)
+        self.bt_refresh.connect("clicked", self.on_collections_changed)
+        toolbar.add(self.bt_refresh)
+
+        return toolbar
+
+    def _update_toolbar(self):
+        col_selected = self._current_coll is not None
+        self.bt_home.set_sensitive(col_selected)
+        self.bt_rm.set_sensitive(col_selected)
+        self.bt_edit.set_sensitive(col_selected)
+
+    def on_add_collection_clicked(self, sender) -> None:
+        dlg = AddCollDlg(self.pageview)
+        dlg.run()
+        c = dlg.result
+        if not c:
+            return
+        self.add_collection(c)
+        self.notifier.notify(R.COLLECTION_ADDED.format(col=c.title))
+
+    def on_rm_collection_clicked(self, sender) -> None:
+        if self._current_coll is None:
+            return
+        title = self._current_coll.title
+        ok = RmCollConfirmDlg(self, title).run()
+        if not ok:
+            return
+        self.db.rm_collection(self._current_coll.id)
+        self.notifier.notify(R.COLLECTION_REMOVED.format(col=title))
+
+    def on_edit_collection_clicked(self, sender) -> None:
+        if self._current_coll is None:
+            return
+        col_updated = EditCollDlg(self.pageview, self._current_coll).run()
+        if col_updated is None:
+            return
+        new_path = col_updated.href
+        if col_updated.title != self._current_coll.title:
+            new_path = self.update_path_and_title(col_updated.title)
+
+        # if the collection is visible, regenerate it
+        if col_updated.query:
+            col_page = HRef.new_from_wiki_link(col_updated.href).names
+            if self.pageview.page.name == col_page:
+                gen = Autogen(col_updated, self.pageview)
+                gen.run()
+        self.db.update_collection(col_updated, new_path)
+
+    def update_path_and_title(self, new_title: str) -> str:
+        assert self._current_coll is not None
+        href = HRef.new_from_wiki_link(self._current_coll.href)
+        if href.anchor is None:
+            new_path_list = href.names.split(":")
+            new_path_list[-1] = new_title
+            new_path = ":".join(new_path_list)
+            self.pageview.notebook.move_page(
+                Path(href.names), Path(new_path), update_heading=True
+            )
+        else:
+            page = self.pageview.notebook.get_page(Path(href.names))
+            Misc.rename_heading(page, anchor=href.anchor, new_title=new_title)
+            new_path = HRef(
+                HREF_REL_FLOATING, href.names, heading_to_anchor(new_title)
+            ).to_wiki_link()
+        return new_path
+
+    def goto_collection(self, href: str) -> None:
+        """Switch to the given collection by href."""
+        try:
+            self._current_coll, model = self.index[href]
+        except KeyError:
+            coll = self.db.get_collection_by_href(href)
+            self._index_collections([coll])
+            self._current_coll, model = self.index[href]
+
+        self.coll_filter.set_text(self._current_coll.title)
+        self.coll_filter.update_input_valid()
+        self.collection_view.set_model(model)
+        widget = "collection-view" if len(model) > 0 else "empty-col-placeholder"
+        self.main_view.set_visible_child_name(widget)
+        self._update_toolbar()
+        self.focus()
+
+    def on_collections_changed(self, sender=None) -> None:
+        """Refresh the collections index and UI."""
+        self._index_collections()
+        self.coll_filter.clear()
+        self.coll_filter.populate(self.db.all_collections())
+        self._current_coll = None
+        self.collection_view.set_model(None)
+        self._update_toolbar()
+        placeholder = "select-col-placeholder" if self.index else "no-cols-placeholder"
+        self.main_view.set_visible_child_name(placeholder)
+
+    def on_goto_hub_clicked(self, sender):
+        if self._current_coll is None:
+            return
+        self.pageview.activate_link(self._current_coll.href)
+
+    def on_styling_clicked(self, sender):
+        dlg = StylingDlg(self, self.styling)
+        updated_styling = dlg.run()
+        if updated_styling:
+            self.styling = updated_styling
+            self.db.save_styling(updated_styling)
+
+    def focus(self):
+        """Focus the pane in the UI."""
+        position = self.plugin.preferences["pane"]
+        self.pageview.get_toplevel().set_pane_state(
+            pane=position,
+            visible=True,
+            activetab=self.__class__.__name__,
+            grab_focus=True,
+        )
+
+    def _find_archive_roots(self, tags_str: str) -> frozenset[Path]:
+        nb = self.pageview.notebook
+        archive_tags = [tag.strip() for tag in tags_str.split(",") if tag.strip()]
+        archived_roots = set()
+        for tag in archive_tags:
+            try:
+                archived_roots.update(nb.tags.list_pages(tag))
+            except IndexNotFoundError:
+                pass
+        return frozenset(archived_roots)
+
+    def _find_tagged_hubs(self, tags_str: str) -> bool:
+        nb = self.pageview.notebook
+        hub_tags = set(tag.strip() for tag in tags_str.split(",") if tag.strip())
+        page_path_set = set()
+        for tag in hub_tags:
+            try:
+                page_path_set |= set(nb.tags.list_pages(tag))
+            except IndexNotFoundError:
+                pass
+
+        colls = []
+        for page_path in page_path_set:
+            page = nb.get_page(page_path)
+            page_struct = Misc.parse_page_structure(page, nb)
+            for href, title, tags, _ in page_struct.values():
+                if tags & hub_tags and not self.db.is_existing_coll_href(href):
+                    colls.append(Collection(id=-1, title=title, href=href, query=None))
+        if colls:
+            self.db.add_collections(colls)
+        return bool(colls)
+
+    def is_archived_page(self, page: Path) -> bool:
+        return any(page == root or page.ischild(root) for root in self.archive_roots)
+
+    def add_collection(self, col: Collection) -> None:
+        self.db.add_collections([col])
+        if col.href in self.index:
+            self.goto_collection(col.href)
+
+        # if the collection is visible, regenerate it
+        if col.query:
+            col_page = HRef.new_from_wiki_link(col.href).names
+            if self.pageview.page.name == col_page:
+                gen = Autogen(col, self.pageview)
+                gen.run()
+
+    def goto_note(self, sender, path, column) -> None:
+        model = sender.get_model()
+        note_it = model.get_iter(path)
+        if note_it is not None:
+            note = model[note_it]
+            if self.db.is_existing_coll_href(note[1]):
+                self.goto_collection(href=note[1])
+                return
+            self.pageview.activate_link(note[1])
+
+    def set_orientation(self, orientation) -> None:
+        pass
+
+    def _index_one_collection(self, coll: Collection) -> list[IndexEntry]:
+        """Build a comprehensive index of notes related to the given collection.
+
+        Finds all notes connected to a collection in two directions:
+        1. Forward links: Notes that are linked from the collection's hub page
+        2. Backward links: Notes that link to the collection's hub page
+
+        For each note, it determines whether it's a collection itself, is archived,
+        and collects its tags.
+
+        Args:
+            coll: The Collection object to index
+
+        Returns:
+            A list of IndexEntry objects representing all notes related to this collection
+        """
+        nb = self.pageview.notebook
+        entries_seen: set[str] = set()
+
+        def not_seen_before(href: str):
+            if href in entries_seen:
+                return False
+            entries_seen.add(href)
+            return True
+
+        # Add notes found in the hub note
+        entries_forw = Misc.parse_section_links(coll.href, nb)
+        entries_seen = {e.href for e in entries_forw}
+
+        pages = set()
+        for e in entries_forw:
+            href = HRef.new_from_wiki_link(e.href)
+            path = nb.pages.resolve_link(self.pageview.page, href)
+            page = nb.get_page(path)
+            if page.hascontent:
+                pages.add(page)
+
+        notes: PageStructureT = {}
+        for p in pages:
+            notes |= Misc.parse_page_structure(p, nb)
+
+        index: list[IndexEntry] = [
+            IndexEntry(
+                e.title,
+                e.href,
+                IndexRecDir.FORW,
+                self.db.is_existing_coll_href(e.href),
+                self.is_archived_page(Path(e.href)),
+                notes[e.href][2],
+            )
+            for e in entries_forw
+            if e.href in notes
+        ]
+
+        # Add notes that link to the hub
+        coll_path = Path(HRef.new_from_wiki_link(coll.href).names)
+        entries_back = list(nb.links.list_links(coll_path, LINK_DIR_BACKWARD))
+        entries_back.append(IndexLink(coll_path, Path("")))
+
+        index += [
+            IndexEntry(
+                title,
+                href,
+                IndexRecDir.BACK,
+                self.db.is_existing_coll_href(href),
+                self.is_archived_page(Path(href)),
+                tags,
+            )
+            for e in entries_back
+            for href, title, tags, links in Misc.parse_page_structure(
+                nb.get_page(e.source), nb
+            ).values()
+            if coll.href in links and not_seen_before(href)
+        ]
+
+        return index
+
+    def _index_to_model_row(self):
+        pass
+
+    def _index_collections(self, collections=None) -> None:
+        CLR_TEXT_NORM = self.pageview.get_style_context().get_color(
+            Gtk.StateFlags.NORMAL
+        )
+        CLR_ARCHIVED = Gdk.RGBA()
+        CLR_ARCHIVED.parse(self.plugin.preferences["archive_color"])
+
+        collections = collections or self.db.all_collections()
+        for coll in collections:
+            # title, href, None, strikethru, text-style, text-color, tag-slab, tag-color
+            model = Gtk.ListStore(
+                str, str, str, bool, Pango.Style, Gdk.RGBA, str, Gdk.RGBA
+            )
+            self.index[coll.href] = (coll, model)
+            index = self._index_one_collection(coll)
+
+            # Priorities for collection entries:
+            #   - Collections over non-collections,
+            #   - Collections with BACK direction,
+            #   - Entries with styled tags,
+            #   - Non-archived entries over archived ones.
+            index.sort(
+                reverse=True,
+                key=lambda rec: (2 if rec.is_col else 0)
+                + (1 if rec.dir == IndexRecDir.BACK and rec.is_col else 0)
+                + (1 if self.styling.get_style_for_tags(rec.tags) is not None else 0)
+                - (2 if rec.is_archived else 0),
+            )
+            for entry in index:
+                tag_color = (
+                    self.styling.get_style_for_tags(entry.tags)
+                    if not entry.is_col
+                    else None
+                )
+                slab = (
+                    (R.SLAB_PIN if tag_color else None)
+                    if not entry.is_col
+                    else (R.SLAB_UP if entry.dir == IndexRecDir.BACK else R.SLAB_DOWN)
+                )
+                model.append(
+                    [
+                        entry.title,
+                        entry.href,
+                        None,
+                        entry.is_archived,
+                        (
+                            Pango.Style.NORMAL
+                            if not entry.is_archived
+                            else Pango.Style.ITALIC
+                        ),
+                        CLR_TEXT_NORM if not entry.is_archived else CLR_ARCHIVED,
+                        slab,
+                        tag_color,
+                    ]
+                )
+
+    def get_collections_for_page(self, page_href: str) -> list[Collection]:
+        """Get collections this page belongs to."""
+        result = []
+        for coll, model in self.index.values():
+            for row in model:
+                href = HRef.new_from_wiki_link(row[1]).names
+                if href == page_href:
+                    result.append(coll)
+        return result
+
+    def on_page_changed(self, sender, row, content):
+        nb = self.pageview.notebook
+        page = Path(row["name"])
+
+        # Hub changed - invalidate all collections with hubs on  this page
+        hubs = self.db.get_hubs_for_page(page.name)
+
+        # non hub page changed - invalidate all collections it's part of
+        hrefs = (
+            Misc.canonical_href(href.to_wiki_link(), nb, page)
+            for href in content.iter_href(include_anchors=True)
+        )
+        colls_internal = [
+            self.db.get_collection_by_href(href)
+            for href in hrefs
+            if self.db.is_existing_coll_href(href)
+        ]
+        colls_external = self.get_collections_for_page(page.name)
+        for c in hubs + colls_external + colls_internal:
+            try:
+                del self.index[c.href]
+            except KeyError:
+                pass
+
+    def on_archive_roots_changed(self):
+        self.archive_roots = self._find_archive_roots(
+            self.plugin.preferences["archive_tags"]
+        )

--- a/zim/plugins/collections/styling.py
+++ b/zim/plugins/collections/styling.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from gi.repository import Gtk, Gdk  # type: ignore
+
+from zim.gui.widgets import Dialog
+from zim.notebook import Notebook, HRef, Path, IndexNotFoundError
+from zim.plugins.collections import Misc
+from zim.plugins.collections.common import Collection, R
+
+
+class StylingData:
+    def __init__(self):
+        self.order_dict: dict[str, int] = {}
+        self.clr_dict: dict[str, Gdk.RGBA] = {}
+
+    def to_model(self):
+        model = Gtk.ListStore(Gdk.RGBA, str)  # color, tag
+
+        if not self.order_dict:
+            self._default_populate(model)
+            return model
+
+        tags = sorted(self.order_dict.keys(), key=lambda t: self.order_dict[t])
+        for t in tags:
+            model.append([self.clr_dict[t], t])
+
+        return model
+
+    @staticmethod
+    def from_model(model) -> StylingData:
+        self = StylingData()
+        for rank, row in enumerate(model):
+            clr, tag = row
+            self.order_dict[tag] = rank
+            self.clr_dict[tag] = clr
+        return self
+
+    @staticmethod
+    def _default_populate(model):
+        colors = [
+            (0.8, 0.1, 0.1),  # Red
+            (0.8, 0.1, 0.1),  # Red
+            (0.8, 0.8, 0.1),  # Yellow
+            (0.1, 0.8, 0.1),  # Green
+            (0.1, 0.1, 0.8),  # Blue
+        ]
+        strings = [
+            R.TagDefPin,
+            R.TagDefWork,
+            R.TagDefImportant,
+            R.TagDefIdea,
+            R.TagDefProject,
+        ]
+
+        for color, string in zip(colors, strings):
+            rgba = Gdk.RGBA(color[0], color[1], color[2], 1.0)
+            model.append([rgba, string])
+
+    def get_style_for_tags(self, tags: Iterable[str]) -> Gdk.RGBA | None:
+        """
+        Select the tag with the highest priority (lowest order value).
+        Tags not present in order_dict are treated as lowest priority.
+        """
+        size = len(self.order_dict)
+        if not tags or size == 0:
+            return None
+
+        tag = min(
+            tags,
+            key=lambda tag: (self.order_dict[tag] if tag in self.order_dict else size),
+        )
+        return self.clr_dict[tag] if tag in self.clr_dict else None
+
+    def get_collection_style(self, c: Collection, nb: Notebook) -> Gdk.RGBA | None:
+        href = HRef.new_from_wiki_link(c.href)
+        if not href.anchor:
+            try:
+                tags = list(tag.name for tag in nb.tags.list_tags(Path(href.names)))
+                return self.get_style_for_tags(tags)
+            except IndexNotFoundError:
+                return None
+
+        page = nb.get_page(Path(href.names))
+        structure = Misc.parse_page_structure(page, nb)
+        if c.href not in structure:
+            return None
+
+        return self.get_style_for_tags(structure[c.href][2])
+
+
+class AddTagDlg(Dialog):
+    def __init__(self, parent):
+        Dialog.__init__(self, parent, R.ADD_TAG_DLG, button=R.ADD)
+
+        layout = Gtk.HBox(spacing=12)
+        self.color_but = Gtk.ColorButton()
+        layout.pack_start(self.color_but, False, False, 0)
+        self.tags_entry = Gtk.Entry()
+        self.tags_entry.set_placeholder_text(R.ADD_TAG_PLACEHOLDER)
+        layout.pack_start(self.tags_entry, True, True, 0)
+        self.vbox.add(layout)
+        self.vbox.props.spacing = 24
+
+    def do_response_ok(self) -> bool:
+        tags_text = self.tags_entry.get_text()
+        color = self.color_but.get_rgba()
+        tags = [tag.strip() for tag in tags_text.split(",") if len(tag.strip()) > 0]
+        if not tags:
+            self.result = None
+            return False
+        self.result = (tags, color)
+        return True
+
+
+class StylingDlg(Dialog):
+    def __init__(self, parent, data: StylingData):
+        Dialog.__init__(
+            self, parent, R.TAG_STYLING_TITLE, help="Plugins:Collections#styling"
+        )
+
+        self.model = data.to_model()
+
+        self.treeview = Gtk.TreeView(model=self.model)
+        self.treeview.props.reorderable = True
+
+        color_renderer = Gtk.CellRendererText()
+        color_renderer.props.text = R.SLAB_PIN
+        column = Gtk.TreeViewColumn(" ", color_renderer, foreground_rgba=0)
+        column.set_clickable(True)
+        column.set_resizable(True)
+        self.treeview.append_column(column)
+
+        text_renderer = Gtk.CellRendererText()
+        text_renderer.props.editable = True
+        text_renderer.connect("edited", self.on_tag_edited)
+        text_column = Gtk.TreeViewColumn(R.TAG, text_renderer, text=1)
+        self.treeview.append_column(text_column)
+
+        self.treeview.connect("row-activated", self.on_select_color_clicked)
+
+        bt_add = Gtk.ToolButton()
+        bt_add.set_icon_name("list-add-symbolic")
+        bt_add.set_tooltip_text(R.ADD_TAG)
+        bt_add.connect("clicked", self.on_add_tag_clicked)
+
+        bt_rm = Gtk.ToolButton()
+        bt_rm.set_icon_name("list-remove-symbolic")
+        bt_rm.set_tooltip_text(R.REMOVE_TAG)
+        bt_rm.connect("clicked", self.on_rm_tag_clicked)
+
+        toolbar = Gtk.Toolbar()
+        toolbar.set_icon_size(Gtk.IconSize.SMALL_TOOLBAR)
+
+        toolbar.add(bt_add)
+        toolbar.add(bt_rm)
+
+        self.vbox.pack_start(toolbar, False, False, 0)
+        self.vbox.pack_start(self.treeview, True, True, 0)
+
+    def on_tag_edited(self, obj, path, new_text):
+        it = self.model.get_iter(path)
+        self.model[it][1] = new_text
+
+    def on_select_color_clicked(self, treeview, path, column):
+        iter_ = self.model.get_iter(path)
+
+        # Open color chooser dialog
+        color = self.model.get_value(iter_, 0)
+        color_chooser = Gtk.ColorChooserDialog(R.ASSIGN_COLOR_FOR_TAG, self)
+        color_chooser.set_rgba(color)
+
+        response = color_chooser.run()
+        if response == Gtk.ResponseType.OK:
+            new_color = color_chooser.get_rgba()
+            self.model.set_value(iter_, 0, new_color)
+        color_chooser.destroy()
+
+    def on_add_tag_clicked(self, widget):
+        dlg = AddTagDlg(self)
+        response = dlg.run()
+        if response is None:
+            return
+        tags, color = response
+
+        for tag in tags:
+            self.model.append([color, tag])
+
+    def on_rm_tag_clicked(self, widget):
+        selection = self.treeview.get_selection()
+        model, tree_iter = selection.get_selected()
+        if tree_iter:
+            model.remove(tree_iter)
+
+    def do_response_ok(self) -> bool:
+        self.result = StylingData.from_model(self.model)
+        return True


### PR DESCRIPTION
### Collections
Many users maintain central notes(often called hubs or MoCs) with collections of links to better organize their notes. These notes act as maps, linking to related content without containing any original material themselves. Hubs help users efficiently gather, navigate, and retrieve related content, making their notes more structured. For background, see Zettelkarsten or Linking Your Thinking.

The plugin enhances this workflow in Zim. It pulls all links from existing hubs and displays them in a side pane for quick access and easy navigation, similar to the Index. The key features are:
- **Dedicated Collections Pane:** A new pane alongside the Index and Tags, where users can manage their collections of links pulled from their existing hubs.
- **Auto-Generation:** Users can define queries to dynamically add matching notes to the hubs, saving time and effort.

### Why Collections?
- Think of collections as _non-intrusive overlays_ — they organize your existing notes without altering the notes themselves. For example, I might build a collection of books I want to recommend to my friend Rick, and then another collection for Lisa. Some books may appear in both collections, but the collections themselves can change, grow, or be removed without any updates necessary to the pages about a particular book themselves.
- Tags can serve various purposes, such as marking note types (e.g., ''@book'' or ''@person''), topics (e.g., ''@history_of_music''), statuses (e.g., ''@postponed''), or actions. Collections can help separate these roles, e.g. organize by topic with collections while using tags for status. For example, you can tag book review notes with  ''@book'' and notes about authors with ''@author'', while using collections to organize books about a war or all books by a specific author.
- Unlike flat-level tags, hubs can include other hubs, introducing hierarchy. However, unlike a hierarchical index, the same page can belong to multiple collections. Collections blend features both of a strict hierarchy and flat tags.
- Zim offers hierarchical index and tags for organization, but with this plugin, users can also mix an match tags with collections or index with collections for their organization methods.
### Atomic Notes
This plugin is built around atomic notes—self-contained pieces of information or insights that focus on a single idea or concept. Since Zim shows only one page at a time, it’s impractical to have a dedicated page for each atomic note, especially if they are short. To overcome this, the plugin works at the heading level instead of the whole page, allowing different sections of the same page to belong to different collections. A single page can contain several hubs as well without conflict. Importantly, tags and links below a heading are considered to be part of that section, not the entire page.
### Collections Hierarchy
If a hub links to another hub, the corresponding collections of links form a parent-child relationship, creating a hierarchy—or rather a lattice, since a single collection can have multiple parent collections. Each collection in the Collections pane shows parent or child collections in addition to the actual member pages, enabling navigation within the lattice.
### Hub Tags
All pages tagged with any of the hub tags (as specified in the configuration page) are automatically recognized as hubs, creating corresponding collections.
### Archived Pages
Pages tagged as archived (using tags specified in the configuration page) or their descendants are always listed at the end of a collection and grayed out to signal low importance visually.
### Styling
The Collections pane supports color coding of pages based on their tags. Use the Styling dialog to assign colors to different tags.
### Auto-Generation
To avoid the manually adding links to hubs, users can specify a query to dynamically add links to all matching pages in the hub. The syntax is somewhat similar to the Search syntax. Auto-generation can be viewed as saved search queries, eliminating the need for repetitive manual searches, saving thus time and effort.

Users are free to customize and decorate the auto-generated list, such as highlighting important entries, adding supporting information, or using different formatting styles. Auto-generation runs automatically but does not interfere with existing links in the hub; it only adds new links if found.

Auto-generation can be enabled in the New Collection or Edit dialogs by checking the “Enable Autogeneration” checkbox. This will display a dedicated tab to edit a query.
### Auto-Generation Syntax
The query syntax is similar to the Search syntax but is simplified. It consists of one or several commands separated by spaces as follows:
- ''+tag:XXX''– Required tag; the matching page must have all specified tags.
- ''?tag:XXX''– Optional tag; the matching page must have at least one of the specified optional tags.
- ''-tag:XXX''– Excluded tag; the matching page must not have any of the excluded tags.
- ''links:XXX'' or ''linksfrom:XXX'' – Matches all pages that are linked by a certain page.
- ''linksto:XXX'' – Matches all pages that link to a certain page. Can appear only once in a query.