### PR TITLE
Feature : edit alt image

### DIFF
--- a/tests/pageview.py
+++ b/tests/pageview.py
@@ -3551,7 +3551,7 @@ class TestPageviewDialogs(tests.TestCase):
 			}
 		)
 		file = tests.ZIM_DATA_FOLDER.file('zim.png')
-		buffer.insert_image_at_cursor(file, '../MYPATH/./data/zim.png')
+		buffer.insert_image_at_cursor(file, '../MYPATH/./data/zim.png', alt='Alternate Text')
 		dialog = EditImageDialog(None, buffer, notebook, Path(':some_page'))
 		self.assertEqual(dialog.form['width'], 48)
 		self.assertEqual(dialog.form['height'], 48)
@@ -3564,11 +3564,14 @@ class TestPageviewDialogs(tests.TestCase):
 		dialog.form['height'] = 24
 		self.assertEqual(dialog.form['width'], 24)
 		self.assertEqual(dialog.form['height'], 24)
+		self.assertEqual(dialog.form['alt'], 'Alternate Text')
+		dialog.form['alt'] = 'New alternate Text'
 		dialog.assert_response_ok()
 		iter = buffer.get_iter_at_offset(0)
 		imagedata = buffer.get_image_data(iter)
 		self.assertEqual(imagedata, {
 			'src': './data/zim.png', # preserve relative path
+			'alt': 'New alternate Text',
 			'height': 24,
 		})
 		self.assertEqual(type(imagedata['height']).__name__, 'int')

--- a/zim/gui/pageview/dialogs.py
+++ b/zim/gui/pageview/dialogs.py
@@ -381,14 +381,16 @@ class EditImageDialog(Dialog):
 			src = src[:i]
 		href = image_data.get('href', '')
 		anchor = image_data.get('id', '')
+		alt = image_data.get('alt', '')
 		self.add_form([
 				('file', 'image', _('Location')), # T: Input in 'edit image' dialog
 				('href', 'link', _('Link to'), path), # T: Input in 'edit image' dialog
+				('alt', 'string', _('Alternate text')), # T: Input in 'edit image' dialog
 				('width', 'int', _('Width'), (0, 1)), # T: Input in 'edit image' dialog
 				('height', 'int', _('Height'), (0, 1)), # T: Input in 'edit image' dialog
 				('anchor', 'string', _('Id'))
 			],
-			{'file': src, 'href': href, 'anchor': anchor}
+			{'file': src, 'href': href, 'anchor': anchor, 'alt': alt}
 			# range for width and height are set in set_ranges()
 		)
 		self.form.widgets['file'].set_use_relative_paths(notebook, path)
@@ -484,6 +486,7 @@ class EditImageDialog(Dialog):
 
 		attrib = self._image_data
 		attrib['src'] = self.notebook.relative_filepath(file, self.path) or file.uri
+		attrib['alt'] = self.form['alt'] # TODO We should escape / protect from special chars
 
 		href = self.form['href']
 		if href:


### PR DESCRIPTION
The feature adds a text field in the image edit box to modify the alt text.

<img width="650" height="435" alt="Capture d’écran du 2025-11-13 20-47-10" src="https://github.com/user-attachments/assets/b75379f1-e5ac-4e0d-9fe8-a0c363f9764c" />
