### PR TITLE
Do not rebuild the task list twice, or while it is not visible

### DIFF
--- a/tests/tasklist.py
+++ b/tests/tasklist.py
@@ -527,6 +527,71 @@ class TestTaskList(tests.TestCase):
 
 		# TODO test filtering for tags, labels, string - all case insensitive
 
+	def _setUpTaskListWidget(self):
+		plugin = PluginManager.load_plugin('tasklist')
+		notebook = self.setUpNotebook(content=tests.FULL_NOTEBOOK)
+		notebook.index.check_and_update()
+
+		widget = TaskListWidget(
+			notebook.index,
+			tests.MockObject(), # opener
+			plugin.notebook_properties(notebook),
+			False, # show_inbox_next
+			notebook.state['TaskListWidget'],
+			tests.MockObject(), # show_dialog_action
+		)
+		return widget
+
+	def _listTaskIds(self, widget):
+		ids = []
+
+		def collect(model, path, iter):
+			ids.append(model[iter][TASKID_COL])
+
+		widget.tasklisttreeview.real_model.foreach(collect)
+		return ids
+
+	def _countRefresh(self, widget):
+		counts = {}
+
+		def wrap(key, view):
+			counts[key] = 0
+			original = view.refresh
+
+			def refresh():
+				counts[key] += 1
+				original()
+
+			view.refresh = refresh
+
+		wrap('tasks', widget.tasklisttreeview)
+		wrap('tags', widget.tag_list)
+		return counts
+
+	def testReloadViewRefreshesOnlyOnce(self):
+		# Each refresh() rebuilds the view from scratch, so doing it twice per
+		# reload is expensive - see reload_view()
+		widget = self._setUpTaskListWidget()
+		before = self._listTaskIds(widget)
+
+		counts = self._countRefresh(widget)
+		widget.reload_view()
+
+		self.assertEqual(counts, {'tasks': 1, 'tags': 1})
+		self.assertEqual(self._listTaskIds(widget), before)
+
+	def testReloadViewWithUnknownSelection(self):
+		# Fall back to a plain refresh when the selection key is not found,
+		# e.g. because an older version wrote it to the uistate
+		widget = self._setUpTaskListWidget()
+		widget.taskselection_type = SELECTION_ALL
+		widget.selection_list._select = lambda key: False
+
+		counts = self._countRefresh(widget)
+		widget.reload_view()
+
+		self.assertEqual(counts, {'tasks': 1, 'tags': 1})
+
 
 	#~ def testDialog(self):
 		#~ '''Check tasklist plugin dialog'''

--- a/tests/tasklist.py
+++ b/tests/tasklist.py
@@ -13,6 +13,8 @@ from zim.plugins.tasklist.indexer import *
 from zim.plugins.tasklist.indexer import _MAX_DUE_DATE, _MIN_START_DATE
 from zim.plugins.tasklist.gui import *
 
+from gi.repository import Gtk
+
 from zim.parse.dates import old_parse_date
 from zim.parse.tokenlist import testTokenStream
 from zim.formats.wiki import Parser as WikiParser
@@ -527,7 +529,7 @@ class TestTaskList(tests.TestCase):
 
 		# TODO test filtering for tags, labels, string - all case insensitive
 
-	def _setUpTaskListWidget(self):
+	def _setUpTaskListWidget(self, show=True):
 		plugin = PluginManager.load_plugin('tasklist')
 		notebook = self.setUpNotebook(content=tests.FULL_NOTEBOOK)
 		notebook.index.check_and_update()
@@ -540,7 +542,18 @@ class TestTaskList(tests.TestCase):
 			notebook.state['TaskListWidget'],
 			tests.MockObject(), # show_dialog_action
 		)
+		if show:
+			self._showTaskListWidget(widget)
 		return widget
+
+	def _showTaskListWidget(self, widget):
+		# reload_view() only does work while the widget is mapped
+		window = Gtk.Window()
+		window.add(widget)
+		self.addCleanup(window.destroy)
+		window.show_all()
+		tests.gtk_process_events()
+		assert widget.get_mapped()
 
 	def _listTaskIds(self, widget):
 		ids = []
