### PR TITLE
Add index to look up pages by tag

### DIFF
--- a/zim/notebook/index/tags.py
+++ b/zim/notebook/index/tags.py
@@ -73,6 +73,14 @@ class TagsIndexer(IndexerBase):
 
 				CONSTRAINT uc_TagSourceOnce UNIQUE (source, tag)
 			);
+			-- Index to look up the pages that have a given tag. The unique
+			-- constraint above only serves the opposite direction: it starts
+			-- with "source", so sqlite cannot use it to search by tag and
+			-- falls back to scanning the whole table. Selecting by tag is
+			-- used a lot - e.g. by the tree models of the Tags plugin, which
+			-- locate a page below each of its tags for every page that is
+			-- indexed. Including "source" makes the index cover those queries.
+			CREATE INDEX IF NOT EXISTS tagsources_tag ON tagsources(tag, source);
 		''')
 
 	def on_page_changed(self, pagesindexer, pagerow, doc):


### PR DESCRIPTION
The `tagsources` table only has the unique constraint on `(source, tag)`.
That serves lookups by page, but not the opposite direction: sqlite cannot
use an index whose leading column is not constrained, so every query that
selects by tag scans the whole table.

Selecting by tag is not rare. The tree models of the Tags plugin do it for
every page they see: on each `page-row-changed` they locate the page below
each of its tags, which needs a `COUNT` over the pages carrying that tag.
While typing, that happens for every tag on the page being edited. During a
full re-index it happens once per page.

### Measurements

Profiling the start of the GUI against a missing index, on a notebook of
7.400 pages with the Tags plugin enabled. Same run, before and after:

| | before | after |
| --- | --- | --- |
| `TagsTreeModelMixin._find_all_pages()` | **33,0 s** | **7,3 s** |
| ... of which inside sqlite (123.955 queries either way) | 25,8 s | **1,0 s** |
| `TagsTreeModelMixin.on_tag_added_to_page()` | 13,3 s | 2,5 s |
| `PagesTreeModelMixin.on_page_row_changed()` | 22,3 s | 10,0 s |
| all `sqlite3.Connection.execute()` | 42,1 s | 16,2 s |
| total work in the run | 105,2 s | 77,0 s |

Before this patch `_find_all_pages()` was the single largest item in the
profile: 33 of 105 seconds. The number of queries is unchanged - they just
stop scanning the table.

The last row varies by up to 16% between runs of the same build here
(filesystem cache, background load), so treat it as an order of magnitude
rather than a measurement. The per-function numbers above it are stable.

The cost that is removed grows with the size of the whole `tagsources` table
rather than with the number of pages carrying the tag, so it gets worse as a
notebook accumulates tags. The query plan changes from `SCAN tagsources` to
`SEARCH tagsources USING COVERING INDEX tagsources_tag (tag=?)`. Adding
`source` as the second column is what makes it covering for the queries that
only read source ids, which is most of them.

Lookups by page are unaffected - they keep using the unique constraint,
measured unchanged. The only cost is maintaining a second b-tree when tags
are added to or removed from a page.

### Possibly fixes #2950

That report describes long lags while typing on pages with many tags
("~10 second pauses every 5-10 seconds on a page with ~1200 lines and ~1200
tags"), on a notebook of only 262 pages - and ends with "I then disabled the
*tags* plugin - and there is no performance problem anymore".

That matches this code path: the queries above are issued by the tree models
of the Tags plugin and by nothing else, and their cost scales with the number
of tags rather than with the number of pages. I have not been able to verify
against the reporter's notebook, so this is a plausible cause rather than a
confirmed one.

### Compatibility

No database migration is needed: the `CREATE INDEX` statement is part of the
script that runs on every connect, so a database written by an older version
gets the index the next time the notebook is opened. Verified by dropping the
index from an existing database and re-opening it.

`python3 test.py` passes.
