### PR TITLE
Keep list numbering intact when moving lines in a numbered list

### DIFF
--- a/tests/linesorter.py
+++ b/tests/linesorter.py
@@ -157,6 +157,74 @@ class TestLineSorterWindowExtension(tests.TestCase, TextBufferTestCaseMixin):
 		self.extension.move_line_down()
 		self.assertEqual(self.get_text(), 'C line\nA line\nB line\ntrailing text\n')
 
+	# In a numbered list the bullet belongs to the position, not to the line,
+	# so moving a line must not take its number along
+
+	NUMBERED_LIST = (
+		'<li indent="0" style="numbered-list">'
+		'1. foo\n2. bar\n3. baz\n4. x\n</li>'
+	)
+
+	def testMoveDownInNumberedList(self):
+		self.set_buffer(self.buffer, self.NUMBERED_LIST)
+		self.place_cursor(16) # on "baz"
+		self.extension.move_line_down()
+		self.assertBufferEqual(self.buffer,
+			'<li indent="0" style="numbered-list">'
+			'1. foo\n2. bar\n3. x\n4. baz\n</li>'
+		)
+
+	def testMoveUpInNumberedList(self):
+		self.set_buffer(self.buffer, self.NUMBERED_LIST)
+		self.place_cursor(16) # on "baz"
+		self.extension.move_line_up()
+		self.assertBufferEqual(self.buffer,
+			'<li indent="0" style="numbered-list">'
+			'1. foo\n2. baz\n3. bar\n4. x\n</li>'
+		)
+
+	def testMoveFirstItemOfNumberedListKeepsListStart(self):
+		# Moving the first item used to leave the list starting at "2.",
+		# which survives saving because the first bullet defines the start
+		self.set_buffer(self.buffer, self.NUMBERED_LIST)
+		self.place_cursor(3) # on "foo"
+		self.extension.move_line_down()
+		self.assertBufferEqual(self.buffer,
+			'<li indent="0" style="numbered-list">'
+			'1. bar\n2. foo\n3. baz\n4. x\n</li>'
+		)
+
+	NESTED_NUMBERED_LIST = (
+		'<li indent="0" style="numbered-list">1. foo\n2. bazooka\n</li>'
+		'<li indent="1" style="numbered-list">a. abc\nb. def\nc. hij\n</li>'
+		'<li indent="0" style="numbered-list">3. bar\n</li>'
+	)
+
+	def testMoveUpOutOfNestedNumberedList(self):
+		# The line ends up on the position of a list item one level up - its
+		# own bullet style and indent must survive that
+		self.set_buffer(self.buffer, self.NESTED_NUMBERED_LIST)
+		self.place_cursor(22) # on "abc"
+		self.extension.move_line_up()
+		self.assertEqual(self.get_text().splitlines()[:3], ['1. foo', 'a. abc', '2. bazooka'])
+		self.assertEqual(self.buffer.get_bullet(1), 'a.')
+		self.assertEqual(self.buffer.get_indent(1), 1)
+
+	def testMoveUpWithinNestedNumberedList(self):
+		self.set_buffer(self.buffer, self.NESTED_NUMBERED_LIST)
+		self.place_cursor(29) # on "def"
+		self.extension.move_line_up()
+		self.assertEqual(self.get_text().splitlines()[2:5], ['a. def', 'b. abc', 'c. hij'])
+
+	def testMoveInNumberedListIsSingleUndoStep(self):
+		# Renumbering used to add an undo group per corrected bullet
+		self.set_buffer(self.buffer, self.NUMBERED_LIST)
+		self.buffer.undostack.clear_undostack()
+		self.place_cursor(16) # on "baz"
+		self.extension.move_line_up()
+		self.buffer.undostack.undo()
+		self.assertBufferEqual(self.buffer, self.NUMBERED_LIST)
+
 	def testNothingHappensMoveUpAtStart(self):
 		self.set_text('A line\nB line\nC line\n')
 		self.select_range(3, 11)

--- a/zim/plugins/linesorter.py
+++ b/zim/plugins/linesorter.py
@@ -8,11 +8,28 @@ from zim.actions import action
 from zim.base.naturalsort import natural_sort_key
 from zim.gui.pageview import PageViewExtension
 from zim.gui.pageview.serialize import textbuffer_internal_serialize_range, textbuffer_internal_insert_at_cursor
+from zim.gui.pageview.textbuffer import is_numbered_bullet_re
 
 
 #~ import logging
 
 #~ logger = logging.getLogger('zim.plugins.linesorter')
+
+
+def _numbered_bullet_kind(bullet):
+	'''Tell apart the styles of numbered bullet
+	@param bullet: a bullet, as returned by C{TextBuffer.get_bullet()}
+	@returns: C{"number"} for "1.", C{"letter"} for "a.", C{"auto"} for "#.",
+	or C{None} if this is not a numbered bullet at all
+	'''
+	if bullet is None or not is_numbered_bullet_re.match(bullet):
+		return None
+	elif bullet[0].isdigit():
+		return 'number'
+	elif bullet[0] == '#':
+		return 'auto'
+	else:
+		return 'letter'
 
 
 class LineSorterPlugin(PluginClass):
@@ -125,6 +142,17 @@ class LineSorterPageViewExtension(PageViewExtension):
 			cursor = buffer.get_insert_iter()
 			cursor_offset = cursor.get_line_offset()
 