@@ -579,6 +592,29 @@ class TestTaskList(tests.TestCase):
 
 		self.assertEqual(counts, {'tasks': 1, 'tags': 1})
 		self.assertEqual(self._listTaskIds(widget), before)
+
+	def testReloadViewSkippedWhenNotVisible(self):
+		# Nobody can see the widget, so rebuilding it is wasted work - e.g. an
+		# inactive tab in the side pane while the notebook is being indexed
+		widget = self._setUpTaskListWidget(show=False)
+		self.assertFalse(widget.get_mapped())
+
+		counts = self._countRefresh(widget)
+		widget.reload_view()
+
+		self.assertEqual(counts, {'tasks': 0, 'tags': 0})
+		self.assertTrue(widget._reload_pending)
+
+	def testReloadViewDoneWhenShown(self):
+		# ... but the postponed reload must happen once it becomes visible
+		widget = self._setUpTaskListWidget(show=False)
+		widget.reload_view()
+
+		counts = self._countRefresh(widget)
+		self._showTaskListWidget(widget)
+
+		self.assertEqual(counts, {'tasks': 1, 'tags': 1})
+		self.assertFalse(widget._reload_pending)
 
 	def testReloadViewWithUnknownSelection(self):
 		# Fall back to a plain refresh when the selection key is not found,

--- a/zim/plugins/tasklist/gui.py
+++ b/zim/plugins/tasklist/gui.py
@@ -128,8 +128,9 @@ class TaskListWidgetMixin(object):
 
 	def _set_selection_state(self, state):
 		self.status = state[1]
-		self.selection_list._select(state[0])
+		selected = self.selection_list._select(state[0])
 		self.tag_list._set_selected_labels_tags_pages(*state[2])
+		return selected
 
 	def _create_tasklisttreeview(self, opener, properties):
 		self.tasklisttreeview = TaskListTreeView(
@@ -235,11 +236,18 @@ class TaskListWidgetMixin(object):
 		)
 
 	def reload_view(self):
+		# NOTE: no explicit refresh() of the views here. Restoring the
+		# selection state below emits "row-activated" on the selection list,
+		# which ends up in set_selection() and refreshes both views with the
+		# new selection object. Refreshing first would rebuild both views
+		# twice for each reload - which is costly because both are rebuilt
+		# from scratch. Only when the selection key is not found - e.g. a
+		# stale uistate - no refresh is triggered and we need to do it here.
 		state = self._get_selection_state()
-		for view in (self.tasklisttreeview, self.tag_list):
-			if view is not None:
-				view.refresh()
-		self._set_selection_state(state)
+		if not self._set_selection_state(state):
+			for view in (self.tasklisttreeview, self.tag_list):
+				if view is not None:
+					view.refresh()
 
 	def on_selection_activated(self, listbox, boxrow):
 		label = boxrow.get_children()[0]

--- a/zim/plugins/tasklist/gui.py
+++ b/zim/plugins/tasklist/gui.py
@@ -116,6 +116,9 @@ class TaskListWidgetMixin(object):
 		self.taskselection = self.SELECTION_MAP[self.taskselection_type][1].new_from_index(index)
 		self.label_tag_filter = (None, None, None) # NOTE: Not taken from uistate since encoding&validation would be non-trivial
 
+		self._reload_pending = False
+		self.connect('map', self.on_map)
+
 		self.connectto(properties, 'changed', self.on_properties_changed)
 
 	def _init_selection_state(self):
@@ -235,7 +238,25 @@ class TaskListWidgetMixin(object):
 			show_pages=properties['show_pages']
 		)
 
+	def on_map(self, *a):
+		if self._reload_pending:
+			self.reload_view()
+
 	def reload_view(self):
