### PR TITLE
Page Index, Tags: add option to enable lines in the tree view

### DIFF
--- a/data/manual/Plugins/PageIndex.txt
+++ b/data/manual/Plugins/PageIndex.txt
@@ -29,6 +29,10 @@ restart Zim to see the correct rendering.
 The option **Use tooltips** allows toggling whether or not tooltips are shown
 for pages in the index.
 
+The option **Show tree lines** allows toggling whether or not lines are drawn to
+visually connect subsections to their parent. For the full old-school experience,
+use a Gtk theme with zebra stripes.
+
 ===== Style =====
 
 This plugin uses a widget name to allow CSS styling for the floating widget:

--- a/data/manual/Plugins/Tags.txt
+++ b/data/manual/Plugins/Tags.txt
@@ -32,6 +32,10 @@ restart Zim to see the correct rendering.
 The option **Use tooltips** allows toggling whether or not tooltips are shown
 for pages in the index.
 
+The option **Show tree lines** allows toggling whether or not lines are drawn to
+visually connect subsections to their parent. For the full old-school experience,
+use a Gtk theme with zebra stripes.
+
 ===== Usage =====
 The tag index has 3 views:
 

--- a/zim/plugins/pageindex/__init__.py
+++ b/zim/plugins/pageindex/__init__.py
@@ -70,6 +70,8 @@ This plugin adds the page index pane to the main window.
 			# T: preferences option
 		('use_tooltip', 'bool', _('Use tooltips'), True),
 			# T: preferences option
+		('tree_lines', 'bool', _('Show tree lines'), False),
+			# T: preferences option
 	)
 
 
@@ -104,6 +106,7 @@ class PageIndexNotebookViewExtension(NotebookViewExtension):
 		self.treeview.set_use_ellipsize(not preferences['use_hscroll'])
 			# To use horizontal scrolling, turn off ellipsize
 		self.treeview.set_autoexpand(preferences['autoexpand'], preferences['autocollapse'])
+		self.treeview.set_enable_tree_lines(preferences['tree_lines'])
 
 	def on_page_changed(self, pageview, page):
 		treepath = self.treeview.set_current_page(page, vivificate=True)

--- a/zim/plugins/tags.py
+++ b/zim/plugins/tags.py
@@ -54,6 +54,8 @@ This plugin provides a page index filtered by means of selecting tags in a cloud
 			# T: preferences option
 		('use_tooltip', 'bool', _('Use tooltips'), True),
 			# T: preferences option
+		('tree_lines', 'bool', _('Show tree lines'), False),
+			# T: preferences option
 	)
 
 
@@ -90,6 +92,7 @@ class TagsNotebookViewExtension(NotebookViewExtension):
 		self.widget.treeview.set_use_ellipsize(not preferences['use_hscroll'])
 			# To use horizontal scrolling, turn off ellipsize
 		self.widget.treeview.set_autoexpand(preferences['autoexpand'], preferences['autocollapse'])
+		self.widget.treeview.set_enable_tree_lines(preferences['tree_lines'])
 
 
 class TagsPluginWidget(Gtk.VPaned, WindowSidePaneWidget):


### PR DESCRIPTION
Closes #2895. Zebra stripes are handled by the Gtk theme.


<img width="140" height="183" alt="image" src="https://github.com/user-attachments/assets/aa702f49-222f-4cf7-92ce-824c4b5105ec" />

They're off by default, though I'd argue having them on by default would be as swell to honor the legacy of 0.69.