### PR TITLE
Fix garbage collected object_widgets weakref

### DIFF
--- a/zim/gui/pageview/textview.py
+++ b/zim/gui/pageview/textview.py
@@ -211,6 +211,7 @@ class TextView(Gtk.TextView):
 
 		self.add_child_at_anchor(widget, anchor)
 		self._object_widgets.add(widget)
+		weakref.finalize(widget, self.remove, widget)
 		widget.show_all()
 
 	def on_size_allocate(self, *a):


### PR DESCRIPTION
Since python-gobject 3.56 we get a KeyError about a weakref removal from Textview _object_widgets WeakSet.

Implement a weakref finalizer callback to remove the weakref object from the Textview children when it is garbage collected to avoid attempting removing it when already gone before filling the TextView buffer.

Closes #2934 