+		# In a numbered list the bullet belongs to the position, not to the
+		# line - so remember the number of the top most line we are about to
+		# touch. Without this the moved line takes its old number along and
+		# the automatic renumbering has no way to tell what the list started
+		# with.
+		first_line = start.get_line()
+		top_line = min(first_line, first_line + offset)
+		top_bullet = buffer.get_bullet(top_line)
+		top_kind = _numbered_bullet_kind(top_bullet)
+		top_indent = buffer.get_indent(top_line)
+
 		# get copy tree
 		assert start.starts_line()
 		linedata = textbuffer_internal_serialize_range(buffer, start, end)
@@ -155,6 +183,17 @@ class LineSorterPageViewExtension(PageViewExtension):
 			iter = buffer.get_insert_iter()
 			if not iter.starts_line():
 				buffer.insert_at_cursor('\n')
+
+			# Give the top most affected line its original number back and
+			# renumber the list from there. Lines above it were not touched,
+			# so "top_line" is still valid. Only do so when the line that ended
+			# up there belongs to the same list: same indent level and same
+			# style of numbering. Else we would e.g. turn a checkbox into a
+			# number, or renumber a sub list item with the number of its parent
+			if top_kind is not None \
+			and _numbered_bullet_kind(buffer.get_bullet(top_line)) == top_kind \
+			and buffer.get_indent(top_line) == top_indent:
+				buffer.set_bullet(top_line, top_bullet) # also renumbers downward
 
 			# redo selection/place cursor at same position
 			if has_selection:


### PR DESCRIPTION
Moving lines inside a numbered list with "Move Line Up" / "Move Line Down" breaks the numbering. Starting from:

```
1. foo
2. bar
3. baz
4. x
5. y
6. z
```

with the cursor on `baz`, moving the line **up** gives:

```
1. foo
3. baz
4. bar
5. x
6. y
7. z
```

Moving the **first** item down leaves the list starting at `2.`, and unlike the case above that one survives saving.

Moving a line **down** produces correct numbers, but takes three undo steps to revert.

## Cause

In a numbered list the bullet belongs to the position, not to the line. `move_line()` serializes the line including its bullet and re-inserts it elsewhere, so the number travels with the text:

https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/51937eb4afce1047e445b605289810cc39fd176c/zim/plugins/linesorter.py#L128-L145

The automatic renumbering is supposed to clean that up. On delete, the buffer queues the line to check:

https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/51937eb4afce1047e445b605289810cc39fd176c/zim/gui/pageview/textbuffer.py#L2256-L2259

and works through the queue once the user action ends:

https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/51937eb4afce1047e445b605289810cc39fd176c/zim/gui/pageview/textbuffer.py#L381-L399

That queue holds a plain line number. It is captured before the line is re-inserted, and re-inserting shifts the lines below the insert point. When moving down the insert happens below the recorded line, so the number stays valid by accident. When moving up everything shifts by one, renumbering starts one line too low, never looks at the moved line, and renumbers the rest from the wrong base.

The first-item case is different: there the recorded line is fine, but the line that ended up on top brought its own number along. `renumber_list()` treats the bullet of the first item of a list as the start of that list - which is correct in general, a list may legitimately start at "5." - so the list is renumbered from that number. On save the wiki dumper takes the start of the list from the first bullet as well, which is why this one persists:

https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/51937eb4afce1047e445b605289810cc39fd176c/zim/formats/plain.py#L151-L157

The undo granularity has the same origin: every bullet the renumbering corrects goes through `_replace_bullet()`, which opens its own user action:

https://github.com/zim-desktop-wiki/zim-desktop-wiki/blob/51937eb4afce1047e445b605289810cc39fd176c/zim/gui/pageview/textbuffer.py#L1244-L1246

Called from the `end-user-action` handler the counter is already back at zero, so this is a new user action rather than a nested one, and `UndoStackManager` closes the current group for each of them.

## Fix

Lines above the top most affected position are not touched by a move, so the line number of that position stays valid across the operation. Remember the number that was there before the move, put it back afterwards, and let `set_bullet()` renumber downward from there.

This is only done when the line that ended up on that position belongs to the same list - same indent level and same style of numbering. Both checks are needed: `is_numbered_bullet_re` matches `a.` as well as `1.`, so without them moving a sub list item past its parent would rewrite its `a.` into the `2.` of the parent. Moves within a checkbox or bullet list are not affected at all.

The undo granularity is fixed as a side effect: the deferred renumbering now finds the numbers already correct and makes no changes of its own, so the whole move is a single undo step.

## Alternative considered

Detecting that two numbered items are swapped and exchanging only their text, leaving the bullets untouched, would avoid renumbering altogether. It is arguably the better model, but it only covers the single-line same-level case, while `move_line()` also handles multi-line selections, moves in and out of lists and moves across indent levels - and swapping text rather than lines would silently change which indent the text ends up at. That looked like a rewrite of `move_line()` rather than a fix, so this patch stays with the smaller change.

## Testing

`python3 test.py linesorter` and `python3 test.py pageview` pass. Six test cases are added: moving down, moving up, moving the first item of a list, reverting a move in a single undo step, moving a sub list item past its parent, and moving within a sub list. Also verified by hand in the GUI, including that the numbering survives save and reload.

Known limitation, not a regression: when the length of a bullet changes (`10.` -> `9.`) the restored cursor column can be off by one character. The previous code had the same behaviour via the deferred renumbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
