### PR TITLE
fix: handle generator returning no image file (closes #2960)

### DIFF
--- a/zim/plugins/base/imagegenerator.py
+++ b/zim/plugins/base/imagegenerator.py
@@ -156,6 +156,11 @@ class ImageGeneratorModel(ImageGeneratorModelBase):
 		# Do not clean up the existing self.image_file - we don't know if
 		# any other object is using the same file
 		# TODO: use index table to keep track and clean up when ref count is zero ?
+		if image_file is None:
+			# Generator returned no image (e.g. invalid input that did not raise
+			# an Error). Keep existing state rather than crashing on attribute access.
+			logger.warning('Image generator returned no image file; keeping previous state')
+			return
 		self.data = text
 		self.image_file = self._new_image_file()
 		image_file.moveto(self.image_file)
@@ -211,6 +216,12 @@ class BackwardImageGeneratorModel(ImageGeneratorModelBase):
 	def set_from_generator(self, text, image_file):
 		# FIXME: refactor the file saving sequence (save script first, generate image second); see #2112
 		self.script_file.write(text)
+		if image_file is None:
+			# Generator returned no image (e.g. invalid input that did not raise
+			# an Error). Keep existing state rather than crashing on attribute access.
+			logger.warning('Image generator returned no image file; keeping previous state')
+			self.emit('changed')
+			return
 		image_file = adapt_from_oldfs(image_file)
 		image_file._set_mtime(self.script_file.mtime())  # avoid needless regen
 

--- a/zim/plugins/base/imagegenerator.py
+++ b/zim/plugins/base/imagegenerator.py
@@ -157,8 +157,6 @@ class ImageGeneratorModel(ImageGeneratorModelBase):
 		# any other object is using the same file
 		# TODO: use index table to keep track and clean up when ref count is zero ?
 		if image_file is None:
-			# Generator returned no image (e.g. invalid input that did not raise
-			# an Error). Keep existing state rather than crashing on attribute access.
 			logger.warning('Image generator returned no image file; keeping previous state')
 			return
 		self.data = text
@@ -217,8 +215,6 @@ class BackwardImageGeneratorModel(ImageGeneratorModelBase):
 		# FIXME: refactor the file saving sequence (save script first, generate image second); see #2112
 		self.script_file.write(text)
 		if image_file is None:
-			# Generator returned no image (e.g. invalid input that did not raise
-			# an Error). Keep existing state rather than crashing on attribute access.
 			logger.warning('Image generator returned no image file; keeping previous state')
 			self.emit('changed')
 			return


### PR DESCRIPTION
Fixes #2960.

When an image generator (e.g. PlantUML plugin) returns `(None, log_file)` per the documented `generate_image` contract, both `ImageGeneratorModel.set_from_generator` and `BackwardImageGeneratorModel.set_from_generator` crashed with `AttributeError` on the first attribute access.

This guards both implementations: if the generator returned no image, log a warning and keep existing state instead of crashing.