### PR TITLE
Use Gtk.Menu instead of Gtk.Popover for the edit bar menus

### DIFF
--- a/tests/pageview.py
+++ b/tests/pageview.py
@@ -2828,6 +2828,29 @@ Baz
 		self.assertFalse(pageview.edit_bar.get_property('visible'))
 		self.assertFalse(pageview.find_bar.get_property('visible'))
 
+	def testEditBarMenusAreMenuShells(self):
+		# Menu items in a Gtk.Popover register their mnemonics on the toplevel
+		# window instead of on the menu, because a popover is not a
+		# Gtk.MenuShell - so they shadow accelerators using the same key, also
+		# while the menu is closed. E.g. the "Heading 1" .. "Heading 5" items
+		# used to break the <Alt>1 .. <Alt>5 accelerators of the bookmarksbar
+		# plugin. See issue #2096.
+		def iter_widgets(widget):
+			yield widget
+			if isinstance(widget, Gtk.Container):
+				for child in widget.get_children():
+					yield from iter_widgets(child)
+
+		pageview = setUpPageView(self.setUpNotebook())
+		buttons = [
+			w for w in iter_widgets(pageview.edit_bar)
+				if isinstance(w, Gtk.MenuButton)
+		]
+		self.assertTrue(buttons) # ensure we are actually testing something
+		for button in buttons:
+			self.assertIsNone(button.get_popover())
+			self.assertIsInstance(button.get_popup(), Gtk.Menu)
+
 	def testShowFindWithAndWithoutSelection(self):
 		pageview = setUpPageView(self.setUpNotebook(), text='test 123\n')
 		buffer = pageview.textview.get_buffer()

--- a/zim/gui/pageview/editbar.py
+++ b/zim/gui/pageview/editbar.py
@@ -1,6 +1,7 @@
 # Copyright 2020 - 2022 Jaap Karssenberg <jaap.karssenberg@gmail.com>
 
 from gi.repository import Gtk
+from gi.repository import Gdk
 from gi.repository import Pango
 from gi.repository import Gio
 
@@ -193,10 +194,16 @@ class EditBar(EditActionMixin, Gtk.ActionBar):
 		hbox.add(Gtk.Image.new_from_icon_name('pan-down-symbolic', Gtk.IconSize.BUTTON))
 		button.add(hbox)
 
-		popover = Gtk.Popover()
-		popover.bind_model(menu)
-		popover.connect('closed', lambda o: self.pageview.grab_focus())
-		button.set_popover(popover)
+		button.set_use_popover(False)
+			# Use a real Gtk.Menu instead of a Gtk.Popover - a popover is not a
+			# Gtk.MenuShell, so GTK registers the mnemonics of its menu items
+			# on the toplevel window instead of on the menu itself. There they
+			# shadow accelerators using the same key, also while the menu is
+			# closed: e.g. the "Heading _1" .. "Heading _5" items shadow the
+			# "<Alt>1" .. "<Alt>5" accelerators of the bookmarksbar plugin.
+			# See issue #2096.
+		button.set_menu_model(menu)
+		button.get_popup().connect('deactivate', lambda o: self.pageview.grab_focus())
 
 		return button
 
@@ -251,16 +258,16 @@ class ToolBarEditBarManager(EditActionMixin, ConnectorMixin):
 		button.set_tooltip_text(label.replace('_', '')+'...') # icon button should always have tooltip
 		button.set_icon_name(icon_name)
 
-		popover = Gtk.Popover()
-		popover.bind_model(menu)
-		popover.set_relative_to(button)
-		def toggle_popover(button):
+		gtkmenu = Gtk.Menu.new_from_model(menu)
+			# Use a real Gtk.Menu instead of a Gtk.Popover, see comment in
+			# EditBar._create_menu_button() and issue #2096
+		gtkmenu.attach_to_widget(button, None)
+		def toggle_menu(button):
 			if button.get_active():
-				popover.popup()
-			else:
-				popover.popdown()
-		button.connect('toggled', toggle_popover)
-		popover.connect('closed', lambda o: button.set_active(False))
-		popover.connect('closed', lambda o: self.pageview.grab_focus())
+				gtkmenu.popup_at_widget(
+					button, Gdk.Gravity.SOUTH_WEST, Gdk.Gravity.NORTH_WEST, None)
+		button.connect('toggled', toggle_menu)
+		gtkmenu.connect('deactivate', lambda o: button.set_active(False))
+		gtkmenu.connect('deactivate', lambda o: self.pageview.grab_focus())
 
 		return button


