### PR TITLE
setup.py: fix requires (xdg -> pyxdg)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -338,7 +338,7 @@ if __name__ == '__main__':
 		scripts = scripts,
 		packages = collect_packages(),
 		data_files = collect_data_files(),
-		requires = ['gi', 'xdg'],
+		requires = ['gi', 'pyxdg'],
 
 		**py2exeoptions
 	)


### PR DESCRIPTION
"import xdg.Mime" verifies that this is the actual dependency, not the deprecated xdg which is now called xdg-base-dirs. Closes #2847.