### PR TITLE
Add indexes on files table to fix quadratic index check and re-index

### DIFF
--- a/zim/notebook/index/files.py
+++ b/zim/notebook/index/files.py
@@ -67,6 +67,10 @@ class FilesIndexer(SignalEmitter):
 
 			CONSTRAINT no_self_ref CHECK (parent <> id)
 		);
+		-- Partial index to find records that still need to be checked,
+		-- see FilesIndexChecker.check_iter() which queries per record
+		CREATE INDEX IF NOT EXISTS files_index_status
+			ON files(node_type, id) WHERE index_status > 0;
 		''')
 		row = self.db.execute('SELECT * FROM files WHERE id == 1').fetchone()
 		if row is None:
@@ -352,6 +356,10 @@ class FilesIndexChecker(object):
 		# this makes e.g. index links more efficient and robust
 		# sort by id to ensure parents are found before children
 
+		# NOTE: this query runs once per record, so it depends on the partial
+		# index "files_index_status" to avoid scanning the whole table each
+		# time - without that index the loop below is O(n^2) on the number of
+		# records and dominates the check time for large notebooks
 		while True:
 			row = self.db.execute(
 				'SELECT id, path, node_type, mtime, index_status FROM files'

--- a/zim/notebook/index/files.py
+++ b/zim/notebook/index/files.py
@@ -71,6 +71,14 @@ class FilesIndexer(SignalEmitter):
 		-- see FilesIndexChecker.check_iter() which queries per record
 		CREATE INDEX IF NOT EXISTS files_index_status
 			ON files(node_type, id) WHERE index_status > 0;
+		-- Partial index to find records that still need to be updated,
+		-- see FilesIndexer._update_iter_inner() which queries per record.
+		-- The index above does not serve that query: sqlite only uses a
+		-- partial index when it can prove the query implies the index
+		-- condition, and it does not derive "index_status > 0" from
+		-- "index_status = ?". The literal below is STATUS_NEED_UPDATE.
+		CREATE INDEX IF NOT EXISTS files_need_update
+			ON files(node_type, id) WHERE index_status = 2;
 		-- Index to look up the children of a folder, used when checking
 		-- and when updating the contents of a folder
 		CREATE INDEX IF NOT EXISTS files_parent ON files(parent);
@@ -100,6 +108,11 @@ class FilesIndexer(SignalEmitter):
 		# sort folders before files: first index structure, then contents
 		# this makes e.g. index links more efficient and robust
 		# sort by id to ensure parents are found before children
+
+		# NOTE: this query runs once per record, so it depends on the partial
+		# index "files_need_update" to avoid scanning the whole table each
+		# time - without that index the loop below is O(n^2) on the number of
+		# records and dominates the time of a full re-index
 		while True:
 			row = self.db.execute(
 				'SELECT id, path, node_type FROM files'

--- a/zim/notebook/index/files.py
+++ b/zim/notebook/index/files.py
@@ -71,6 +71,9 @@ class FilesIndexer(SignalEmitter):
 		-- see FilesIndexChecker.check_iter() which queries per record
 		CREATE INDEX IF NOT EXISTS files_index_status
 			ON files(node_type, id) WHERE index_status > 0;
+		-- Index to look up the children of a folder, used when checking
+		-- and when updating the contents of a folder
+		CREATE INDEX IF NOT EXISTS files_parent ON files(parent);
 		''')
 		row = self.db.execute('SELECT * FROM files WHERE id == 1').fetchone()
 		if row is None:
@@ -422,6 +425,8 @@ class FilesIndexChecker(object):
 		# This method adds more robustness for detecting new / missing files
 		# in cases where the folder mtime is not reliable. This is a issue seen
 		# a few times already on cloud synced and encrypted file systems.