### PR DESCRIPTION
Fixes #2096

## Problem

With the BookmarksBar plugin enabled, `<Alt>1` .. `<Alt>5` do nothing at all - no
action is run and nothing shows up in the debug log - while `<Alt>6` .. `<Alt>9`
work fine. Bisecting points at 60577049, the commit that introduced the edit bar.

## Root cause

The edit bar builds its "List" / "Heading" / "Insert" dropdowns as a `Gio.Menu`
bound to a `Gtk.Popover`. Menu items in a popover end up with mnemonics on the
toplevel window, where they shadow accelerators using the same key:

1. `Gtk.Popover.bind_model()` creates a `GtkModelButton` per item and binds the
   item `label` to the button `text` property (`gtkmenusectionbox.c:310`).
2. `gtk_model_button_set_text()` applies the text with
   `gtk_label_set_text_with_mnemonic()` (`gtkmodelbutton.c:406`), so the "_" in
   `Heading _1` .. `Heading _5` really does define a mnemonic.
3. A popover is not a `GtkMenuShell` - `_gtk_window_add_popover()` does
   `gtk_widget_set_parent (popover, GTK_WIDGET (window))` (`gtkwindow.c:12552`).
   So in `gtk_label_setup_mnemonic()` (`gtklabel.c:1890`) the
   `_gtk_menu_shell_add_mnemonic()` branch is skipped and
   `gtk_window_add_mnemonic()` is used instead: the mnemonics `1` .. `5` are
   registered on the main window, and stay registered while the menu is closed.
4. `gtk_window_activate_key()` (`gtkwindow.c:12071`) breaks out of its lookup
   loop on the first mnemonic entry and never looks at accelerators:

   ```c
   if (entry->is_mnemonic) { if (enable_mnemonics) { found_entry = entry; break; } }
   else                    { if (enable_accels && !found_entry) found_entry = entry; }
   ```

   Activating the mnemonic then fails silently, because the menu items are not
   mapped while the popover is closed. The key press is lost between the two
   mechanisms.

The edit bar is constructed unconditionally in `PageView.__init__()` and only
hidden afterwards, so this also happens when the edit bar is disabled in the
preferences, and equally in the "classic" toolbar mode, which shares the same
menu models.

Headings only go up to 5, which is exactly why `<Alt>6` .. `<Alt>9` are
unaffected. `<Alt>D` of the journal plugin survives by luck: the mnemonic was
dropped from the "Date and Time..." item in the same commit 60577049.
Mnemonic-vs-mnemonic conflicts (e.g. `_Image...` vs the `_Insert` menu) degrade
gracefully, because `_gtk_mnemonic_hash_activate()` skips unmapped widgets and
moves on to the next candidate - only mnemonic-vs-accelerator is fatal.

## Fix

Use a real `Gtk.Menu` for these three dropdowns instead of a `Gtk.Popover`, so
GTK scopes their mnemonics to the menu itself. `Gtk.MenuButton` builds the menu
from the same `Gio.Menu` model via `set_use_popover(False)` +
`set_menu_model()`; the toolbar variant uses `Gtk.Menu.new_from_model()` with
`popup_at_widget()`.

This fixes the cause rather than the symptom: any item added to these menus
later would otherwise start shadowing an accelerator again.

Two alternatives were considered and rejected:

- Stripping the "_" from the labels that go into the popover models. Simple, but
  it only papers over the problem and drops mnemonic selection inside the open
  menu.
- Binding the menu model only while the popover is open. Keeps the popover look,
  but the menu items then no longer resolve their `pageview.*` actions reliably,
  and it did not survive testing.

Trade-off of the chosen approach: the dropdowns now look like classic menus
rather than popovers. If the popover look is preferred, I am happy to rework
this into one of the alternatives above.

## Testing

- `python3 test.py pageview` passes, no regressions.
- Added a regression test asserting these dropdowns are real menus rather than
  popovers.
- Verified manually on Linux / GTK 3.24: `<Alt>1` .. `<Alt>5` reach the
  bookmarksbar actions again (`Action: bookmark_1` etc. show up in the debug
  log), and the List / Heading / Insert menus open and their items work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
