### PR TITLE
fix(markdown): parse fenced code block at end of file

### DIFF
--- a/tests/formats.py
+++ b/tests/formats.py
@@ -1116,6 +1116,20 @@ class TestMarkdownNativeFormat(tests.TestCase, TestFormatMixin):
 		self.assertIn('lang="python"', xml)
 		self.assertIn('def hello():', xml)
 
+	def testParseFencedCodeAtEndOfFile(self):
+		# The closing fence may be the last line of the file, without a
+		# trailing newline - see issue #3001
+		for input in (
+			'```python\ndef hello():\n    pass\n```',
+			'~~~python\ndef hello():\n    pass\n~~~',
+		):
+			parser = self.format.Parser()
+			tree = parser.parse(input)
+			xml = tree.tostring()
+			self.assertIn('<pre', xml)
+			self.assertIn('lang="python"', xml)
+			self.assertIn('def hello():', xml)
+
 	def testParseTable(self):
 		input = '| H1 | H2 |\n|---|---|\n| A | B |\n| C | D |\n'
 		parser = self.format.Parser()

--- a/zim/formats/markdown.py
+++ b/zim/formats/markdown.py
@@ -184,7 +184,7 @@ class MarkdownParser(object):
 			Rule(OBJECT, r'''
 				^[ \t]* `{3,} [ \t]* \{ (\S+) : [ \t]* (.*?) \} [ \t]* \n		# ```{type: params}
 				( (?:^.*\n)*? )													# body
-				^[ \t]* `{3,} [ \t]* \n											# closing ```
+				^[ \t]* `{3,} [ \t]* (?:\n|\Z)									# closing ```
 			''',
 				process=self.parse_object
 			),
@@ -192,7 +192,7 @@ class MarkdownParser(object):
 			Rule(VERBATIM_BLOCK, r'''
 				^[ \t]* (`{3,}) [ \t]* (.*?) \n					# opening backtick fence with optional info
 				( (?:^.*\n)*? )									# multi-line content
-				^[ \t]* `{3,} [ \t]* \n							# closing backtick fence
+				^[ \t]* `{3,} [ \t]* (?:\n|\Z)					# closing backtick fence
 			''',
 				process=self.parse_fenced_code
 			),
@@ -200,7 +200,7 @@ class MarkdownParser(object):
 			Rule(VERBATIM_BLOCK, r'''
 				^[ \t]* (~{3,}) [ \t]* (.*?) \n					# opening tilde fence with optional info
 				( (?:^.*\n)*? )									# multi-line content
-				^[ \t]* ~{3,} [ \t]* \n							# closing tilde fence
+				^[ \t]* ~{3,} [ \t]* (?:\n|\Z)					# closing tilde fence
 			''',
 				process=self.parse_fenced_code
 			),


### PR DESCRIPTION
Closes #3001

The markdown block parser required a newline after the closing fence, so a fenced code block that is the last thing in a `.md` file (no trailing newline) was never matched and fell through to the paragraph parser, rendering the raw backticks instead of a code block. Allowing the closing fence to be terminated by end of input as well fixes it for backtick fences, tilde fences and the zim object block.

`tests/formats.py::TestMarkdownNativeFormat::testParseFencedCodeAtEndOfFile` fails without the change (`'<pre' not found in ... <p>```python...`) and passes with it.