+		# NOTE: this runs once per folder, so it depends on the "files_parent"
+		# index to avoid scanning the whole table for each folder
 		on_disk = folder.list_names()
 		in_index = sorted(os.path.basename(r['path'])
 			for r in self.db.execute('SELECT path FROM files WHERE parent = ?', (node_id,))


### PR DESCRIPTION
Startup on a notebook with ~10.600 files took ~30 seconds of CPU time here. A `cProfile` run showed 25,3 of those 30 seconds inside `sqlite3.Connection.execute`, with 21.214 of the calls coming from `FilesIndexChecker.check_iter()`. `posix.stat` accounted for 0,22 s and no page parsing happened at all, so this is not the indexer re-reading files - it is the index check querying the database.

The cause is that the [`files` table](https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/51937eb4afce1047e445b605289810cc39fd176c/zim/notebook/index/files.py#L58-L69) has no index at all, only the primary key and the implicit autoindex on `path`. Three loops query that table once per record or per folder, so each of them ends up quadratic on the number of records.

### 1. `check_iter()` - one full table scan per record

The loop queries for the next record to check:

```sql
SELECT id, path, node_type, mtime, index_status FROM files
 WHERE index_status > ? ORDER BY node_type, id
```

https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/51937eb4afce1047e445b605289810cc39fd176c/zim/notebook/index/files.py#L355-L361

`EXPLAIN QUERY PLAN` gives `SCAN files` + `USE TEMP B-TREE FOR ORDER BY`, and the query is repeated for every record, so the check is O(n^2). A partial index on the records that still need checking removes both the scan and the sort, and it shrinks as records are marked up-to-date - when the notebook is fully indexed the index is empty.

Measured with a stand-alone script replaying the same query loop against a table with the same schema (CPU time):

| records | before | after |
|---|---|---|
| 5.000 | 5,8 s | 0,9 s |
| 10.600 | 26,6 s | 1,7 s |
| 16.275 | 60,8 s | 2,5 s |
| 21.200 | 105,6 s | 3,8 s |

The 16.275 record row is interesting: the [Performance-large-notebook](https://github.com/zim-desktop-wiki/zim-desktop-wiki/wiki/Performance-large-notebook) wiki page documents a test with exactly 16.275 files where the background check took "~1 minute". That measurement appears to be this quadratic loop.

A plain composite index on `(index_status, node_type, id)` does *not* help (26,3 s vs 25,0 s without any index): the range condition on the leading column means the ordering still has to be built with a temporary B-tree. The partial index is what makes the difference.

Dropping the `ORDER BY` instead of adding an index is not enough either. Without it SQLite scans in rowid order and stops at the first matching row, but the records that are already up-to-date sit at the start of that scan, so the scan front keeps moving and the loop stays quadratic - only with cheaper steps (same table, 10.600 records, CPU time):

| query | plan | time |
|---|---|---|
| `ORDER BY`, no index | `SCAN files` + `USE TEMP B-TREE FOR ORDER BY` | 24,2 s |
| no `ORDER BY`, no index | `SCAN files` | 5,7 s |
| `ORDER BY` + partial index | `SCAN files USING INDEX files_index_status` | 1,7 s |
| no `ORDER BY` + partial index | `SCAN files USING INDEX files_index_status` | 1,6 s |

With the index in place the ordering costs nothing (1,7 s vs 1,6 s), because the index already returns the records in that order. And the ordering is worth keeping in `check_iter()`: checking a folder before its children means that when a folder is gone, the update drops the whole subtree at once, instead of `stat()`-ing each child that is about to disappear anyway.

### 2. `_check_folder_content()` - one full table scan per folder

The same pattern, one level up: [the method](https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/51937eb4afce1047e445b605289810cc39fd176c/zim/notebook/index/files.py#L413-L420) runs `SELECT path FROM files WHERE parent = ?` once per folder whose mtime is unchanged, and without an index on `parent` each call scans the whole table. This mostly hurts notebooks with many attachments, where the record count is far larger than the page count.

Measured with a real folder tree of `foo<N>/attach<NN>.bin` (21 attachments per folder) plus a matching `files` table, replaying the `listdir` and the query per folder (CPU time):

| folders | records | before |
|---|---|---|
| 1.000 | 23.001 | 1,3 s |
| 2.000 | 46.001 | 5,2 s |
| 3.000 | 69.001 | 14,6 s |
| 4.000 | 92.001 | 27,4 s |

With the index the 4.000 folder case goes from 27,4 s to 0,3 s. The same index also serves the other queries that select children by parent id, in `update_folder()` and `delete_folder()`.

### 3. `_update_iter_inner()` - one full table scan per record, while re-indexing

The same shape once more, this time in the indexer rather than the checker. The loop queries for the next record to update:

```sql
SELECT id, path, node_type FROM files
 WHERE index_status = ? AND path LIKE ?
 ORDER BY node_type, id
```

https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/51937eb4afce1047e445b605289810cc39fd176c/zim/notebook/index/files.py#L96-L102

The `files_index_status` index from part 1 does not serve this query. SQLite only uses a partial index when it can prove that the query implies the index condition, and it does not derive `index_status > 0` from `index_status = ?` - not even when the value is spelled out as a literal. So this loop kept doing a full table scan plus a temporary B-tree for the `ORDER BY` on every record.

Where the check loop is quadratic on every background check, this one is quadratic on every full re-index - which is what happens when a plugin that indexes page content changes its settings.

Profiling `zim --index` on a notebook of 7.400 pages, this single query accounts for 30 of the 40 seconds spent in sqlite. Replaying the same query loop against a table with the same schema (7.400 records, CPU time per query):

| | per query |
|---|---|
| before | 1,72 ms |
| after | 0,03 ms |

This adds a second partial index rather than adding a redundant `index_status > 0` term to the query. The condition of the new index is exactly the condition the loop selects on, so the query needs no change and the optimization cannot be lost by editing it later. The index covers only the records waiting for an update, so it is empty once the notebook is indexed, and replaying the loop with both partial indexes in place costs the same per iteration as with one.

### Cost and compatibility

Inserting 92.000 records goes from 0,23 s to 0,28 s and the database file grows from 3,7 MB to 4,8 MB.

No database migration is needed and `DB_VERSION` is left alone: all three `CREATE INDEX IF NOT EXISTS` statements are part of the script that already runs on every connect, so an existing `index.db` picks up the indexes on the first run without re-indexing. Verified on a database created with the old schema - the query plans switch to `USING INDEX files_index_status` and `SEARCH ... USING INDEX files_parent`, with all records left in place. Creating the index on a real `index.db` of ~10.600 records took 0,016 s.

I also added a comment at each of the three call sites, since the quadratic behaviour is not obvious when reading the loop and the dependency on the index is easy to lose.

### Testing

`./test.py` gives the same result on this branch as on an unmodified checkout: 1155 tests, 1 failure and 1 error, both unrelated to this change (a broken local `ditaa` binary and an untracked file in my working copy).

The analysis and the patch were prepared with AI assistance, as recorded in the `Co-Authored-By` trailers on the commits. The measurements and the test runs were reproduced locally before submitting.
