### PR TITLE
Speed up the versions dialog on repositories with a long history

### DIFF
--- a/tests/versioncontrol.py
+++ b/tests/versioncontrol.py
@@ -195,13 +195,9 @@ class TestVersionsDialog(tests.TestCase):
 	def testDialog(self):
 		pass # TODO test other dialog functions
 
-	@tests.slowTest
-	@tests.skipUnless(VCS.check_dependencies(VCS.GIT), 'Missing dependencies')
-	def testVersionList(self):
-		# The list must be sorted by age, newest first. For git the revision
-		# ids are hashes, which do not sort by age at all - the dialog relies
-		# on VCSApplicationBase.revision_sort_key() for this
-		root = get_tmp_dir('versioncontrol_TestVersionsDialog')
+	def setUpGitNotebook(self, name, numbers):
+		"""Sets up a notebook under git control with a version per number"""
+		root = get_tmp_dir(name)
 		vcs = VCS.create(VCS.GIT, root, root)
 		self.addCleanup(vcs.disconnect_all)
 		vcs.init_repo()
@@ -211,16 +207,27 @@ class TestVersionsDialog(tests.TestCase):
 			content=('Test',),
 			folder=LocalFolder(root.path)
 		)
-		mainwindow = setUpMainWindow(notebook)
 
 		file = root.folder('foo').file('bar.txt')
-		numbers = list(range(1, 7))
-			# Enough commits that sorting the hashes by chance gives the
-			# same order as sorting by age
 		for i in numbers:
 			file.write('version %i\n' % i)
 			vcs.stage()
 			vcs.commit_version('test %i' % i)
