### PR TITLE
Add missing docstring to set_icon_search_path function

### DIFF
--- a/zim/gui/__init__.py
+++ b/zim/gui/__init__.py
@@ -15,6 +15,14 @@ from zim.config import data_dirs
 
 
 def set_icon_search_path():
+	'''Function to set the icon search path for the default icon theme.
+
+	This function appends directories containing icons to the search path
+	of the default Gtk icon theme. It checks for directories named "icons"
+	in the data directories provided by `data_dirs()`.
+
+	Called directly when this module is loaded.
+	'''
 	icon_theme = Gtk.IconTheme.get_default()
 	for dir in data_dirs():
 		if dir.folder('icons').exists():


### PR DESCRIPTION
## Problem
The public function `set_icon_search_path` in `zim/gui/__init__.py` was missing a docstring, which reduced code readability and made it harder for developers to understand its purpose and usage.

## Solution
Added a detailed docstring to the `set_icon_search_path` function to document its behavior. The docstring explains that the function sets the icon search path for the default Gtk icon theme by appending directories containing icons from `data_dirs()`, and that it is called directly when the module is loaded.

## Verification
This change only modifies documentation and does not alter the function's behavior or API. It can be verified by:
1. Reviewing the code to ensure the docstring accurately describes the function.
2. Running the existing test suite to confirm no regressions (e.g., using `pytest` or similar).