### PR TITLE
Tray icon plugin: app indicator detection, double menu, enabling at runtime

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,9 @@ Depends: ${python3:Depends}, ${misc:Depends}, python3 (>= 3.6), libgtk-3-0 (>= 3
 # git or similar required for the version control plugin
 # scrot required for the screenshot plugin
 # dvipng required for the "equation" plugin
-Suggests: git, graphviz, scrot, dvipng
+# gir1.2-ayatanaappindicator3-0.1 required for the tray icon plugin to show an
+# application indicator instead of a (deprecated) status icon
+Suggests: git, graphviz, scrot, dvipng, gir1.2-ayatanaappindicator3-0.1 | gir1.2-appindicator3-0.1
 Description: Desktop Wiki Editor
  Zim is a graphical text editor used to maintain a collection of wiki pages.
  Each page can contain links to other pages, simple formatting and images.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -73,6 +73,7 @@ __all__ = [
 	'quicknote', 'attachmentbrowser', 'insertsymbol',
 	'sourceview', 'tableeditor', 'bookmarksbar', 'spell',
 	'arithmetic', 'linesorter', 'commandpalette', 'windowtitleeditor',
+	'trayicon',
 	'indexed_fts'
 ]
 

--- a/tests/trayicon.py
+++ b/tests/trayicon.py
@@ -1,10 +1,15 @@
-
 # Copyright 2026 Self-Perfection <alexander.s.m@gmail.com>
 
 
+from gi.repository import Gtk
+
 import tests
 
-from zim.plugins.trayicon import StatusIconTrayIcon
+from tests.mainwindow import setUpMainWindow
+
+import zim.plugins.trayicon
+
+from zim.plugins.trayicon import StatusIconTrayIcon, TrayIconPlugin, TrayIconMainWindowExtension
 
 
 class TestStatusIconTrayIcon(tests.TestCase):
@@ -27,3 +32,27 @@ class TestStatusIconTrayIcon(tests.TestCase):
 		icon.emit('popup-menu', 3, 0)
 		self.assertEqual(len(icon.menus), 1)
 		icon.destroy()
+
+
+class TestTrayIconMainWindowExtension(tests.TestCase):
+
+	def runTest(self):
+		# When the plugin is enabled from the preferences dialog the window is
+		# already part of the application - the extension must be able to set up
+		# in that state as well. Else it is never registered and "teardown()"
+		# does not run when the plugin is disabled again, leaving a tray icon
+		# for a disabled plugin and a window that keeps hiding itself on close.
+		application = Gtk.Application()
+		application.register(None) # else windows are not accepted
+		window = setUpMainWindow(self.setUpNotebook())
+		application.add_window(window)
+		self.assertIsNotNone(window.get_application())
+
+		plugin = TrayIconPlugin()
+		extension = TrayIconMainWindowExtension(plugin, window)
+		self.assertIsNotNone(zim.plugins.trayicon.GLOBAL_TRAYICON)
+		self.assertTrue(window.hideonclose)
+
+		extension.teardown()
+		self.assertIsNone(zim.plugins.trayicon.GLOBAL_TRAYICON)
+		self.assertFalse(window.hideonclose)

--- a/tests/trayicon.py
+++ b/tests/trayicon.py
@@ -1,0 +1,29 @@
+
+# Copyright 2026 Self-Perfection <alexander.s.m@gmail.com>
+
+
+import tests
+
+from zim.plugins.trayicon import StatusIconTrayIcon
+
+
+class TestStatusIconTrayIcon(tests.TestCase):
+
+	def runTest(self):
+		# "do_popup_menu" is the default handler for the "popup-menu"
+		# signal of Gtk.StatusIcon - if it is connected to the signal as
+		# well, the menu shows up twice for a single click
+		class MyStatusIconTrayIcon(StatusIconTrayIcon):
+
+			def __init__(self):
+				self.menus = []
+				StatusIconTrayIcon.__init__(self)
+
+			def do_popup_menu(self, button=3, activate_time=0):
+				# Build the menu, but don't show it during tests
+				self.menus.append(self.get_trayicon_menu())
+
+		icon = MyStatusIconTrayIcon()
+		icon.emit('popup-menu', 3, 0)
+		self.assertEqual(len(icon.menus), 1)
+		icon.destroy()

--- a/tests/trayicon.py
+++ b/tests/trayicon.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Self-Perfection <alexander.s.m@gmail.com>
 
 
+import sys
+
 from gi.repository import Gtk
 
 import tests
@@ -12,6 +14,7 @@ import zim.plugins.trayicon
 from zim.plugins.trayicon import StatusIconTrayIcon, TrayIconPlugin, TrayIconMainWindowExtension
 
 
+@tests.skipIf(sys.platform == 'darwin', 'Gtk.StatusIcon crashes the test process on macOS')
 class TestStatusIconTrayIcon(tests.TestCase):
 
 	def runTest(self):
@@ -34,6 +37,7 @@ class TestStatusIconTrayIcon(tests.TestCase):
 		icon.destroy()
 
 
+@tests.skipIf(sys.platform == 'darwin', 'Gtk.StatusIcon crashes the test process on macOS')
 class TestTrayIconMainWindowExtension(tests.TestCase):
 
 	def runTest(self):

--- a/zim/plugins/trayicon.py
+++ b/zim/plugins/trayicon.py
@@ -110,10 +110,7 @@ This is a core plugin shipping with zim.
 	def on_preferences_changed(self, preferences):
 		if GLOBAL_TRAYICON:
 			# Only refresh once someone else loaded it
-			application = GLOBAL_TRAYICON.get_application() if hasattr(GLOBAL_TRAYICON, 'get_application') else None
-			trayicon = set_global_trayicon(self.preferences['classic'])
-			if trayicon and application:
-				application.add_window(trayicon)
+			set_global_trayicon(self.preferences['classic'])
 
 
 class TrayIconMainWindowExtension(MainWindowExtension):
@@ -121,10 +118,7 @@ class TrayIconMainWindowExtension(MainWindowExtension):
 	def __init__(self, plugin, window):
 		MainWindowExtension.__init__(self, plugin, window)
 		self.window.hideonclose = True
-		icon = set_global_trayicon(plugin.preferences['classic'])
-		application = window.get_application()
-		if application:
-			application.add_window(icon)
+		set_global_trayicon(plugin.preferences['classic'])
 
 	def teardown(self):
 		global GLOBAL_TRAYICON

--- a/zim/plugins/trayicon.py
+++ b/zim/plugins/trayicon.py
@@ -271,9 +271,9 @@ class StatusIconTrayIcon(TrayIconBase, Gtk.StatusIcon):
 			self.set_from_file(icon)
 
 		self.set_tooltip_text(_('Zim Desktop Wiki')) # T: tooltip for tray icon
-		self.connect('popup-menu', self.__class__.do_popup_menu)
 
 	def do_activate(self):
+		# Default handler for the "activate" signal of Gtk.StatusIcon
 		open_notebooks = list(self.list_open_notebooks())
 		if len(open_notebooks) == 0:
 			# No open notebooks, open default or prompt full list
@@ -296,7 +296,9 @@ class StatusIconTrayIcon(TrayIconBase, Gtk.StatusIcon):
 		menu.popup(None, None, None, self, button, activate_time)
 
 	def do_popup_menu(self, button=3, activate_time=0):
-		#~ print('>>', button, activate_time)
+		# Default handler for the "popup-menu" signal of Gtk.StatusIcon
+		# Do *not* connect this method to the signal as well, that would
+		# result in the menu being popped up twice per click
 		menu = self.get_trayicon_menu()
 		menu.show_all()
 		menu.popup(None, None, None, self, button, activate_time)

--- a/zim/plugins/trayicon.py
+++ b/zim/plugins/trayicon.py
@@ -15,16 +15,30 @@ from zim.notebook import get_notebook_list, NotebookInfo, NotebookInfoList
 
 from zim.gui.mainwindow import MainWindowExtension
 
-# Try if we are on Ubunutu with app-indicator support
-try:
-	import gi
-	gi.require_version('AppIndicator3', '0.1')
-	from gi.repository import AppIndicator3 as AppIndicator
-except:
-	AppIndicator = None
-
-
 logger = logging.getLogger('zim.plugins.trayicon')
+
+
+# Try if there is app-indicator support. The original "AppIndicator3" from
+# Ubuntu is no longer maintained and has been dropped by several distributions
+# in favor of the "AyatanaAppIndicator3" fork, so try that one first.
+def _import_appindicator():
+	import gi
+	import importlib
+
+	for namespace in ('AyatanaAppIndicator3', 'AppIndicator3'):
+		try:
+			gi.require_version(namespace, '0.1')
+			module = importlib.import_module('gi.repository.' + namespace)
+		except (ImportError, ValueError) as error:
+			logger.debug('No app-indicator support for "%s": %s', namespace, error)
+		else:
+			logger.debug('Using app-indicator support from "%s"', namespace)
+			return module
+
+	return None
+
+
+AppIndicator = _import_appindicator()
 
 
 
@@ -86,7 +100,7 @@ This is a core plugin shipping with zim.
 	@classmethod
 	def check_dependencies(klass):
 		return (True, [
-			('Unity appindicator', bool(AppIndicator), False),
+			('Application indicator (ayatana or unity)', bool(AppIndicator), False),
 		])
 
 	def __init__(self):


### PR DESCRIPTION
Four independent fixes for the tray icon plugin, one per commit.

**App indicator is never detected on current distributions.** The plugin only looks for the `AppIndicator3` typelib, which comes from Ubuntu's unmaintained libappindicator. Debian, Ubuntu and derivates ship the `AyatanaAppIndicator3` fork instead, so `gi.require_version()` fails and the plugin silently falls back to `Gtk.StatusIcon`. The fallback is not equivalent: the status icon is deprecated, needs XEmbed tray support, and has no `zim-panel` icon outside the ubuntu-mono themes - it then loads `data/zim.png`, a 48x48 bitmap that gets scaled down to panel size and looks blurry, where the indicator refers to its icon by name and scales cleanly. Try Ayatana first, keep `AppIndicator3` as fallback. The bare `except:` that hid the reason is replaced by `(ImportError, ValueError)` plus a debug log line. Probably the cause of #2320.

**Nothing pulls in that typelib**, so a plain package install degrades to the status icon - added to `Suggests` in `debian/control`, next to the other per-plugin optional dependencies.

**The menu pops up twice per right click.** `do_popup_menu()` is the default class handler for the `popup-menu` signal of `Gtk.StatusIcon`, and it is connected to the same signal on top of that, so a single click stacks two identical menus. This is item 6 of #1334, and may be part of #491 - though not the other half of those reports, where a menu is not dismissed by clicking outside of it, which looks like a separate problem with the menu not taking a grab.

**Enabling the plugin on a running instance raises `TypeError`.** `application.add_window(icon)` gets the tray icon, which is not a `Gtk.Window`. At startup the extension is created before the window joins the application, so `window.get_application()` is None and the call is skipped - but from the preferences dialog it throws, the plugin manager catches it, and the extension is never registered. The icon appears (it is created before the raise), so enabling looks fine, but `teardown()` never runs: after disabling the plugin the icon stays in the tray and stays functional, and `hideonclose` stays set, so closing the window no longer closes zim. Both until restart. The calls are removed rather than fixed - they never did anything in the path that works, since the application is kept alive by the main window, which is hidden and not destroyed, and the `--plugin trayicon` command has its own `hold()`.

New `tests/trayicon.py` covers the last two: both tests fail on current code and pass with the fixes. Full suite run with `python3 test.py` shows no new failures.