### PR TITLE
QuickNote plugin: fix the use of "--page" and "--section"

### DIFF
--- a/data/manual/Plugins/Quick_Note.txt
+++ b/data/manual/Plugins/Quick_Note.txt
@@ -20,6 +20,7 @@ The "Quick Note" plugin offers a dialog for inserting quick notes into a noteboo
 --namespace STRING     (deprecated) Same as "--section"
 --basename STRING      (deprecated) Same as "--title"
 --append [true|false]  Set whether to append or create new page
+--open [true|false]    Open the page on which the note was placed
 --text TEXT            Provide the text directly
 --input stdin          Provide the text on stdin
 --input clipboard      Take the text from the clipboard

--- a/data/manual/Plugins/Quick_Note.txt
+++ b/data/manual/Plugins/Quick_Note.txt
@@ -12,17 +12,22 @@ The "Quick Note" plugin offers a dialog for inserting quick notes into a noteboo
 **Options:**
 
 '''
+--help, -h             Print this help text and exit
 --notebook URI         Select the notebook in the dialog
---page STRING          Fill in full page name
---section STRING       Fill in the page section in the dialog
---basename STRING      Fill in the page name in the dialog
+--page STRING          Fill in full page name (e.g. "PageA:PageB") (--append=true)
+--section STRING       Fill in the full page name under which the new page will be added (--append=false)
+--title STRING         Fill in the page or section title (requires --append=false)
+--namespace STRING     (deprecated) Same as "--section"
+--basename STRING      (deprecated) Same as "--title"
 --append [true|false]  Set whether to append or create new page
 --text TEXT            Provide the text directly
 --input stdin          Provide the text on stdin
 --input clipboard      Take the text from the clipboard
 --encoding base64      Text is encoded in base64
---encoding url         Text is url encoded (In both cases expects UTF-8 after decoding)
---attachments FOLDER   Import all files in FOLDER as attachments, wiki input can refer these files relatively
+--encoding url         Text is url encoded
+                       (In both cases expects UTF-8 after decoding)
+--attachments FOLDER   Import all files in FOLDER as attachments,
+                       wiki input can refer these files relatively
 --option url=STRING    Set template parameter
 '''
 

--- a/tests/quicknote.py
+++ b/tests/quicknote.py
@@ -58,6 +58,24 @@ class TestQuickNotePlugin(tests.TestCase):
 		cmd = QuickNotePluginCommand('quicknote')
 		cmd.parse_options('--option', 'url=foo')
 		self.assertEqual(cmd.template_options, {'url': 'foo'})
+		
+		# Field assignments.
+		cmd = QuickNotePluginCommand('quicknote')
+		cmd.parse_options('--section', 'TheSection', '--pagetitle', 'TheTitle')
+		self.assertEqual(cmd.opts['namespace'], 'TheSection')
+		self.assertEqual(cmd.opts['basename'], 'TheTitle')
+		
+		# Field assignments.
+		cmd = QuickNotePluginCommand('quicknote')
+		cmd.parse_options('--namespace', 'TheSection', '--basename', 'TheTitle')
+		self.assertEqual(cmd.opts['namespace'], 'TheSection')
+		self.assertEqual(cmd.opts['basename'], 'TheTitle')
+		
+		# Field assignments, new options should override the deprecated ones.
+		cmd = QuickNotePluginCommand('quicknote')
+		cmd.parse_options('--namespace', 'TheNamespace', '--basename', 'Thebasename', '--section', 'TheSection', '--pagetitle', 'TheTitle')
+		self.assertEqual(cmd.opts['namespace'], 'TheSection')
+		self.assertEqual(cmd.opts['basename'], 'TheTitle')
 
 	# TODO: other commandline args
 	# TODO: widget interaction - autcomplete etc.

--- a/tests/quicknote.py
+++ b/tests/quicknote.py
@@ -15,44 +15,7 @@ from zim.gui.clipboard import Clipboard, SelectionClipboard
 @tests.skipIf(os.name == 'nt', 'QuickNote not supported on Windows')
 class TestQuickNotePlugin(tests.TestCase):
 