+
+		return vcs, notebook
+
+	@tests.slowTest
+	@tests.skipUnless(VCS.check_dependencies(VCS.GIT), 'Missing dependencies')
+	def testVersionList(self):
+		# The list must be sorted by age, newest first. For git the revision
+		# ids are hashes, which do not sort by age at all - the dialog relies
+		# on VCSApplicationBase.revision_sort_key() for this
+		numbers = list(range(1, 7))
+			# Enough commits that sorting the hashes by chance gives the
+			# same order as sorting by age
+		vcs, notebook = self.setUpGitNotebook(
+			'versioncontrol_TestVersionList', numbers)
+		mainwindow = setUpMainWindow(notebook)
 
 		versions = vcs.list_versions()
 		self.assertEqual(
@@ -240,6 +247,34 @@ class TestVersionsDialog(tests.TestCase):
 		revisions = [row[VersionsTreeView.REV_COL] for row in rows]
 		self.assertEqual(revisions, [rev for rev, date, user, msg in reversed(versions)])
 			# the revision id shown is the real one, not the sorting key
+
+	@tests.slowTest
+	@tests.skipUnless(VCS.check_dependencies(VCS.GIT), 'Missing dependencies')
+	def testSwitchingBetweenNotebookAndPage(self):
+		# Switching the radio buttons emits "toggled" for the option that is
+		# switched off as well - reloading the list for the option the user
+		# just left means reading the whole history for nothing
+		vcs, notebook = self.setUpGitNotebook(
+			'versioncontrol_TestSwitchingVersions', (1, 2))
+		mainwindow = setUpMainWindow(notebook)
+
+		dialog = VersionsDialog(mainwindow, vcs, notebook, page=Path('Test'))
+		self.addCleanup(dialog.destroy)
+
+		requested = []
+		list_versions = vcs.list_versions
+		def wrapper(file=None):
+			requested.append(file)
+			return list_versions(file)
+		vcs.list_versions = wrapper
+
+		dialog.page_radio.set_active(True)
+		self.assertEqual(len(requested), 1)
+		self.assertIsNotNone(requested[0]) # only the log for the page
+
+		del requested[:]
+		dialog.notebook_radio.set_active(True)
+		self.assertEqual(requested, [None]) # only the log for the notebook
 
 
 class VersionControlBackendTests(object):

--- a/tests/versioncontrol.py
+++ b/tests/versioncontrol.py
@@ -248,6 +248,12 @@ class TestVersionsDialog(tests.TestCase):
 		self.assertEqual(revisions, [rev for rev, date, user, msg in reversed(versions)])
 			# the revision id shown is the real one, not the sorting key
 
+		self.assertTrue(dialog.versionlist.get_fixed_height_mode())
+		self.assertTrue(all(
+			c.get_sizing() == Gtk.TreeViewColumnSizing.FIXED
+				for c in dialog.versionlist.get_columns()
+		)) # fixed height mode requires all columns to be of fixed size
+
 	@tests.slowTest
 	@tests.skipUnless(VCS.check_dependencies(VCS.GIT), 'Missing dependencies')
 	def testSwitchingBetweenNotebookAndPage(self):

--- a/tests/versioncontrol.py
+++ b/tests/versioncontrol.py
@@ -195,6 +195,52 @@ class TestVersionsDialog(tests.TestCase):
 	def testDialog(self):
 		pass # TODO test other dialog functions
 
+	@tests.slowTest
+	@tests.skipUnless(VCS.check_dependencies(VCS.GIT), 'Missing dependencies')
+	def testVersionList(self):
+		# The list must be sorted by age, newest first. For git the revision
+		# ids are hashes, which do not sort by age at all - the dialog relies
+		# on VCSApplicationBase.revision_sort_key() for this
+		root = get_tmp_dir('versioncontrol_TestVersionsDialog')
+		vcs = VCS.create(VCS.GIT, root, root)
+		self.addCleanup(vcs.disconnect_all)
+		vcs.init_repo()
+
+		notebook = self.setUpNotebook(
+			mock=tests.MOCK_ALWAYS_REAL,
+			content=('Test',),
+			folder=LocalFolder(root.path)
+		)
+		mainwindow = setUpMainWindow(notebook)
+
+		file = root.folder('foo').file('bar.txt')
+		numbers = list(range(1, 7))
+			# Enough commits that sorting the hashes by chance gives the
+			# same order as sorting by age
+		for i in numbers:
+			file.write('version %i\n' % i)
+			vcs.stage()
+			vcs.commit_version('test %i' % i)
+
+		versions = vcs.list_versions()
+		self.assertEqual(
+			[msg.strip() for rev, date, user, msg in versions],
+			['test %i' % i for i in numbers]
+		) # list_versions() is documented to go from oldest to newest
+
+		dialog = VersionsDialog(mainwindow, vcs, notebook)
+		self.addCleanup(dialog.destroy)
+		rows = [tuple(row) for row in dialog.versionlist.get_model()]
+
+		self.assertEqual(
+			[row[VersionsTreeView.MSG_COL].strip() for row in rows],
+			['test %i' % i for i in reversed(numbers)]
+		) # newest version on top
+
+		revisions = [row[VersionsTreeView.REV_COL] for row in rows]
+		self.assertEqual(revisions, [rev for rev, date, user, msg in reversed(versions)])
+			# the revision id shown is the real one, not the sorting key
+
 
 class VersionControlBackendTests(object):
 

--- a/zim/plugins/versioncontrol/__init__.py
+++ b/zim/plugins/versioncontrol/__init__.py
@@ -963,11 +963,17 @@ state. Or select multiple versions to see changes between those versions.
 				comp_button.set_sensitive(bool(usepage and self._side_by_side_app))
 
 		def on_page_change(o):
+			if not self.page_radio.get_active():
+				return
+				# Also called when the radio button is toggled *off* and for
+				# the page entry while the notebook option is selected
 			pagesource = self._get_file()
 			if pagesource:
-				self.versionlist.load_versions(vcs.list_versions(self._get_file()))
+				self.versionlist.load_versions(vcs.list_versions(pagesource))
 
 		def on_book_change(o):
+			if not self.notebook_radio.get_active():
+				return # Also called when the radio button is toggled *off*
 			self.versionlist.load_versions(vcs.list_versions())
 
 		self.page_radio.connect('toggled', on_ui_change)

--- a/zim/plugins/versioncontrol/__init__.py
+++ b/zim/plugins/versioncontrol/__init__.py
@@ -636,6 +636,20 @@ class VCSApplicationBase(ConnectorMixin):
 		versions = self.log_to_revision_list(lines)
 		return versions
 
+	def revision_sort_key(self, i, rev):
+		"""Returns the key used to sort a revision in the versions dialog
+
+		@param i: the position of the revision in the list returned by
+		          L{list_versions()}, thus counting from the oldest revision
+		@param rev: the revision id
+		@returns: a str() to be used as sorting key
+		@implementation: optional, to be implemented in the child class when
+		                 the revision id does not sort by age, e.g. when it is
+		                 a hash. Note that this key is only used for sorting,
+		                 the revision id itself is what is shown to the user.
+		"""
+		return natural_sort_key(rev)
+
 	def log(self, file=None):
 		"""Returns the history related to a file.
 		@param file: a L{File} instance representing the file or None (for the entire repository)
@@ -867,7 +881,7 @@ state. Or select multiple versions to see changes between those versions.
 		vbox.pack_start(label, False, True, 0)
 
 		# Version list
-		self.versionlist = VersionsTreeView()
+		self.versionlist = VersionsTreeView(vcs.revision_sort_key)
 		self.versionlist.load_versions(vcs.list_versions())
 		scrolled = ScrolledWindow(self.versionlist)
 		vbox.add(scrolled)
@@ -1069,10 +1083,12 @@ class VersionsTreeView(SingleClickTreeView):
 	USER_COL = 3
 	MSG_COL = 4
 
-	def __init__(self):
+	def __init__(self, revision_sort_key):
 		model = Gtk.ListStore(str, str, str, str, str)
 			# REV_SORT_COL, REV_COL, DATE_COL, USER_COL, MSG_COL
 		GObject.GObject.__init__(self)
+		self.revision_sort_key = revision_sort_key
+			# See L{VCSApplicationBase.revision_sort_key()}
 		self.set_model(model)
 
 		self.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)
@@ -1104,9 +1120,9 @@ class VersionsTreeView(SingleClickTreeView):
 		model.set_sort_column_id(self.REV_SORT_COL, Gtk.SortType.DESCENDING)
 			# By default sort by rev
 
-		for version in versions:
+		for i, version in enumerate(versions):
 			#~ print version
-			key = natural_sort_key(version[0]) # key for REV_SORT_COL
+			key = self.revision_sort_key(i, version[0]) # key for REV_SORT_COL
 			model.append((key,) + tuple(version))
 
 	def get_versions(self):

--- a/zim/plugins/versioncontrol/__init__.py
+++ b/zim/plugins/versioncontrol/__init__.py
@@ -1112,10 +1112,23 @@ class VersionsTreeView(SingleClickTreeView):
 			else:
 				column.set_sort_column_id(i)
 
-			if i == self.DATE_COL:
+			if i == self.USER_COL:
 				column.set_expand(True)
+					# The date has a fixed format and the revision a fixed
+					# length, the author name is the one that varies
 
+			column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
+			column.set_resizable(True)
+				# Required for fixed height mode below. Side effect is that the
+				# column width no longer grows to fit the widest value in the
+				# whole list, so make the columns resizable by the user instead
 			self.append_column(column)
+
+		self.set_fixed_height_mode(True)
+			# All rows show a single line of text, so they all have the same
+			# height. Without this the widget measures every single row after
+			# the dialog is shown, which takes seconds for a repository with
+			# many revisions.
 
 		model.set_sort_column_id(self.REV_SORT_COL, Gtk.SortType.DESCENDING)
 			# By default sort by rev

--- a/zim/plugins/versioncontrol/git.py
+++ b/zim/plugins/versioncontrol/git.py
@@ -207,6 +207,13 @@ class GITApplicationBackend(VCSApplicationBase):
 		versions.reverse()
 		return versions
 
+	def revision_sort_key(self, i, rev):
+		# Revision ids are hashes, sorting them gives a random order. Use the
+		# position in the log instead, which is ordered oldest to newest.
+		# Zero padded to sort as text; 8 digits is plenty, a repository with
+		# more revisions than that can not be listed in the dialog anyway.
+		return '%08i' % i
+
 
 	def move(self, oldpath, newpath):
 		return self.add(newpath) # move already happened


### PR DESCRIPTION
Opening `Tools -> Versions` on a notebook under git control gets painfully slow once the history grows. Three separate causes, one commit each.

### 1. The sorting key for the revision column

The version list is sorted on a hidden column holding `natural_sort_key(rev)`. For a git hash that key explodes:

```
0. the revision id             40 chars  a4ab3227e9c1f0d5b6a7c8e9f0a1b2c3d4e5f607
1. numbers padded to 5 digits 103 chars  a00004ab03227e00009c00001f00000d00005b...
2. locale.strxfrm()           518 chars
3. hex encoded               1345 chars
```

Step 1 is meant for names like `Page9` vs `Page10`, but a hash is hexadecimal: this one contains 17 separate groups of digits, each padded from one or two characters to five. Step 2 is the collation key, some five weights per character. Step 3 assumes `strxfrm()` returns 8-bit bytes, as it did on python 2 - on python 3 it returns wide characters, values well above 255, so `"%02x"` emits three and four digits rather than two. Together a factor of 33.

The tree model is sorted while it is filled, so every insert compares those strings again through `g_utf8_collate()`. Profiled on a notebook with 27001 revisions, `load_versions()` took 27.3 s: 22.9 s in `Gtk.ListStore.append()` and 4.3 s in `natural_sort_key()` itself.

For git the key is not merely expensive, it is meaningless: hashes have no order, so sorting the "Rev" column currently sorts hashes alphabetically. Added `VCSApplicationBase.revision_sort_key()`, defaulting to the present behavior, and let the git backend return the position in the log instead - `list_versions()` returns revisions from oldest to newest, which is exactly the wanted order. Profiled again on the full history of the same notebook, 47106 revisions: `load_versions()` now takes 3.2 s.

Backends with numeric revision ids (bzr, mercurial) keep the old key and are untouched. Their keys stay 71 characters regardless of the revision number, because the padding caps a run of digits at five.

### 2. Reloading the list for the option that was switched off

Toggling a radio button emits `toggled` for the button that becomes inactive as well. Both signals were connected to handlers that reload the list, so switching to "Page" first read the log for the complete notebook - the option just left - and only then the log for the page. An extra `git log` over the whole history plus a full refill of the model, on every switch.

### 3. Measuring every row after the dialog is shown

`GtkTreeView` measures each row to know the total height of the list. On 47000 rows that keeps a core busy for some 8 seconds after the dialog is already interactive, and the scrollbar is recalculated the whole time, its slider shrinking and drifting under the hand of anyone who tries to scroll. All three visible columns hold a single line of text, so fixed height mode applies:

```
47106 rows, fixed height mode off : 8.09 s cpu after show_all()
47106 rows, fixed height mode on  : 0.04 s cpu after show_all()
```

Fixed height mode requires columns of fixed size, so their width is no longer grown to fit the widest value in the whole list. To compensate the columns are now resizable, which they were not before, and the spare width of the dialog goes to the author column instead of the date - the date has a fixed format and the revision a fixed length, so the author name is the one that needs the room.

### Not addressed here

The page entry reloads the list on `changed`, which fires per keystroke, so typing a page name in "Page" mode runs one `git log --follow` per character. Fixing that needs a decision on how the dialog should react to typing (debounce, or reload on activate), so it is left out of this pull request.

### Testing

`python3 test.py` passes. The versions dialog had no test coverage at all (`testDialog` was a `pass`); added tests for the order of the version list, for the revision ids shown in it, and for not reloading the list of the option that is switched off.
