### PR TITLE
versioncontrol plugin : notebook properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ debian/python-module-stampdir/
 
 # Rider
 .vs
+
+.pylintrc
+.vscode/

--- a/data/manual/Plugins/Version_Control.txt
+++ b/data/manual/Plugins/Version_Control.txt
@@ -14,6 +14,13 @@ If the option **Autosave version when the notebook is closed** is enabled zim wi
 When the option **Autosave version on regular intervals** is enabled zim will save (or "commit") a new version after a set time interval. The **Autosave interval in minutes** gives the time interval.
 Saving at regular intervals also includes at the exit and at the start of the application.
 
+===== Override options for notebooks =====
+You can override those global options for a notebook by enabling the option **Override global preferences** in the [[Help:Properties|notebook properties panel]].
+
+Then you can redefine the plugin behavior for the current notebook.
+
+A basic usage for override will be if you want to enable autosave globally (for all notebooks) but you want to disable it on a specific notebook because it is part of a project already versionned and you don't want the zim commits to "interfere" with it.
+
 ===== Usage =====
 If you want to keep track of your changes or if you want to collaborate on a Zim notebook as a team, version control is the best way to go. Zim integrates very well with existing version control software because all relevant data is stored in plain text files.
 

--- a/tests/versioncontrol.py
+++ b/tests/versioncontrol.py
@@ -147,6 +147,36 @@ class TestMainWindowExtension(tests.TestCase):
 		tests.gtk_process_events()
 		assert ongoing_operation(notebook) is None
 
+@tests.skipUnless(
+	any(
+		map(VCS.check_dependencies, (VCS.BZR, VCS.GIT, VCS.HG))
+	), 'Missing dependencies')
+class TestOverridePreferences(tests.TestCase):
+	'''Testing reading plugin preferences and notebook properties override'''
+
+	def runTest(self):
+		'''Main test'''
+		plugin = PluginManager.load_plugin('versioncontrol')
+
+		dir = get_tmp_dir('versioncontrol_TestMainWindowExtension')
+		notebook = self.setUpNotebook(
+			mock=tests.MOCK_ALWAYS_REAL,
+			content=('Test',),
+			folder=LocalFolder(dir.path)
+		)
+
+		notebook_ext = find_extension(notebook, NotebookExtension)
+
+		## autosave
+		plugin.preferences['autosave'] = True
+		self.assertTrue(notebook_ext.get_preference('autosave'))
+
+		## override autosave
+		notebook_ext.properties['notebook_override'] = True
+		self.assertFalse(notebook_ext.get_preference('autosave'))
+		notebook_ext.properties['notebook_autosave'] = True
+		self.assertTrue(notebook_ext.get_preference('autosave'))
+
 
 @tests.slowTest
 class TestVersionsDialog(tests.TestCase):

--- a/zim/plugins/versioncontrol/__init__.py
+++ b/zim/plugins/versioncontrol/__init__.py
@@ -69,6 +69,13 @@ This is a core plugin shipping with zim.
 		('autosave_interval', 'int', _('Autosave interval in minutes'), 10, (1, 3600)), # T: Label for plugin preference
 	)
 
+	plugin_notebook_properties = (
+		('notebook_override', 'bool', _('Override global preferences'), False), # T: Label for notebook properties
+		('notebook_autosave', 'bool', _('Autosave version when the notebook is closed'), False), # T: Label for notebook preference
+		('notebook_autosave_at_interval', 'bool', _('Autosave version on regular intervals'), False), # T: Label for notebook preference
+		('notebook_autosave_interval', 'int', _('Autosave interval in minutes'), 10, (1, 3600)), # T: Label for notebook preference
+	)
+
 	@classmethod
 	def check_dependencies(klass):
 		has_bzr = VCS.check_dependencies(VCS.BZR)
@@ -83,6 +90,7 @@ class VersionControlNotebookExtension(NotebookExtension):
 
 	def __init__(self, plugin, notebook):
 		NotebookExtension.__init__(self, plugin, notebook)
+		self.properties = self.plugin.notebook_properties(notebook)
 		self.vcs = None
 		self.detect_vcs()
 
@@ -111,6 +119,15 @@ class VersionControlNotebookExtension(NotebookExtension):
 		if self.vcs:
 			self.vcs.disconnect_all()
 
+	def get_preference(self, name):
+		'''Get a preference value. It returns the notebook property if override is active or 
+		the plugin preference otherwise
+		@param name: str - name of the preference
+		@returns Value of the property / preference'''
+		if self.properties['notebook_override']:
+			return self.properties['notebook_' + name]
+		return self.plugin.preferences[name]
+
 
 class VersionControlMainWindowExtension(MainWindowExtension):
 
@@ -129,27 +146,29 @@ class VersionControlMainWindowExtension(MainWindowExtension):
 			self.on_preferences_changed(None, start=True)
 
 		def on_close(o):
-			if self.plugin.preferences['autosave'] \
-			or self.plugin.preferences['autosave_at_interval']:
+			if self.notebook_ext.get_preference('autosave') \
+			or self.notebook_ext.get_preference('autosave_at_interval'):
 				self.do_save_version()
 
 		self.window.connect('close', on_close)
 
 		self.connectto(self.plugin.preferences, 'changed',
 			self.on_preferences_changed)
+		self.connectto(self.notebook_ext.properties, 'changed',
+			self.on_preferences_changed)
 
 	def on_preferences_changed(self, o, start=False):
 		self._stop_timer()
 
-		if (start and self.plugin.preferences['autosave']) \
-		or self.plugin.preferences['autosave_at_interval']:
+		if self.notebook_ext.get_preference('autosave') \
+		or self.notebook_ext.get_preference('autosave_at_interval'):
 			self.do_save_version_async()
 
-		if self.plugin.preferences['autosave_at_interval']:
+		if self.notebook_ext.get_preference('autosave_at_interval'):
 			self._start_timer()
 
 	def _start_timer(self):
-		timeout = 60000 * self.plugin.preferences['autosave_interval']
+		timeout = 60000 * self.notebook_ext.get_preference('autosave_interval')
 		self._autosave_timer = GObject.timeout_add(
 			timeout, self.do_save_version_async)
 


### PR DESCRIPTION
The merge request adds notebook properties to the versioncontrol plugin : it allows to override global configuration on a notebook basis.

Use case : We enable autosave globally but we want to disable it on a specific notebook because it is part of a project already versionned and we don't want the zim commits to "interfere" with it.