-	def assertRun(self, args, text):
-		# Bootstrap via "handle_local_commandline" to emulate
-		# how application will handle this
-		cmd = QuickNotePluginCommand('quicknote')
-		cmd.parse_options(*args)
-		args = cmd.handle_local_commandline(list(args))
-
-		cmd = QuickNotePluginCommand('quicknote')
-		cmd.parse_options(*args)
-		dialog = cmd.run()
-
-		self.assertIsInstance(dialog, QuickNoteDialog)
-		buffer = dialog.textview.get_buffer()
-		start, end = buffer.get_bounds()
-		result = start.get_text(end)
-		self.assertIn(text, result)
-
 	def testMain(self):
-		# Text on commandline
-		text = 'foo bar baz\ndus 123'
-		self.assertRun(('--text', text), text)
-
-		encoded = 'Zm9vIGJhciBiYXoKZHVzIDEyMwo='
-		self.assertRun(('--text', encoded, '--encoding', 'base64'), text)
-
-		encoded = 'foo%20bar%20baz%0Adus%20123'
-		self.assertRun(('--text', encoded, '--encoding', 'url'), text)
-
-		# Clipboard input
-		text = 'foo bar baz\ndus 123'
-		SelectionClipboard.clipboard.clear() # just to be sure
-		SelectionClipboard.clipboard.set_text('', -1) # HACK to clear it
-		Clipboard.set_text(text)
-		self.assertRun(('--input', 'clipboard',), text)
-
-		text = 'foo bar baz\ndus 456'
-		SelectionClipboard.set_text(text)
-		self.assertRun(('--input', 'clipboard',), text)
 
 		# Template options
 		cmd = QuickNotePluginCommand('quicknote')
@@ -76,6 +39,18 @@ class TestQuickNotePlugin(tests.TestCase):
 		cmd.parse_options('--namespace', 'TheNamespace', '--basename', 'Thebasename', '--section', 'TheSection', '--title', 'TheTitle')
 		self.assertEqual(cmd.opts['namespace'], 'TheSection')
 		self.assertEqual(cmd.opts['basename'], 'TheTitle')
+		
+		# Field assignments, interpret boolean flags correctly.
+		cmd = QuickNotePluginCommand('quicknote')
+		cmd.parse_options('--append', 'true', '--open', 'true')
+		self.assertTrue(cmd.opts['append'])
+		self.assertTrue(cmd.opts['open'])
+		
+		# Field assignments, interpret boolean flags correctly.
+		cmd = QuickNotePluginCommand('quicknote')
+		cmd.parse_options('--append', 'false', '--open', 'false')
+		self.assertFalse(cmd.opts['append'])
+		self.assertFalse(cmd.opts['open'])
 
 	# TODO: other commandline args
 	# TODO: widget interaction - autcomplete etc.

--- a/tests/quicknote.py
+++ b/tests/quicknote.py
@@ -15,7 +15,44 @@ from zim.gui.clipboard import Clipboard, SelectionClipboard
 @tests.skipIf(os.name == 'nt', 'QuickNote not supported on Windows')
 class TestQuickNotePlugin(tests.TestCase):
 
+	def assertRun(self, args, text):
+		# Bootstrap via "handle_local_commandline" to emulate
+		# how application will handle this
+		cmd = QuickNotePluginCommand('quicknote')
+		cmd.parse_options(*args)
+		args = cmd.handle_local_commandline(list(args))
+
+		cmd = QuickNotePluginCommand('quicknote')
+		cmd.parse_options(*args)
+		dialog = cmd.run()
+
+		self.assertIsInstance(dialog, QuickNoteDialog)
+		buffer = dialog.textview.get_buffer()
+		start, end = buffer.get_bounds()
+		result = start.get_text(end)
+		self.assertIn(text, result)
+
 	def testMain(self):