+		# Rebuilding the views is expensive - both are rebuilt from scratch -
+		# so don't do it while the widget is not visible. That happens both for
+		# an inactive tab in the side pane and for the window after it was
+		# closed, since closing only hides it. Postpone to the moment the
+		# widget is shown instead. Without this the list is rebuilt for every
+		# "tasklist-changed" signal even when nobody can see it, which adds up
+		# e.g. while indexing a notebook, where the signal is emitted for every
+		# page that has tasks.
+		if not self.get_mapped():
+			self._reload_pending = True
+			return
+
+		self._reload_pending = False
+
 		# NOTE: no explicit refresh() of the views here. Restoring the
 		# selection state below emits "row-activated" on the selection list,
 		# which ends up in set_selection() and refreshes both views with the


### PR DESCRIPTION
The task list is rebuilt on every `tasklist-changed` signal. Two things make
that much more expensive than it needs to be:

1. `reload_view()` refreshes both views and then restores the selection state
   - but restoring the selection emits `row-activated` on the selection list,
   which ends up in `set_selection()` and refreshes both views again. So every
   reload rebuilt both of them twice.
2. It happens whether or not anyone can see the widget. The side pane shows
   only the widget on the active tab, and the window is kept alive and hidden
   when it is "closed" - which is the default presentation, since
   *Show tasklist in sidepane* is off by default.

Neither refresh is cheap: the tree store is cleared and re-filled, and the
label & tag list removes all of its rows and constructs new widgets for each
of them.

### Measurements

Profiling the start of the GUI against a missing index, on a notebook of
7.400 pages with the Task List in the side pane on an inactive tab. During
indexing `tasklist-changed` is emitted for every page that has tasks, so
`reload_view()` runs ~610 times.

| | before | after 1st commit | after 2nd commit |
| --- | --- | --- | --- |
| `reload_view()` total | **44,9 s** | 23,3 s | **0,0 s** |
| `LabelAndTagView.refresh()` | 1226 calls | 612 calls | 2 calls |
| `TaskListTreeView.refresh()` | 1226 calls | 612 calls | 2 calls |
| `_create_item()` | 91.458 calls | 45.626 calls | 6 calls |
| GObject constructor calls | 371.074 | 188.974 | 6.663 |
| total work in the run | 158,4 s | 141,4 s | 105,2 s |

So on that run the task list accounted for 44,9 of 158,4 seconds - 28% of the
time spent starting up with a cold index - while never being on screen. The
two remaining `refresh()` calls are the ones that build the widget.

The call counts are exact and reproducible. The total-work row varies by up to
16% between runs of the same build here (filesystem cache, background load), so
treat it as an order of magnitude rather than a measurement.

Part of the remaining gain of the second commit shows up outside
`reload_view()`: the main loop itself gets 6 s cheaper, because rebuilding the
list queued a resize and a redraw of the pane each time.

### The changes

**Do not rebuild twice.** Drop the explicit pair of `refresh()` calls in
`reload_view()` and rely on the one triggered by restoring the selection. That
one is also the correct one - it runs after `set_selection()` has installed the
new selection object, where the first pair still used the previous one. Keep an
explicit refresh for the case where the selection key is not found, since then
no `row-activated` is emitted.

**Do not rebuild what is not visible.** Skip the reload when the widget is not
mapped, remember that one is pending, and do it from the `map` handler when the
widget is shown. `get_mapped()` covers all the cases at once - inactive tab in
the side pane, collapsed pane, hidden window - which I verified against
`WindowSidePane` before relying on it. The handler lives in
`TaskListWidgetMixin`, so both the side pane widget and the window get it.

### Tests

Four tests in `tests/tasklist.py`: that a reload refreshes each view exactly
once and leaves the same content, that the fallback path still refreshes when
the selection key is unknown, that an unmapped widget defers instead of
rebuilding, and that the deferred rebuild happens when it becomes visible.
Each of them fails without the corresponding change.

`python3 test.py` passes.

### Related

#2950 reports the index update becoming slow while the Task List plugin was
enabled. This reduces that cost, but the main cause there looks like the Tags
plugin instead - see #3019.
