### PR TITLE
Handle None image_file when generator legitimately fails (#2960)

### DIFF
--- a/tests/imagegenerators.py
+++ b/tests/imagegenerators.py
@@ -16,7 +16,8 @@ from zim.notebook import Path
 
 from zim.plugins import PluginManager
 from zim.plugins.base.imagegenerator import \
-	ImageGeneratorClass, ImageGeneratorDialog, BackwardImageGeneratorObjectType
+	ImageGeneratorClass, ImageGeneratorDialog, BackwardImageGeneratorObjectType, \
+	BackwardImageGeneratorModel, ImageGeneratorModel
 
 from zim.plugins.equationeditor import InsertEquationPlugin
 from zim.plugins.diagrameditor import InsertDiagramPlugin
@@ -31,6 +32,45 @@ def assertIsPNG(file):
 	with open(file.path, "rb") as fh:
 		data = fh.read(8)
 		assert data == b'\x89PNG\x0d\x0a\x1a\x0a', 'Not a PNG file: %s' % file.path
+
+
+class _StubImageGenerator(ImageGeneratorClass):
+	# Stub generator used to construct model instances without invoking
+	# external image-rendering commands.
+	imagefile_extension = '.png'
+
+	def generate_image(self, text):
+		return None, None
+
+
+class TestSetFromGeneratorAcceptsNoneImage(tests.TestCase):
+	# Regression test for #2960: when generate_image legitimately fails and
+	# returns None for the image file, set_from_generator must not crash with
+	# AttributeError. See ImageGeneratorClass.generate_image docstring, which
+	# documents that the image file may be None.
+
+	def testImageGeneratorModelSetFromGeneratorAcceptsNone(self):
+		notebook = self.setUpNotebook()
+		page = notebook.get_page(Path('Test'))
+		generator = _StubImageGenerator(tests.MockObject(), notebook, page)
+
+		model = ImageGeneratorModel(notebook, page, generator, {}, '')
+		# Must not raise AttributeError on None.moveto(...)
+		model.set_from_generator('some text', None)
+
+	def testBackwardImageGeneratorModelSetFromGeneratorAcceptsNone(self):
+		attachment_dir = self.setUpFolder()
+		attachment_dir.touch()
+		notebook = self.setUpNotebook()
+		notebook.get_attachments_dir = lambda *a: attachment_dir
+		page = notebook.get_page(Path('Test'))
+		generator = _StubImageGenerator(tests.MockObject(), notebook, page)
+
+		model = BackwardImageGeneratorModel(
+			notebook, page, generator, {'src': '_new_'}, '', 'test.txt'
+		)
+		# Must not raise AttributeError on None._set_mtime(...)
+		model.set_from_generator('some text', None)
 
 
 @tests.slowTest

--- a/zim/plugins/base/imagegenerator.py
+++ b/zim/plugins/base/imagegenerator.py
@@ -156,6 +156,10 @@ class ImageGeneratorModel(ImageGeneratorModelBase):
 		# Do not clean up the existing self.image_file - we don't know if
 		# any other object is using the same file
 		# TODO: use index table to keep track and clean up when ref count is zero ?
+		if image_file is None:
+			# Generator legitimately failed to produce an image; see issue #2960
+			# and the ImageGeneratorClass.generate_image docstring.
+			return
 		self.data = text
 		self.image_file = self._new_image_file()
 		image_file.moveto(self.image_file)
@@ -211,6 +215,11 @@ class BackwardImageGeneratorModel(ImageGeneratorModelBase):
 	def set_from_generator(self, text, image_file):
 		# FIXME: refactor the file saving sequence (save script first, generate image second); see #2112
 		self.script_file.write(text)
+		if image_file is None:
+			# Generator legitimately failed to produce an image; see issue #2960
+			# and the ImageGeneratorClass.generate_image docstring.
+			self.emit('changed')
+			return
 		image_file = adapt_from_oldfs(image_file)
 		image_file._set_mtime(self.script_file.mtime())  # avoid needless regen
 


### PR DESCRIPTION
Fixes #2960.

When an image generator plugin (PlantUML, equation, diagram, etc.) legitimately fails and returns `None` for the image file - as the `ImageGeneratorClass.generate_image` docstring explicitly documents is allowed - both `ImageGeneratorModel.set_from_generator` and `BackwardImageGeneratorModel.set_from_generator` crash with `AttributeError` on `None.moveto(...)` and `None._set_mtime(...)`.

This guards both methods so that a failed image generation no longer crashes Zim. A regression test exercising both code paths with a stub generator that returns `None` is added in `tests/imagegenerators.py`.