### PR TITLE
Fix duplicate last line bug

### DIFF
--- a/tests/linesorter.py
+++ b/tests/linesorter.py
@@ -194,6 +194,12 @@ class TestLineSorterWindowExtension(tests.TestCase, TextBufferTestCaseMixin):
 		self.extension.duplicate_line()
 		self.assertEqual(self.get_text(), 'Line A\nLine B\nLine A\nLine B\nLine C\n')
 
+	def testDuplicateLastLine(self):
+		self.set_text('Line A\nLine B\nLast Line')
+		self.place_cursor(20)
+		self.extension.duplicate_line()
+		self.assertEqual(self.get_text(), 'Line A\nLine B\nLast Line\nLast Line')
+
 	def testDuplicateLineAvoidResetHeaderForBullet(self):
 		# Test case for specific issue seen #1457
 		# Effective testing pageview behavior, so might be in the wrong place

--- a/zim/plugins/linesorter.py
+++ b/zim/plugins/linesorter.py
@@ -182,12 +182,16 @@ class LineSorterPageViewExtension(PageViewExtension):
 
 	@action(_('_Duplicate Line'), accelerator='<Primary><Shift>D', menuhints='edit')  # T: Menu item
 	def duplicate_line(self):
-		'''Menu action to dublicate line'''
+		'''Menu action to duplicate line'''
 		buffer = self.pageview.textview.get_buffer()
 		start, end = self._get_iters_one_or_more_lines(buffer)
+		# Remove newline to standardize linedata text
+		if not end.is_end():
+			end.backward_char()
 		linedata = textbuffer_internal_serialize_range(buffer, start, end)
 		with buffer.user_action:
 			buffer.place_cursor(end)
+			buffer.insert_at_cursor('\n')
 			textbuffer_internal_insert_at_cursor(buffer, linedata)
 
 


### PR DESCRIPTION
The behavior of `Duplicate Line` from the Line Sorter plugin changed after 6c8e5a34a4409f689fe5ac09ac6087760abb93bb. When a line was duplicated, the cursor was placed at the end of the duplicated line, but now the cursor is placed at the start of the empty line below. This new behavior prevents duplicating a line multiple times in a row just by pressing the keyboard shortcut multiple times, something I use often.

In addition, I noticed that there was a problem with `Duplicate Line` when the command was issued on the last line of the page: the duplicated line would be pasted in the same line as the original. Here's the current behavior for both conditions, when duplicating a normal line in the middle of the page and when duplicating the last line of the page:

https://github.com/user-attachments/assets/ed17b8aa-ca32-4b80-9b06-9265095feebc

This pull request resolves both issues. It standardizes the position of the cursor to the end of the duplicated line to facilitate repeated line duplication and fixes the bug when duplicating the last line. Here's the behavior with the code from this pull request:

https://github.com/user-attachments/assets/2671cc14-b514-423f-9010-dd2cd9b691c1

I've also added a small test for checking the duplicate last line behavior.

Cheers,
Bruno