### PR TITLE
fix(arithmetic): keep grouped results from breaking GTK formatting

### DIFF
--- a/tests/arithmetic.py
+++ b/tests/arithmetic.py
@@ -5,7 +5,7 @@
 # by Patricio Paez <pp@pp.com.mx>
 
 import tests
-from zim.inc.arithmetic import feed
+from zim.inc.arithmetic import ParserGTK, feed
 
 
 class ArithmeticTest(tests.TestCase):
@@ -93,3 +93,34 @@ class ArithmeticTest(tests.TestCase):
 		W * Höhe=15
 		'''
 		self.assertEqual(feed(text), wanted)
+
+
+class MockTextBuffer:
+	'''Minimal stand-in for the parts of Gtk.TextBuffer used by writeResult()'''
+
+	def __init__(self):
+		self.inserted = None
+
+	def get_iter_at_line_offset(self, line, offset):
+		return (line, offset)
+
+	def insert(self, iter, text):
+		self.inserted = text
+
+
+class ArithmeticGtkGroupedResultTest(tests.TestCase):
+
+	def runTest(self):
+		'''Grouped results must not break the GTK result formatting'''
+		# AddCommas() groups thousands, so writeResult() must not feed
+		# the separators straight into float() - see issue #2994
+		for text, wanted in (
+			('1,000', '1,000'),
+			('-1,000', '-1,000'),
+			('15,625', '15,625'),
+			('1,501.5', '1,501.5'),
+			('10', '10'),
+		):
+			buffer = MockTextBuffer()
+			ParserGTK().writeResult(0, buffer, 0, 0, text)
+			self.assertEqual(buffer.inserted, wanted)

--- a/zim/inc/arithmetic.py
+++ b/zim/inc/arithmetic.py
@@ -488,8 +488,11 @@ class ParserGTK(Parser):
 
     def writeResult(self, i, textBuffer, start, end, text):
         'Write text in line i of lines from start to end offset.'
-        # Format decimals
-        formatted = f"{float(text):.{self.output_decimals}f}"
+        # Format decimals - strip the thousands separators added by
+        # AddCommas() first, float() does not accept them
+        formatted = f"{float(text.replace(',', '')):.{self.output_decimals}f}"
+        if ',' in text:
+            formatted = AddCommas(formatted)
         # Don't add unnecessary zeros
         if len(formatted) < len(text):
             text = formatted


### PR DESCRIPTION
Closes #2994

`evaluate()` returns thousands-grouped results (`AddCommas()`), but `ParserGTK.writeResult()` passed that string straight to `float()`, which raises `ValueError` on the separators. The caller's bare `except` swallowed it and logged `eval error`, so `500*2=` produced no result at all while `5*2=` worked.

The separators are now stripped before formatting and re-applied afterwards, so grouped output is preserved. The new test fails with the reported `ValueError: could not convert string to float: '1,000'` without the fix and passes with it.
