### PR TITLE
Use the shared "page access" context menu in the backlinks pane

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -67,7 +67,7 @@ __all__ = [
 	'preferencesdialog', 'searchdialog', 'customtools', 'templateeditordialog',
 	'main', 'plugins',
 	# Plugins
-	'pathbar', 'pageindex', 'toolbar',
+	'pathbar', 'pageindex', 'toolbar', 'backlinkpane',
 	'journal', 'printtobrowser', 'versioncontrol', 'inlinecalculator',
 	'tasklist', 'tags', 'imagegenerators', 'tableofcontents',
 	'quicknote', 'attachmentbrowser', 'insertsymbol',

--- a/tests/backlinkpane.py
+++ b/tests/backlinkpane.py
@@ -1,0 +1,37 @@
+import tests
+
+from gi.repository import Gtk
+
+from zim.notebook import Path
+from zim.plugins import PluginManager
+
+from zim.plugins.backlinkpane import BackLinksWidget, TEXT_COL
+
+
+class TestBackLinksWidget(tests.TestCase):
+
+	def setUp(self):
+		self.notebook = self.setUpNotebook(content={
+			'Test': 'Link to [[Foo]]\n',
+			'Foo': 'Test page\n',
+		})
+		plugin = PluginManager.load_plugin('backlinkpane')
+		self.widget = BackLinksWidget(tests.MockObject(), plugin.preferences)
+		self.widget.set_page(self.notebook, Path('Foo'))
+
+	def testShowsBackLinks(self):
+		model = self.widget.treeview.get_model()
+		self.assertEqual([row[TEXT_COL] for row in model], ['Test'])
+
+	def testContextMenuHasPageActions(self):
+		# Used to be a single hard-coded "Open in New Window" item
+		treeview = self.widget.treeview
+		treeview.get_selection().select_path(Gtk.TreePath((0,)))
+		menu = treeview.get_popup()
+		self.assertIsInstance(menu, Gtk.Menu)
+		self.assertGreater(len(menu.get_children()), 1)
+
+	def testNoContextMenuWithoutSelection(self):
+		treeview = self.widget.treeview
+		treeview.get_selection().unselect_all()
+		self.assertIsNone(treeview.get_popup())

--- a/zim/plugins/backlinkpane.py
+++ b/zim/plugins/backlinkpane.py
@@ -12,7 +12,8 @@ from zim.notebook import Path, LINK_DIR_BACKWARD
 from zim.notebook.index import IndexNotFoundError
 
 from zim.gui.pageview import PageViewExtension
-from zim.gui.widgets import RIGHT_PANE, PANE_POSITIONS, BrowserTreeView, populate_popup_add_separator, \
+from zim.gui.uiactions import UIActions, PAGE_ACCESS_ACTIONS
+from zim.gui.widgets import RIGHT_PANE, PANE_POSITIONS, BrowserTreeView, \
 	WindowSidePaneWidget, StatusPage
 
 
@@ -77,6 +78,7 @@ class BackLinksWidget(Gtk.ScrolledWindow, WindowSidePaneWidget):
 
 		self.opener = opener
 		self.preferences = preferences
+		self.notebook = None
 
 		self._stack = Gtk.Stack()
 		self.treeview = LinksTreeView()
@@ -93,6 +95,7 @@ class BackLinksWidget(Gtk.ScrolledWindow, WindowSidePaneWidget):
 		self.treeview.connect('populate-popup', self.on_populate_popup)
 
 	def set_page(self, notebook, page):
+		self.notebook = notebook
 		model = self.treeview.get_model()
 		model.clear()
 
@@ -138,20 +141,21 @@ class BackLinksWidget(Gtk.ScrolledWindow, WindowSidePaneWidget):
 		self.opener.open_page(path)
 
 	def on_populate_popup(self, treeview, menu):
-		populate_popup_add_separator(menu)
-
-		item = Gtk.MenuItem.new_with_mnemonic(_('Open in New _Window'))
-		item.connect('activate', self.on_open_new_window, treeview)
-		menu.append(item)
-
-		# Other per page menu items do not really apply here...
-		menu.show_all()
-
-	def on_open_new_window(self, o, treeview):
 		model, iter = treeview.get_selection().get_selected()
-		if model and iter:
-			path = model[iter][PAGE_COL]
-			self.opener.open_page(path, new_window=True)
+		if model is None or iter is None:
+			return # E.g. right click below the last row
+
+		# Use the "access" actions, not the full page menu: this is a list of
+		# pages that refer to the current page, so e.g. "Delete Page" would
+		# remove the page from the notebook, not the link from the list
+		uiactions = UIActions(
+			self,
+			self.notebook,
+			model[iter][PAGE_COL],
+			self.opener,
+		)
+		uiactions.populate_menu_with_actions(PAGE_ACCESS_ACTIONS, menu)
+		menu.show_all()
 
 
 class LinksTreeView(BrowserTreeView):


### PR DESCRIPTION
The context menu of the BackLinks pane offers a single item, "Open in New Window", while the page index tree offers the full page menu. The Journal pane shows the same full menu, since it embeds `PageTreeView` from the pageindex plugin.

## Why it is like that

The menu is assembled by hand, and the accompanying comment says the other items do not apply:

https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/51937eb4afce1047e445b605289810cc39fd176c/zim/plugins/backlinkpane.py#L140-L153

That comes from 0790b449 (2012-07-21), which added this handler - and in the same commit dropped the TODO that used to sit on the tree view class:

```diff
 class LinksTreeView(BrowserTreeView):
-	## TODO common base class with page index for popup menus etc. ?
```

At that time the only alternative was the full page menu, so the comment was fair: offering "Delete Page" in a list of referring pages is confusing at best.

Since 00363f63 ("More specific context menus for pageindex and pathbar", see #683) there is a menu definition for exactly this situation:

https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/51937eb4afce1047e445b605289810cc39fd176c/data/menubar.xml#L193-L200

It is currently used by the pathbar only. The reasoning in that commit message - *"'remove page' does remove the page from the notebook, not just from the pathbar"* - applies to the backlinks pane word for word, with "the list" in place of "the pathbar".

## What this changes

The pane now uses `UIActions.populate_menu_with_actions(PAGE_ACCESS_ACTIONS, menu)`, the same call the pathbar makes. The context menu goes from one item to four: "Open in New Window", "Search section", "Search backlinks", "Copy Location".

The destructive items of the full page menu are deliberately left out, for the reason above. "New Page Here" and "New Sub Page" are left out as well - there is no meaningful "here" in a list of backlinks.

The hand-rolled `on_open_new_window()` handler is gone, since `open_new_window` is part of the menu definition. The widget now keeps a reference to the notebook, which `UIActions` needs and which it previously only received as an argument to `set_page()`.

One side effect: no menu is shown when the right click did not land on a row. Previously the lone "Open in New Window" item was shown there, and did nothing - its handler bailed out on the empty selection.

## Testing

`python3 test.py backlinkpane` passes. The plugin had no test module, so this adds `tests/backlinkpane.py` with three cases: backlinks are listed, the context menu contains more than one item, and no menu is built without a selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
