### PR TITLE
Accept both image/png and image/apng MIME types for a PNG image

### DIFF
--- a/zim/newfs/base.py
+++ b/zim/newfs/base.py
@@ -574,7 +574,7 @@ mimetypes = None
 try:
 	import xdg.Mime as xdgmime
 	mytype = xdgmime.get_type('image.png', name_pri=80)
-	if str(mytype) != 'image/png':
+	if str(mytype) not in ('image/png', 'image/apng'):
 		# Even if xdg is installed, the database is not (always) initialized
 		logger.debug("Found 'xdg.Mime', but no database - falling back to 'mimetypes'")
 		xdgmime = None


### PR DESCRIPTION
On my platform, "image.png" is identified as an APNG (an animated PNG file). Since PNG is a valid filename extension [according to Wikipedia](https://en.wikipedia.org/wiki/APNG), I presume that this is not a bug in the MIME database and not an indication that no MIME database is present either.

However, this leads to zim not accepting the `xdg.Mime` module and failing to open certain files properly (e.g. FreeCAD files are not recognized that way) on my system.

This fix allows using the xdg.Mime module in environments where the `image/apng` type is selected for PNG images.