+		# Text on commandline
+		text = 'foo bar baz\ndus 123'
+		self.assertRun(('--text', text), text)
+
+		encoded = 'Zm9vIGJhciBiYXoKZHVzIDEyMwo='
+		self.assertRun(('--text', encoded, '--encoding', 'base64'), text)
+
+		encoded = 'foo%20bar%20baz%0Adus%20123'
+		self.assertRun(('--text', encoded, '--encoding', 'url'), text)
+
+		# Clipboard input
+		text = 'foo bar baz\ndus 123'
+		SelectionClipboard.clipboard.clear() # just to be sure
+		SelectionClipboard.clipboard.set_text('', -1) # HACK to clear it
+		Clipboard.set_text(text)
+		self.assertRun(('--input', 'clipboard',), text)
+
+		text = 'foo bar baz\ndus 456'
+		SelectionClipboard.set_text(text)
+		self.assertRun(('--input', 'clipboard',), text)
 
 		# Template options
 		cmd = QuickNotePluginCommand('quicknote')

--- a/tests/quicknote.py
+++ b/tests/quicknote.py
@@ -61,7 +61,7 @@ class TestQuickNotePlugin(tests.TestCase):
 		
 		# Field assignments.
 		cmd = QuickNotePluginCommand('quicknote')
-		cmd.parse_options('--section', 'TheSection', '--pagetitle', 'TheTitle')
+		cmd.parse_options('--section', 'TheSection', '--title', 'TheTitle')
 		self.assertEqual(cmd.opts['namespace'], 'TheSection')
 		self.assertEqual(cmd.opts['basename'], 'TheTitle')
 		
@@ -73,7 +73,7 @@ class TestQuickNotePlugin(tests.TestCase):
 		
 		# Field assignments, new options should override the deprecated ones.
 		cmd = QuickNotePluginCommand('quicknote')
-		cmd.parse_options('--namespace', 'TheNamespace', '--basename', 'Thebasename', '--section', 'TheSection', '--pagetitle', 'TheTitle')
+		cmd.parse_options('--namespace', 'TheNamespace', '--basename', 'Thebasename', '--section', 'TheSection', '--title', 'TheTitle')
 		self.assertEqual(cmd.opts['namespace'], 'TheSection')
 		self.assertEqual(cmd.opts['basename'], 'TheTitle')
 

