### PR TITLE
newfs: fix _joinuri() for UNC hosts with non-word characters (WSL mounts)

### DIFF
--- a/tests/newfs.py
+++ b/tests/newfs.py
@@ -98,6 +98,46 @@ class TestFilePath(tests.TestCase):
 		))
 
 
+	def testWindowsUNCHostWithSpecialCharacters(self):
+		# Regression test for the Windows-specific `_joinuri()` helper in
+		# zim.newfs.base, which used to silently return None (later causing
+		# "TypeError: Cannot convert None to a FilePath" much further down
+		# the call stack) for UNC hosts containing characters outside \w,
+		# such as the "\\wsl$\..." and "\\wsl.localhost\..." paths Windows
+		# uses to expose WSL mounts.
+		#
+		# This exercises the Windows-specific code path (`_joinuri` /
+		# `_joinabspath` in zim.newfs.base), which is only defined when
+		# `os.name == 'nt'` at import time. To test it on non-Windows
+		# platforms too, reload zim.newfs.base with `os.name` patched to
+		# "nt", then restore it afterwards.
+		import importlib
+		import zim.newfs.base as base
+
+		orig_os_name = os.name
+		orig_home = os.environ.get('HOME')
+		try:
+			os.name = 'nt'
+			os.environ['HOME'] = 'C:\\Users\\fakehome'
+			importlib.reload(base)
+
+			for path, expected_uri in (
+				(r'\\wsl$\Ubuntu-20.04\home\user\notebook',
+					'file://wsl%24/Ubuntu-20.04/home/user/notebook'),
+				(r'\\wsl.localhost\Ubuntu\home\user\notebook',
+					'file://wsl.localhost/Ubuntu/home/user/notebook'),
+				(r'\\myserver\share\notebook', # plain UNC host - no regression
+					'file://myserver/share/notebook'),
+			):
+				self.assertEqual(base.FilePath(path).uri, expected_uri)
+		finally:
+			os.name = orig_os_name
+			if orig_home is None:
+				os.environ.pop('HOME', None)
+			else:
+				os.environ['HOME'] = orig_home
+			importlib.reload(base)
+
 	def testShareDrivePath(self):
 		# Test pathnames for windows share drive
 		for p in (

--- a/zim/newfs/base.py
+++ b/zim/newfs/base.py
@@ -182,7 +182,13 @@ if os.name == 'nt':
 			raise ValueError('Not an absolute path: %s' % '\\'.join(names))
 		elif re.match(r'^\w:$', names[0]): # Drive letter - e.g. file:///C:/foo
 			return 'file:///' + names[0] + '/' + url_encode('/'.join(names[1:]))
-		elif re.match(r'^\\\\\w+$', names[0]): # UNC path - e.g. file://host/share
+		else: # UNC path - e.g. file://host/share
+			# The check above already confirmed this starts with "\\" followed
+			# by a word character, so anything that isn't a drive letter at this
+			# point is a UNC host. Do not restrict the host name to \w further:
+			# e.g. WSL exposes mounts as "\\\\wsl$\\..." or
+			# "\\\\wsl.localhost\\...", where "$" and "." are not matched by \w,
+			# which used to make this function fall through and return None.
 			return 'file://' + url_encode(names[0].strip('\\') + '/' + '/'.join(names[1:]))
 
 else:


### PR DESCRIPTION
Fixes #2387

### Problem

`zim.newfs.base._joinuri()` validates that a path starts with a UNC host (`\\host`), but the branch that actually builds the URI only matched hosts against `^\\\\\w+$` (or a drive letter). UNC hosts containing characters outside `\w` pass the initial validation but don't match either `elif`, so the function falls through and implicitly returns `None`.

This affects real-world paths: Windows exposes WSL distributions as `\\wsl$\Ubuntu-20.04\...` or `\\wsl.localhost\Ubuntu\...`, where `$` and `.` aren't matched by `\w`. Opening a notebook that lives on such a mount fails with a confusing `TypeError: Cannot convert None to a FilePath` deep inside `FilePath.__init__`, far from the actual root cause.

### Fix

Replace the overly strict `elif re.match(r'^\\\\\w+$', ...)` with a plain `else`. Once the earlier check has confirmed the path starts with a drive letter or a UNC-host prefix, and it isn't a drive letter, it must be a UNC host — so build the URI without re-validating the host name against `\w`. Ordinary UNC hosts (e.g. `\\myserver\share\...`) are unaffected since they already matched the old regex too.

### Test

Added `testWindowsUNCHostWithSpecialCharacters` in `tests/newfs.py`, covering `\\wsl$\...`, `\\wsl.localhost\...`, and a plain UNC host as a no-regression check. Since `_joinuri`/`_joinabspath` in `zim.newfs.base` are only defined when `os.name == 'nt'` at import time, the test patches `os.name` and reloads the module (via `importlib.reload`) to exercise the Windows-specific code path on any platform, restoring the original state in a `finally` block.

Verified locally: the new test fails against the current `develop` code (assertion error from `_joinuri` returning `None`/raising) and passes with the fix applied.