--- a/zim/plugins/quicknote.py
+++ b/zim/plugins/quicknote.py
@@ -32,10 +32,11 @@ class QuickNotePluginCommand(GtkCommand):
 
 	options = (
 		('notebook=', '', 'Select the notebook in the dialog'),
-		('page=', '', 'Fill in full page name'),
-		('section=', '', 'Fill in the page section in the dialog'),
-		('namespace=', '', 'Fill in the page section in the dialog'), # backward compatibility
-		('basename=', '', 'Fill in the page name in the dialog'),
+		('page=', '', 'Fill in full page name (e.g. "PageA:PageB")'),
+		('section=', '', 'Fill in the full page name under which the new page will be added.'),
+		('pagetitle=', '', 'Fill in the title of the new page'),
+		('namespace=', '', '(deprecated) Same as "--section"'),
+		('basename=', '', '(deprecated) Same as "--pagetitle"'),
 		('append=', '', 'Set whether to append or create new page ("true" or "false")'),
 		('text=', '', 'Provide the text directly'),
 		('input=', '', 'Provide the text on stdin ("stdin") or take the text from the clipboard ("clipboard")'),
@@ -50,9 +51,11 @@ usage: zim --plugin quicknote [OPTIONS]
 Options:
   --help, -h             Print this help text and exit
   --notebook URI         Select the notebook in the dialog
-  --page STRING          Fill in full page name
-  --section STRING       Fill in the page section in the dialog
-  --basename STRING      Fill in the page name in the dialog
+  --page STRING          Fill in full page name (e.g. "PageA:PageB") (--append=true)
+  --section STRING       Fill in the full page name under which the new page will be added (--append=false)
+  --pagetitle STRING     Fill in the page or section title (requires --append=false)
+  --namespace STRING     (deprecated) Same as "--section"
+  --basename STRING      (deprecated) Same as "--pagetitle"
   --append [true|false]  Set whether to append or create new page
   --text TEXT            Provide the text directly
   --input stdin          Provide the text on stdin
@@ -88,6 +91,12 @@ Options:
 		if 'append' in self.opts:
 			self.opts['append'] = \
 				self.opts['append'].lower() == 'true'
+				
+		if 'section' in self.opts:
+			self.opts['namespace'] = self.opts['section']
+				
+		if 'pagetitle' in self.opts:
+			self.opts['basename'] = self.opts['pagetitle']
 
 		if self.opts.get('attachments', None):
 			folderpath = LocalFolder(self.pwd).get_abspath(self.opts['attachments'])
@@ -219,10 +228,10 @@ class QuickNoteDialog(Dialog):
 			page = namespace or basename
 
 		self.form.add_inputs((
-				('page', 'page', _('Page')),
-				('namespace', 'namespace', _('Page section')), # T: text entry field
-				('new_page', 'bool', _('Create a new page for each note')), # T: checkbox in Quick Note dialog
-				('basename', 'string', _('Title')) # T: text entry field
+				('page', 'page', _('Page')), # T: text entry field; used if new_page is false.
+				('new_page', 'bool', _('Create a new page for each note')), # T: checkbox; if a new page should be created or not.
+				('namespace', 'namespace', _('Page section')), # T: text entry field; section when creating a new page.
+				('basename', 'string', _('Title')) # T: text entry field; pagetitle when creating a new page.
 			))
 		self.form.update({
 				'page': page,
@@ -237,23 +246,19 @@ class QuickNoteDialog(Dialog):
 		if basename:
 			self.uistate['new_page'] = True # Be consistent with input
 
-		# Set up the inputs and set page/ namespace to switch on
-		# toggling the checkbox
-		self.form.widgets['page'].set_no_show_all(True)
-		self.form.widgets['namespace'].set_no_show_all(True)
 		if append is None:
 			self.form['new_page'] = bool(self.uistate['new_page'])
 		else:
 			self.form['new_page'] = not append
 
-		def switch_input(*a):
+		def switch_input(*_):
 			if self.form['new_page']:
-				self.form.widgets['page'].hide()
-				self.form.widgets['namespace'].show()
+				self.form.widgets['page'].set_sensitive(False)
+				self.form.widgets['namespace'].set_sensitive(True)
 				self.form.widgets['basename'].set_sensitive(True)
 			else:
-				self.form.widgets['page'].show()
-				self.form.widgets['namespace'].hide()
+				self.form.widgets['page'].set_sensitive(True)
+				self.form.widgets['namespace'].set_sensitive(False)
 				self.form.widgets['basename'].set_sensitive(False)
 
 		switch_input()
@@ -319,7 +324,7 @@ class QuickNoteDialog(Dialog):
 			try:
 				if isinstance(notebook, str):
 					notebook = NotebookInfo(notebook)
-				obj, x = build_notebook(notebook)
+				obj, _ = build_notebook(notebook)
 				self.form.widgets['namespace'].notebook = obj
 				self.form.widgets['page'].notebook = obj
 				logger.debug('Notebook for autocomplete: %s (%s)', obj, notebook)

--- a/zim/plugins/quicknote.py
+++ b/zim/plugins/quicknote.py
@@ -38,6 +38,7 @@ class QuickNotePluginCommand(GtkCommand):
 		('namespace=', '', '(deprecated) Same as "--section"'),
 		('basename=', '', '(deprecated) Same as "--title"'),
 		('append=', '', 'Set whether to append or create new page ("true" or "false")'),
+		('open=', '', 'Open the page on which the note was placed.'),
 		('text=', '', 'Provide the text directly'),
 		('input=', '', 'Provide the text on stdin ("stdin") or take the text from the clipboard ("clipboard")'),
 		('encoding=', '', 'Text encoding ("base64" or "url")'),
@@ -57,6 +58,7 @@ Options:
   --namespace STRING     (deprecated) Same as "--section"
   --basename STRING      (deprecated) Same as "--title"
   --append [true|false]  Set whether to append or create new page
+  --open [true|false]    Open the page on which the note was placed
   --text TEXT            Provide the text directly
   --input stdin          Provide the text on stdin
   --input clipboard      Take the text from the clipboard
@@ -91,6 +93,10 @@ Options:
 		if 'append' in self.opts:
 			self.opts['append'] = \
 				self.opts['append'].lower() == 'true'
+
+		if 'open' in self.opts:
+			self.opts['open'] = \
+				self.opts['open'].lower() == 'true'
 				
 		if 'section' in self.opts:
 			self.opts['namespace'] = self.opts['section']
@@ -137,9 +143,10 @@ Options:
 		dialog = QuickNoteDialog(None,
 			notebook=notebook,
 			namespace=self.opts.get('namespace'),
-			page=self.opts.get('page'),
+			page_to_append_to=self.opts.get('page'),
 			basename=self.opts.get('basename'),
 			append=self.opts.get('append'),
+			open_page=self.opts.get('open'),
 			text=self.opts.get('text', ''),
 			template_options=self.template_options,
 			attachments=self.opts.get('attachments')
@@ -178,8 +185,9 @@ class QuickNoteMainWindowExtension(MainWindowExtension):
 class QuickNoteDialog(Dialog):
 
 	def __init__(self, window, notebook=None,
-		page=None, namespace=None, basename=None,
-		append=None, text=None, template_options=None, attachments=None
+		page_to_append_to=None, namespace=None, basename=None,
+		append=None, text=None, template_options=None, attachments=None,
+		open_page=None
 	):
 		self.config = ConfigManager.get_config_dict('quicknote.conf')
 		self.uistate = self.config['QuickNoteDialog']
@@ -210,39 +218,41 @@ class QuickNoteDialog(Dialog):
 		self.notebookcombobox.connect('changed', self.on_notebook_changed)
 		self.form.attach(self.notebookcombobox, 1, 2, 0, 1)
 
-		self._init_inputs(namespace, basename, append, text, template_options, page)
+		self._init_inputs(namespace, basename, append, text, open_page, page_to_append_to, template_options)
 
 		self.uistate['lastnotebook'] = notebook
 		self._set_autocomplete(notebook)
 
-	def _init_inputs(self, namespace, basename, append, text, template_options, pageToAppendTo=None, custom=None):
+	def _init_inputs(self, namespace, basename, append, text, open_page, page_to_append_to, template_options):
 		if template_options is None:
 			template_options = {}
 		else:
 			template_options = template_options.copy()
 
-		if pageToAppendTo is not None:
-			page = pageToAppendTo
+		if page_to_append_to is not None:
+			page = page_to_append_to
 		else:
 			if namespace is not None and basename is not None:
 				page = namespace + ':' + basename
-			elif pageToAppendTo is None:
+			elif page_to_append_to is None:
 				page = namespace or basename
 
 		self.form.add_inputs((
 				('page', 'page', _('Page')), # T: text entry field; used if new_page is false.
 				('new_page', 'bool', _('Create a new page for each note')), # T: checkbox; if a new page should be created or not.
 				('namespace', 'namespace', _('Page section')), # T: text entry field; section when creating a new page.
-				('basename', 'string', _('Title')) # T: text entry field; title when creating a new page.
+				('basename', 'string', _('Title')), # T: text entry field; title when creating a new page.
+				('open_page', 'bool', _('Open page')), # T: checkbox; open page.
 			))
 		self.form.update({
 				'page': page,
 				'namespace': namespace,
 				'new_page': True,
 				'basename': basename,
+				'open_page': True,
 			})
 
-		self.uistate.setdefault('open_page', True)
+		# New page.
 		self.uistate.setdefault('new_page', True)
 
 		if basename:
@@ -252,6 +262,14 @@ class QuickNoteDialog(Dialog):
 			self.form['new_page'] = bool(self.uistate['new_page'])
 		else:
 			self.form['new_page'] = not append
+
+		# Open page.
+		self.uistate.setdefault('open_page', True)
+
+		if open_page is None:
+			self.form['open_page'] = bool(self.uistate['open_page'])
+		else:
+			self.form['open_page'] = open_page
 
 		def switch_input(*_):
 			if self.form['new_page']:
@@ -265,12 +283,6 @@ class QuickNoteDialog(Dialog):
 
 		switch_input()
 		self.form.widgets['new_page'].connect('toggled', switch_input)
-
-		self.open_page_check = Gtk.CheckButton.new_with_mnemonic(_('Open _Page')) # T: Option in quicknote dialog
-			# Don't use "O" as accelerator here to avoid conflict with "Ok"
-		self.open_page_check.set_active(self.uistate['open_page'])
-		self.action_area.pack_start(self.open_page_check, False, True, 0)
-		self.action_area.set_child_secondary(self.open_page_check, True)
 
 		# Add the main textview and hook up the basename field to
 		# sync with first line of the textview
@@ -308,7 +320,7 @@ class QuickNoteDialog(Dialog):
 
 		self.connect('delete-event', self.do_delete_event)
 
-	def on_notebook_changed(self, o):
+	def on_notebook_changed(self, _):
 		notebook = self.notebookcombobox.get_notebook()
 		if not notebook or notebook == self.uistate['lastnotebook']:
 			return
@@ -370,7 +382,7 @@ class QuickNoteDialog(Dialog):
 		notebook = self.notebookcombobox.get_notebook()
 		self.uistate['lastnotebook'] = notebook
 		self.uistate['new_page'] = self.form['new_page']
-		self.uistate['open_page'] = self.open_page_check.get_active()
+		self.uistate['open_page'] = self.form['open_page']
 		if notebook is not None:
 			if self.uistate['new_page']:
 				self.config['Namespaces'][notebook] = self.form['namespace']
@@ -440,7 +452,7 @@ class QuickNoteDialog(Dialog):
 		if self.attachments:
 			self.import_attachments(notebook, path, self.attachments)
 
-		if self.open_page_check.get_active():
+		if self.form['open_page']:
 			self.hide()
 			self.get_application().open_notebook(notebook, path)
 
@@ -448,7 +460,7 @@ class QuickNoteDialog(Dialog):
 
 	def _get_notebook(self):
 		uri = self.notebookcombobox.get_notebook()
-		notebook, x = build_notebook(LocalFolder(uri))
+		notebook, _ = build_notebook(LocalFolder(uri))
 		return notebook
 
 	def create_new_page(self, notebook, path, text):

--- a/zim/plugins/quicknote.py
+++ b/zim/plugins/quicknote.py
@@ -34,9 +34,9 @@ class QuickNotePluginCommand(GtkCommand):
 		('notebook=', '', 'Select the notebook in the dialog'),
 		('page=', '', 'Fill in full page name (e.g. "PageA:PageB")'),
 		('section=', '', 'Fill in the full page name under which the new page will be added.'),
-		('pagetitle=', '', 'Fill in the title of the new page'),
+		('title=', '', 'Fill in the title of the new page'),
 		('namespace=', '', '(deprecated) Same as "--section"'),
-		('basename=', '', '(deprecated) Same as "--pagetitle"'),
+		('basename=', '', '(deprecated) Same as "--title"'),
 		('append=', '', 'Set whether to append or create new page ("true" or "false")'),
 		('text=', '', 'Provide the text directly'),
 		('input=', '', 'Provide the text on stdin ("stdin") or take the text from the clipboard ("clipboard")'),
@@ -53,9 +53,9 @@ Options:
   --notebook URI         Select the notebook in the dialog
   --page STRING          Fill in full page name (e.g. "PageA:PageB") (--append=true)
   --section STRING       Fill in the full page name under which the new page will be added (--append=false)
-  --pagetitle STRING     Fill in the page or section title (requires --append=false)
+  --title STRING         Fill in the page or section title (requires --append=false)
   --namespace STRING     (deprecated) Same as "--section"
-  --basename STRING      (deprecated) Same as "--pagetitle"
+  --basename STRING      (deprecated) Same as "--title"
   --append [true|false]  Set whether to append or create new page
   --text TEXT            Provide the text directly
   --input stdin          Provide the text on stdin
@@ -95,8 +95,8 @@ Options:
 		if 'section' in self.opts:
 			self.opts['namespace'] = self.opts['section']
 				
-		if 'pagetitle' in self.opts:
-			self.opts['basename'] = self.opts['pagetitle']
+		if 'title' in self.opts:
+			self.opts['basename'] = self.opts['title']
 
 		if self.opts.get('attachments', None):
 			folderpath = LocalFolder(self.pwd).get_abspath(self.opts['attachments'])
@@ -137,6 +137,7 @@ Options:
 		dialog = QuickNoteDialog(None,
 			notebook=notebook,
 			namespace=self.opts.get('namespace'),
+			page=self.opts.get('page'),
 			basename=self.opts.get('basename'),
 			append=self.opts.get('append'),
 			text=self.opts.get('text', ''),
@@ -180,8 +181,6 @@ class QuickNoteDialog(Dialog):
 		page=None, namespace=None, basename=None,
 		append=None, text=None, template_options=None, attachments=None
 	):
-		assert page is None, 'TODO'
-
 		self.config = ConfigManager.get_config_dict('quicknote.conf')
 		self.uistate = self.config['QuickNoteDialog']
 
@@ -211,27 +210,30 @@ class QuickNoteDialog(Dialog):
 		self.notebookcombobox.connect('changed', self.on_notebook_changed)
 		self.form.attach(self.notebookcombobox, 1, 2, 0, 1)
 
-		self._init_inputs(namespace, basename, append, text, template_options)
+		self._init_inputs(namespace, basename, append, text, template_options, page)
 
 		self.uistate['lastnotebook'] = notebook
 		self._set_autocomplete(notebook)
 
-	def _init_inputs(self, namespace, basename, append, text, template_options, custom=None):
+	def _init_inputs(self, namespace, basename, append, text, template_options, pageToAppendTo=None, custom=None):
 		if template_options is None:
 			template_options = {}
 		else:
 			template_options = template_options.copy()
 
-		if namespace is not None and basename is not None:
-			page = namespace + ':' + basename
+		if pageToAppendTo is not None:
+			page = pageToAppendTo
 		else:
-			page = namespace or basename
+			if namespace is not None and basename is not None:
+				page = namespace + ':' + basename
+			elif pageToAppendTo is None:
+				page = namespace or basename
 
 		self.form.add_inputs((
 				('page', 'page', _('Page')), # T: text entry field; used if new_page is false.
 				('new_page', 'bool', _('Create a new page for each note')), # T: checkbox; if a new page should be created or not.
 				('namespace', 'namespace', _('Page section')), # T: text entry field; section when creating a new page.
-				('basename', 'string', _('Title')) # T: text entry field; pagetitle when creating a new page.
+				('basename', 'string', _('Title')) # T: text entry field; title when creating a new page.
 			))
 		self.form.update({
 				'page': page,

--- a/zim/plugins/quicknote.py
+++ b/zim/plugins/quicknote.py
@@ -242,7 +242,7 @@ class QuickNoteDialog(Dialog):
 				('new_page', 'bool', _('Create a new page for each note')), # T: checkbox; if a new page should be created or not.
 				('namespace', 'namespace', _('Page section')), # T: text entry field; section when creating a new page.
 				('basename', 'string', _('Title')), # T: text entry field; title when creating a new page.
-				('open_page', 'bool', _('Open page')), # T: checkbox; open page.
+				('open_page', 'bool', _('Open _page')), # T: checkbox; open page.
 			))
 		self.form.update({
 				'page': page,


### PR DESCRIPTION
ADD: The processing of the "--section"-option.
ADD: The use of the "--page"-option.
ADD: The option "--title" (alternative to "--basename".
MOD: Input elements are always visible in the dialog.
ADD: Unittests for the processing of the modified / added options.

resolves zim-desktop-wiki/zim-desktop-wiki#2575

I took the liberty of:
* making the input fields always visible but being active/inactive, dependent on the option for creating a new page,
* adding the option "--page", since it was mentioned in the "help",
* adding the option "--title", an alternative to "--basename",
* adding the option "--section", since it was mentioned in the "help".

Both "--title" and "--section" are alternatives. I deduced the workings of "--section" from the fact that "--namespace" was annotated with "backward compatibility".